### PR TITLE
Translate English markdown files in ko/ to Korean

### DIFF
--- a/ko/lbstanza.md
+++ b/ko/lbstanza.md
@@ -5,15 +5,15 @@ contributors:
   - ["Mike Hilgendorf", "https://github.com/m-hilgendorf"]
 ---
 
-LB Stanza (or Stanza for short) is a new optionally-typed general purpose programming language from the University of California, Berkeley. Stanza was designed to help programmers tackle the complexity of architecting large programs and significantly increase the productivity of application programmers across the entire software development life cycle.
+LB Stanza(또는 줄여서 Stanza)는 캘리포니아 대학교 버클리에서 만든 새로운 선택적 타입 범용 프로그래밍 언어입니다. Stanza는 프로그래머가 대규모 프로그램 아키텍처의 복잡성을 해결하고 전체 소프트웨어 개발 수명 주기 동안 애플리케이션 프로그래머의 생산성을 크게 향상시키는 데 도움이 되도록 설계되었습니다.
 
 
 ```
-; this is a comment
+; 이것은 주석입니다.
 ;<A>
-This is a block comment
+이것은 블록 주석입니다.
     ;<B>
-        block comments can be nested with optional tags.
+        블록 주석은 선택적 태그로 중첩될 수 있습니다.
     ;<B>
 ;<A>
 defpackage learn-stanza-in-y:
@@ -21,16 +21,16 @@ defpackage learn-stanza-in-y:
   import collections
 
 ;==============================================================================
-; The basics, things you'd find in most programming languages
+; 대부분의 프로그래밍 언어에서 볼 수 있는 기본 사항
 ;==============================================================================
 
 
-; Variables can be mutable (var) or immutable (val)
+; 변수는 가변(var) 또는 불변(val)일 수 있습니다.
 val immutable = "this string can't be changed"
 var mutable = "this one can be"
 mutable = "like this"
 
-; The basic data types (annotations are optional)
+; 기본 데이터 타입 (주석은 선택 사항)
 val an-int: Int = 12345
 val a-long: Long = 12345L
 val a-float: Float = 1.2345f
@@ -40,22 +40,22 @@ val a-multiline-string = \<tag>
     this is a "raw" string literal
 \<tag>
 
-; Print a formatted string with println and "..." % [...]
+; println과 "..." % [...]를 사용하여 서식화된 문자열 출력
 println("this is a formatted string %_ %_" % [mutable, immutable])
 
-; Stanza is optionally typed, and has a ? (any) type.
+; Stanza는 선택적 타입이며, ? (any) 타입을 가집니다.
 var anything:? = 0
 anything = 3.14159
 anything = "a string"
 
-; Stanza has basic collections like Tuples, Arrays, Vectors and HashTables
+; Stanza에는 튜플, 배열, 벡터 및 해시 테이블과 같은 기본 컬렉션이 있습니다.
 val tuple: Tuple<?> = [mutable, immutable]
 
 val array = Array<?>(3)
 array[0] = "string"
 array[1] = 1
 array[2] = 1.23455
-; array[3] = "out-of-bounds" ; arrays are bounds-checked
+; array[3] = "out-of-bounds" ; 배열은 경계 검사를 합니다.
 
 val vector = Vector<?>()
 vector[0] = "string"
@@ -69,16 +69,16 @@ hash-table["2"] = 1
 
 
 ;==============================================================================
-; Functions
+; 함수
 ;==============================================================================
-; Functions are declared with the `defn` keyword
-defn my-function (arg:?) : ; note the space between identifier and arg list
+; 함수는 `defn` 키워드로 선언됩니다.
+defn my-function (arg:?) : ; 식별자와 인수 목록 사이에 공백이 있습니다.
   println("called my-function with %_" % [arg])
 
-my-function("arg")  ; note the lack of a space to call the function
+my-function("arg")  ; 함수를 호출할 때 공백이 없습니다.
 
-; Functions can be declared inside another function and capture variables from
-; the surrounding environment.
+; 함수는 다른 함수 내부에 선언될 수 있으며,
+; 주변 환경의 변수를 캡처할 수 있습니다.
 defn outer (arg):
   defn inner ():
     println("outer had arg: %_" % [arg])
@@ -86,42 +86,42 @@ defn outer (arg):
 
 outer("something")
 
-; functions are "first-class" in stanza, meaning you can assign variables
-; to functions and pass functions as arguments to other functions.
+; 함수는 stanza에서 "일급"입니다. 즉, 변수를
+; 함수에 할당하고 함수를 다른 함수에 인수로 전달할 수 있습니다.
 val a-function = outer
 defn do-n-times (arg, func, n:Int):
   for i in 0 to n do :
     func(arg)
 do-n-times("argument", a-function, 3)
 
-; sometimes you want to define a function inline, or use an anonymous function.
-; for this you can use the syntax:
+; 때로는 함수를 인라인으로 정의하거나 익명 함수를 사용하고 싶을 때가 있습니다.
+; 이를 위해 다음 구문을 사용할 수 있습니다.
 ;   fn (args):
 ;       ...
 do-n-times("hello", fn (arg): println(arg), 2)
 
-; there is a shorthand for writing anonymous functions
+; 익명 함수를 작성하는 약식 구문이 있습니다.
 do-n-times("hello", { println(_) }, 2)
 
-; the short hand works for multiple arguments as well.
+; 약식 구문은 여러 인수에도 작동합니다.
 val multi-lambda = { println(_ + 2 * _) }
 multi-lambda(1, 2)
 
 ;==============================================================================
-; User defined types
+; 사용자 정의 타입
 ;==============================================================================
-; Structs are declared with the `defstruct` keyword
+; 구조체는 `defstruct` 키워드로 선언됩니다.
 defstruct MyStruct:
   field
 
-; constructors are derived automatically
+; 생성자는 자동으로 파생됩니다.
 val my-struct = MyStruct("field:value")
 
-; fields are accessed using function-call syntax
+; 필드는 함수 호출 구문을 사용하여 액세스됩니다.
 println(field(my-struct))
 
-; Stanza supports subtyping with a "multimethod" system based on method
-; overloading.
+; Stanza는 메서드 오버로딩을 기반으로 한 "다중 메서드" 시스템으로
+; 서브타이핑을 지원합니다.
 deftype MyType
 defmulti a-method (m:MyType)
 
@@ -134,28 +134,28 @@ defmethod a-method (a-foo: Bar):
   println("called a-method on a Bar")
 
 ;==============================================================================
-; The Type System
+; 타입 시스템
 ;==============================================================================
-; True and Falseare types with a single value.
+; True와 False는 단일 값을 가진 타입입니다.
 val a-true: True = true
 val a-false: False = false
 
-; You can declare a union type, or a value that is one of a set of types
+; 유니온 타입을 선언할 수 있습니다. 즉, 여러 타입 중 하나의 값을 가질 수 있습니다.
 val a-boolean: True|False = true
 val another-boolean: True|False = false
 
-; You can pattern match on types
+; 타입에 대해 패턴 매칭을 할 수 있습니다.
 match(a-boolean):
   (t:True): println("is true")
   (f:False): println("is false")
 
-; You can match against a single possible type
+; 단일 가능한 타입에 대해 매칭할 수 있습니다.
 match(a-boolean:True):
   println("is still true")
 else:
   println("is not true")
 
-; You can compose program logic around the type of a variable
+; 변수의 타입을 중심으로 프로그램 로직을 구성할 수 있습니다.
 if anything is Float :
   println("anything is a float")
 else if anything is-not String :
@@ -164,37 +164,37 @@ else :
   println("I don't know what anything is")
 
 ;==============================================================================
-; Control Flow
+; 제어 흐름
 ;==============================================================================
-; stanza has the standard basic control flow
+; stanza에는 표준 기본 제어 흐름이 있습니다.
 val condition = [false, false]
 if condition[0] :
-  ; do something
+  ; 무언가 수행
   false
 else if condition[1] :
-  ; do another thing
+  ; 다른 작업 수행
   false
 else :
-  ; whatever else
+  ; 그 외 모든 것
   false
 
-; there is also a switch statement, which can be used to pattern match
-; on values (as opposed to types)
+; 값에 대해 패턴 매칭하는 데 사용할 수 있는 switch 문도 있습니다.
+; (타입과 반대)
 switch(anything):
   "this": false
   "that": false
   "the-other-thing": false
   else: false
 
-; for and while loops are supported
+; for 및 while 루프가 지원됩니다.
 while condition[0]:
   println("do stuff")
 
 for i in 0 to 10 do:
   vector[i] = i
 
-; stanza also supports named labels which can function as break or return
-; statements
+; stanza는 break 또는 return 문으로 작동할 수 있는
+; 명명된 레이블도 지원합니다.
 defn another-fn ():
   label<False> return:
     label<False> break:
@@ -203,13 +203,13 @@ defn another-fn ():
             break(false)
     return(false)
 
-; For a comprehensive guide on Stanza's advanced control flow, check out
-; this page: http://lbstanza.org/chapter9.html from Stanza-by-Example
+; Stanza의 고급 제어 흐름에 대한 포괄적인 가이드는
+; Stanza-by-Example의 이 페이지를 확인하십시오: http://lbstanza.org/chapter9.html
 
 ;==============================================================================
-; Sequences
+; 시퀀스
 ;==============================================================================
-; for "loops" are sugar for a more powerful syntax.
+; "for" 루프는 더 강력한 구문의 설탕입니다.
 val xs = [1, 2, 3]
 val ys = ['a', 'b', 'c']
 val zs = ["foo", "bar", "baz"]
@@ -218,25 +218,26 @@ for (x in xs, y in ys, z in zs) do :
   println("x:%_, y:%_, z:%_" % [x, y, z])
 
 
-;xs, ys, and zs are all "Seqable" meaning they are Seq types (sequences).
-; the `do` identifier is a special function that just applies the body of
-; the for loop to each element of the sequence.
+;xs, ys, zs는 모두 "Seqable"입니다. 즉, Seq 타입(시퀀스)입니다.
+; `do` 식별자는 for 루프의 본문을 시퀀스의 각 요소에
+; 적용하는 특수 함수입니다.
 ;
-; A common sequence task is concatenating sequences. This is accomplished
-; using the `seq-cat` function. This is analogous to "flattening" iterateors
+; 일반적인 시퀀스 작업은 시퀀스를 연결하는 것입니다. 이것은
+; `seq-cat` 함수를 사용하여 수행됩니다. 이것은 반복자를 "평탄화"하는 것과
+; 유사합니다.
 val concat = to-tuple $
   for sequence in [xs, ys, zs] seq-cat:
     sequence
 
-; we can also use a variation to interleave the elements of multiple sequences
+; 여러 시퀀스의 요소를 인터리브하는 변형을 사용할 수도 있습니다.
 val interleaved = to-tuple $
   for (x in xs, y in ys, z in zs) seq-cat :
     [x, y, z]
 
 println("[%,] [%,]" % [concat, interleaved])
 
-; Another common task is mapping a sequence to another, for example multiplying
-; all the elements of a list of numbers by a constant. To do this we use `seq`.
+; 또 다른 일반적인 작업은 시퀀스를 다른 시퀀스에 매핑하는 것입니다. 예를 들어
+; 숫자 목록의 모든 요소를 상수로 곱하는 것입니다. 이를 위해 `seq`를 사용합니다.
 var numbers = [1.0, 2.0, 3.0, 4.0]
 numbers = to-tuple $
   for n in numbers seq :
@@ -246,33 +247,33 @@ println("%," % [numbers])
 if find({_ == 2.0}, numbers) is-not False :
   println("found it!")
 
-; or maybe we just want to know if there's something in a sequence
+; 또는 시퀀스에 무언가 있는지 알고 싶을 수도 있습니다.
 var is-there =
   for n in numbers any? :
     n == 2.0
 
-; since this is "syntactic sugar" we can write it explicitly using an
-; anonymous function
+; 이것은 "구문 설탕"이므로
+; 익명 함수를 사용하여 명시적으로 작성할 수 있습니다.
 is-there = any?({_ == 2.0}, numbers)
 
-; a detailed reference of the sequence library and various adaptors can
-; be found here: http://lbstanza.org/reference.html#anchor439
+; 시퀀스 라이브러리 및 다양한 어댑터에 대한 자세한 참조는
+; 여기에서 찾을 수 있습니다: http://lbstanza.org/reference.html#anchor439
 
 
 =========================================================================
-; Documentation
+; 문서
 ;=========================================================================
 ;
-; Top level statements can be prefixed with the "doc" field which takes
-; a string value and is used to autogenerate documentation for the package.
+; 최상위 문에는 문자열 값을 사용하는 "doc" 필드가 접두사로 붙을 수 있으며,
+; 패키지에 대한 문서를 자동으로 생성하는 데 사용됩니다.
 doc: \<doc>
-    # Document Strings
+    # 문서 문자열
 
     ```
     val you-can = "include code snippets, too"
     ```
 
-    To render documentation as markdown (compatible with mdbook)
+    문서를 마크다운(mdbook과 호환)으로 렌더링하려면
 
     ```bash
     stanza doc source.stanza -o docs

--- a/ko/ldpl.md
+++ b/ko/ldpl.md
@@ -8,62 +8,61 @@ contributors:
     - ["John Paul Wohlscheid", "https://github.com/JohnBlood"]
 ---
 
-**LDPL** is a powerful, C++ transpiled, open-source programming language designed
-from the ground up to be excessively expressive, readable, fast and easy to learn.
-It mimics plain English, in the likeness of older programming languages like COBOL,
-with the desire that it can be understood by anybody. It's very portable and runs on a
-plethora of different architectures and operating systems and it even supports UTF-8
-out of the box.
+**LDPL**은 C++로 트랜스파일되는 강력한 오픈 소스 프로그래밍 언어로,
+처음부터 과도하게 표현력이 풍부하고, 읽기 쉽고, 빠르고, 배우기 쉽도록 설계되었습니다.
+COBOL과 같은 오래된 프로그래밍 언어와 유사하게 평이한 영어를 모방하여
+누구나 이해할 수 있기를 바라는 마음으로 만들어졌습니다. 매우 이식성이 뛰어나고
+다양한 아키텍처와 운영 체제에서 실행되며, UTF-8을
+즉시 지원합니다.
 
-[Read more here.](https://github.com/lartu/ldpl)
+[여기에서 더 읽어보세요.](https://github.com/lartu/ldpl)
 
 ```coffeescript
-# This is a single line comment in LDPL.
-# LDPL doesn't have multi-line comments.
+# 이것은 LDPL의 한 줄 주석입니다.
+# LDPL에는 여러 줄 주석이 없습니다.
 
-# LDPL is a case-insensitive language: dIsPlaY and DISPLAY are the same
-# statement, and foo and FOO name the same variable.
+# LDPL은 대소문자를 구분하지 않는 언어입니다: dIsPlaY와 DISPLAY는 동일한
+# 문장이며, foo와 FOO는 동일한 변수를 명명합니다.
 
-# An LDPL source file is divided in two sections, the DATA section and
-# the PROCEDURE section.
+# LDPL 소스 파일은 DATA 섹션과 PROCEDURE 섹션의 두 섹션으로 나뉩니다.
 
 DATA:
-# Within the DATA section, variables are declared.
+# DATA 섹션 내에서 변수가 선언됩니다.
 
-myNumber is number          # Defines a real number.
-myString is text            # Defines a string.
-myList is number list       # Defines a list of numbers.
-myMap  is number map        # Defines a map of numbers.
+myNumber is number          # 실수를 정의합니다.
+myString is text            # 문자열을 정의합니다.
+myList is number list       # 숫자 목록을 정의합니다.
+myMap  is number map        # 숫자 맵을 정의합니다.
 
-# LDPL understands four data types: two scalar types (NUMBER, TEXT)
-# and two container types (LISTs and MAPs).
-# LISTs can be TEXT LISTs or NUMBER LISTs, while MAPs can be
-# TEXT MAPs and NUMBER MAPs. You can also chain many containers
-# to create larger data types:
+# LDPL은 네 가지 데이터 타입을 이해합니다: 두 가지 스칼라 타입 (NUMBER, TEXT)
+# 및 두 가지 컨테이너 타입 (LISTs 및 MAPs).
+# LISTs는 TEXT LISTs 또는 NUMBER LISTs가 될 수 있으며, MAPs는
+# TEXT MAPs 및 NUMBER MAPs가 될 수 있습니다. 더 큰 데이터 타입을 만들기 위해
+# 많은 컨테이너를 연결할 수도 있습니다.
 textListList is text list list
 myMulticontainer is number list list map
-# Defines a map of lists of lists of numbers.
+# 숫자 목록의 목록의 목록의 맵을 정의합니다.
 
 PROCEDURE:
-# Within the PROCEDURE section, your code is written.
+# PROCEDURE 섹션 내에서 코드가 작성됩니다.
 
-store -19.2 in myNumber         # Use the STORE statement to assign values
-store "Hi there" in myString    # to variables.
-push 890 to myList # Use PUSH - TO to append values to lists.
+store -19.2 in myNumber         # 값을 할당하려면 STORE 문을 사용합니다.
+store "Hi there" in myString    # 변수에.
+push 890 to myList # 목록에 값을 추가하려면 PUSH - TO를 사용합니다.
 push 100 to myList
 push 500 to myList
-store 45 in myMap:"someIndex" # Use the : operator to index containers.
+store 45 in myMap:"someIndex" # 컨테이너를 인덱싱하려면 : 연산자를 사용합니다.
 
-push list to textListList # Push an empty list into a list of lists.
-push "LDPL is nice!" to textListList:0 #Push text to the pushed list.
+push list to textListList # 목록 목록에 빈 목록을 푸시합니다.
+push "LDPL is nice!" to textListList:0 #푸시된 목록에 텍스트를 푸시합니다.
 
-display "Hello World!" # Use the DISPLAY statement to print values.
-# The display statement can receive multiple values separated by spaces.
+display "Hello World!" # 값을 출력하려면 DISPLAY 문을 사용합니다.
+# display 문은 공백으로 구분된 여러 값을 받을 수 있습니다.
 display crlf "How are you today?" myNumber myString crlf
-# CRLF is the standard line break value in LDPL.
+# CRLF는 LDPL의 표준 줄 바꿈 값입니다.
 display textListList:0:0 " Isn't it?" crlf
 
-# IF statements in LDPL are extremely verbose:
+# LDPL의 IF 문은 매우 장황합니다:
 if myNumber is equal to -19.2 and myList:0 is less than 900 then
     display "Yes!" crlf
 else if myMap:"someIndex" is not equal to 45 then
@@ -71,7 +70,7 @@ else if myMap:"someIndex" is not equal to 45 then
 else
     display "Else!" crlf
 end if
-# Valid LDPL comparison operators are
+# 유효한 LDPL 비교 연산자는 다음과 같습니다.
 # - IS EQUAL TO
 # - IS NOT EQUAL TO
 # - IS LESS THAN
@@ -81,20 +80,20 @@ end if
 if "Hi there!" is not equal to "Bye bye!" then
     display "Yep, those weren't equal." crlf
 end if
-# LDPL normally doesn't understand inline expressions, so you
-# cannot do stuff like:
+# LDPL은 일반적으로 인라인 표현식을 이해하지 못하므로
+# 다음과 같은 작업을 수행할 수 없습니다.
 # if myNumber - 9 * 2 is equal to 10 then
-# LDPL will set your computer on fire and burst your screen if you do so.
+# 그렇게 하면 LDPL이 컴퓨터에 불을 지르고 화면을 터뜨릴 것입니다.
 
-# WHILE loops follow the same rules
+# WHILE 루프는 동일한 규칙을 따릅니다.
 store 0 in myNumber
 while myNumber is less than 10 do
     display "Loop number " myNumber "..." crlf
-    in myNumber solve myNumber + 1 # You can do math like this.
+    in myNumber solve myNumber + 1 # 이렇게 수학을 할 수 있습니다.
 repeat
-# You can use 'break' and 'continue' inside loops just like any other language.
+# 다른 언어와 마찬가지로 루프 내에서 'break' 및 'continue'를 사용할 수 있습니다.
 
-# LDPL also has FOR loops and FOR EACH loops
+# LDPL에는 FOR 루프와 FOR EACH 루프도 있습니다.
 for myNumber from 0 to 100 step 2 do
     display myNumber crlf
 repeat
@@ -104,7 +103,7 @@ for each myNumber in myList do
 repeat
 
 display "Enter your name: "
-accept myString # Use ACCEPT to let the user input values.
+accept myString # 사용자가 값을 입력하도록 하려면 ACCEPT를 사용합니다.
 display "Hi there, " myString crlf
 display "How old are you?: "
 accept myNumber
@@ -112,27 +111,27 @@ if myNumber is greater than 200 then
     display "Woah, you are so old!" crlf
 end if
 
-wait 1000 milliseconds # Pause the program for a whole second.
+wait 1000 milliseconds # 프로그램을 1초 동안 일시 중지합니다.
 
-# Let's do some math
+# 수학을 좀 해보자
 store 1.2 in myNumber
-in myNumber solve myNumber * (10 / 7.2) # Operators are separated by spaces.
+in myNumber solve myNumber * (10 / 7.2) # 연산자는 공백으로 구분됩니다.
 floor myNumber
 display myNumber crlf
-get random in myNumber # get a random number between 0 and 1
-                       # and store it in myNumber
+get random in myNumber # 0과 1 사이의 난수를 얻습니다.
+                       # 그리고 myNumber에 저장합니다.
 
-# Functions in LDPL are called sub-procedures. Sub-procedures, like source
-# files, are divided in sections. The sections found in sub-procedures are
-# the PARAMETERS section, the LOCAL DATA section and the PROCEDURE section.
-# All sections except the PROCEDURE section can be skipped if they aren't
-# used. If no PARAMETERS nor LOCAL DATA sections are used, the PROCEDURE
-# keyword may be omitted.
+# LDPL의 함수는 서브 프로시저라고 합니다. 서브 프로시저는 소스
+# 파일과 마찬가지로 섹션으로 나뉩니다. 서브 프로시저에서 발견되는 섹션은
+# PARAMETERS 섹션, LOCAL DATA 섹션 및 PROCEDURE 섹션입니다.
+# PROCEDURE 섹션을 제외한 모든 섹션은 사용하지 않는 경우 건너뛸 수 있습니다.
+# PARAMETERS 또는 LOCAL DATA 섹션이 사용되지 않는 경우 PROCEDURE
+# 키워드를 생략할 수 있습니다.
 sub myFunction
     parameters:
-        a is number # LDPL is pass by reference
+        a is number # LDPL은 참조에 의한 전달입니다.
         b is number
-        result is number # Thus you can return values through a parameter.
+        result is number # 따라서 매개변수를 통해 값을 반환할 수 있습니다.
     local data:
         c is number
     procedure:
@@ -149,14 +148,14 @@ end sub
 call myFunction with 1 2 myNumber
 display myNumber crlf
 call sayHello
-call sayBye # sub-procedures may be called before they are declared
+call sayBye # 서브 프로시저는 선언되기 전에 호출될 수 있습니다.
 
 sub sayBye
     display "Bye!"
 end sub
 
-# One of the greatest features of LDPL is the ability to create your
-# own statements.
+# LDPL의 가장 큰 특징 중 하나는 자신만의
+# 문장을 만들 수 있다는 것입니다.
 
 create statement "say hi" executing sayHello
 say hi
@@ -168,6 +167,6 @@ display myNumber crlf
 exit
 ```
 
-## Further Reading
+## 더 읽을거리
 
- * [LDPL Docs](https://docs.ldpl-lang.org)
+ * [LDPL 문서](https://docs.ldpl-lang.org)

--- a/ko/less.md
+++ b/ko/less.md
@@ -7,29 +7,29 @@ contributors:
   - ["Saravanan Ganesh", "http://srrvnn.me"]
 ---
 
-Less is a CSS pre-processor, that adds features such as variables, nesting, mixins and more.
-Less (and other preprocessors, such as [Sass](http://sass-lang.com/)) help developers to write maintainable and DRY (Don't Repeat Yourself) code.
+Less는 변수, 중첩, 믹스인 등과 같은 기능을 추가하는 CSS 전처리기입니다.
+Less (및 [Sass](http://sass-lang.com/)와 같은 다른 전처리기)는 개발자가 유지 관리가 가능하고 DRY(Don't Repeat Yourself) 코드를 작성하는 데 도움이 됩니다.
 
 ```less
-//Single line comments are removed when Less is compiled to CSS.
+//한 줄 주석은 Less가 CSS로 컴파일될 때 제거됩니다.
 
-/*Multi line comments are preserved. */
+/*여러 줄 주석은 유지됩니다. */
 
 
 
-/* Variables
+/* 변수
 ==============================*/
 
 
-/* You can store a CSS value (such as a color) in a variable.
-   Use the '@' symbol to create a variable. */
+/* 변수에 CSS 값(예: 색상)을 저장할 수 있습니다.
+   변수를 만들려면 '@' 기호를 사용하십시오. */
 
 @primary-color: #a3a4ff;
 @secondary-color: #51527f;
 @body-font: 'Roboto', sans-serif;
 
-/* You can use the variables throughout your stylesheet.
-   Now if you want to change a color, you only have to make the change once.*/
+/* 스타일시트 전체에서 변수를 사용할 수 있습니다.
+   이제 색상을 변경하려면 한 번만 변경하면 됩니다.*/
 
 body {
 	background-color: @primary-color;
@@ -37,7 +37,7 @@ body {
 	font-family: @body-font;
 }
 
-/* This would compile to: */
+/* 이것은 다음과 같이 컴파일됩니다. */
 
 body {
 	background-color: #a3a4ff;
@@ -46,17 +46,17 @@ body {
 }
 
 
-/* This is much more maintainable than having to change the color
-   each time it appears throughout your stylesheet. */
+/* 스타일시트 전체에서 나타날 때마다 색상을 변경하는 것보다
+   유지 관리가 훨씬 쉽습니다. */
 
 
 
-/* Mixins
+/* 믹스인
 ==============================*/
 
 
-/* If you find you are writing the same code for more than one
-   element, you might want to reuse that easily.*/
+/* 둘 이상의 요소에 대해 동일한 코드를 작성하고 있다는 것을
+   발견하면 쉽게 재사용하고 싶을 수 있습니다.*/
 
 .center {
 	display: block;
@@ -66,14 +66,14 @@ body {
 	right: 0;
 }
 
-/* You can use the mixin by simply adding the selector as a style */
+/* 단순히 선택자를 스타일로 추가하여 믹스인을 사용할 수 있습니다. */
 
 div {
 	.center;
 	background-color: @primary-color;
 }
 
-/* Which would compile to: */
+/* 다음과 같이 컴파일됩니다. */
 
 .center {
   display: block;
@@ -91,8 +91,8 @@ div {
 	background-color: #a3a4ff;
 }
 
-/* You can omit the mixin code from being compiled by adding parenthesis
-   after the selector */
+/* 선택자 뒤에 괄호를 추가하여 믹스인 코드가 컴파일되지 않도록
+   생략할 수 있습니다. */
 
 .center() {
   display: block;
@@ -107,7 +107,7 @@ div {
   background-color: @primary-color;
 }
 
-/* Which would compile to: */
+/* 다음과 같이 컴파일됩니다. */
 div {
   display: block;
   margin-left: auto;
@@ -119,11 +119,11 @@ div {
 
 
 
-/* Nesting
+/* 중첩
 ==============================*/
 
 
-/* Less allows you to nest selectors within selectors */
+/* Less를 사용하면 선택자 내에 선택자를 중첩할 수 있습니다. */
 
 ul {
 	list-style-type: none;
@@ -134,11 +134,11 @@ ul {
 	}
 }
 
-/* '&' will be replaced by the parent selector. */
-/* You can also nest pseudo-classes. */
-/* Keep in mind that over-nesting will make your code less maintainable.
-   Best practices recommend going no more than 3 levels deep when nesting.
-   For example: */
+/* '&'는 부모 선택자로 대체됩니다. */
+/* 의사 클래스를 중첩할 수도 있습니다. */
+/* 과도하게 중첩하면 코드를 유지 관리하기 어려워진다는 점을 명심하십시오.
+   모범 사례는 중첩 시 3단계 이상으로 들어가지 않는 것을 권장합니다.
+   예를 들어: */
 
 ul {
 	list-style-type: none;
@@ -157,7 +157,7 @@ ul {
 	}
 }
 
-/* Compiles to: */
+/* 컴파일 결과: */
 
 ul {
   list-style-type: none;
@@ -178,15 +178,14 @@ ul li a {
 
 
 
-/* Functions
+/* 함수
 ==============================*/
 
 
-/* Less provides functions that can be used to accomplish a variety of
-   tasks. Consider the following: */
+/* Less는 다양한 작업을 수행하는 데 사용할 수 있는 함수를 제공합니다.
+   다음을 고려하십시오. */
 
-/* Functions can be invoked by using their name and passing in the
-   required arguments. */
+/* 함수는 이름을 사용하고 필요한 인수를 전달하여 호출할 수 있습니다. */
 
 body {
   width: round(10.25px);
@@ -200,7 +199,7 @@ body {
   background-color: fadeout(#000, 0.25)
 }
 
-/* Compiles to: */
+/* 컴파일 결과: */
 
 body {
   width: 10px;
@@ -214,25 +213,24 @@ body {
   background-color: rgba(0, 0, 0, 0.75);
 }
 
-/* You may also define your own functions. Functions are very similar to
-   mixins. When trying to choose between a function or a mixin, remember
-   that mixins are best for generating CSS while functions are better for
-   logic that might be used throughout your Less code. The examples in
-   the 'Math Operators' section are ideal candidates for becoming a reusable
-   function. */
+/* 자신만의 함수를 정의할 수도 있습니다. 함수는 믹스인과 매우 유사합니다.
+   함수와 믹스인 중에서 선택할 때, 믹스인은 CSS를 생성하는 데 가장 적합하고
+   함수는 Less 코드 전체에서 사용할 수 있는 논리에 더 적합하다는 것을
+   기억하십시오. '수학 연산자' 섹션의 예제는 재사용 가능한
+   함수가 되기에 이상적인 후보입니다. */
 
-/* This function calculates the average of two numbers: */
+/* 이 함수는 두 숫자의 평균을 계산합니다. */
 
 .average(@x, @y) {
   @average-result: ((@x + @y) / 2);
 }
 
 div {
-  .average(16px, 50px); // "call" the mixin
-  padding: @average-result;    // use its "return" value
+  .average(16px, 50px); // 믹스인 "호출"
+  padding: @average-result;    // "반환" 값 사용
 }
 
-/* Compiles to: */
+/* 컴파일 결과: */
 
 div {
   padding: 33px;
@@ -240,11 +238,11 @@ div {
 
 
 
-/*Extend (Inheritance)
+/* 확장 (상속)
 ==============================*/
 
 
-/*Extend is a way to share the properties of one selector with another. */
+/* 확장은 한 선택자의 속성을 다른 선택자와 공유하는 방법입니다. */
 
 .display {
   height: 50px;
@@ -255,7 +253,7 @@ div {
 	border-color: #22df56;
 }
 
-/* Compiles to: */
+/* 컴파일 결과: */
 .display,
 .display-success {
   height: 50px;
@@ -264,25 +262,25 @@ div {
   border-color: #22df56;
 }
 
-/* Extending a CSS statement is preferable to creating a mixin
-   because of the way it groups together the classes that all share
-   the same base styling. If this was done with a mixin, the properties
-   would be duplicated for each statement that
-   called the mixin. While it won't affect your workflow, it will
-   add unnecessary bloat to the files created by the Less compiler. */
+/* 믹스인을 만드는 것보다 CSS 문을 확장하는 것이 좋습니다.
+   모두 동일한 기본 스타일을 공유하는 클래스를 그룹화하는 방식 때문입니다.
+   이것이 믹스인으로 수행되었다면 속성은
+   믹스인을 호출한 각 문에 대해 복제됩니다.
+   워크플로에는 영향을 미치지 않지만 Less 컴파일러가 생성한
+   파일에 불필요한 부풀림을 추가합니다. */
 
 
 
-/*Partials and Imports
+/* 부분 및 가져오기
 ==============================*/
 
 
-/* Less allows you to create partial files. This can help keep your Less
-   code modularized. Partial files conventionally begin with an '_',
-   e.g. _reset.less. and are imported into a main less file that gets
-   compiled into CSS */
+/* Less를 사용하면 부분 파일을 만들 수 있습니다. 이렇게 하면 Less
+   코드를 모듈화하는 데 도움이 될 수 있습니다. 부분 파일은 관례적으로
+   '_'로 시작합니다(예: _reset.less). 그리고 CSS로 컴파일되는
+   주요 less 파일로 가져옵니다. */
 
-/* Consider the following CSS which we'll put in a file called _reset.less */
+/* _reset.less라는 파일에 넣을 다음 CSS를 고려하십시오. */
 
 html,
 body,
@@ -292,10 +290,10 @@ ol {
   padding: 0;
 }
 
-/* Less offers @import which can be used to import partials into a file.
-   This differs from the traditional CSS @import statement which makes
-   another HTTP request to fetch the imported file. Less takes the
-   imported file and combines it with the compiled code. */
+/* Less는 @import를 제공하여 부분 파일을 파일로 가져올 수 있습니다.
+   이는 가져온 파일을 가져오기 위해 다른 HTTP 요청을 하는
+   전통적인 CSS @import 문과 다릅니다. Less는
+   가져온 파일을 가져와 컴파일된 코드와 결합합니다. */
 
 @import 'reset';
 
@@ -304,7 +302,7 @@ body {
   font-family: Helvetica, Arial, Sans-serif;
 }
 
-/* Compiles to: */
+/* 컴파일 결과: */
 
 html, body, ul, ol {
   margin: 0;
@@ -318,14 +316,14 @@ body {
 
 
 
-/* Math Operations
+/* 수학 연산
 ==============================*/
 
 
-/* Less provides the following operators: +, -, *, /, and %. These can
-   be useful for calculating values directly in your Less files instead
-   of using values that you've already calculated by hand. Below is an example
-   of a setting up a simple two column design. */
+/* Less는 +, -, *, /, % 연산자를 제공합니다.
+   이러한 연산자는 수동으로 계산한 값을 사용하는 대신
+   Less 파일에서 직접 값을 계산하는 데 유용할 수 있습니다.
+   아래는 간단한 2열 디자인을 설정하는 예입니다. */
 
 @content-area: 960px;
 @main-content: 600px;
@@ -351,7 +349,7 @@ body {
   width: @gutter;
 }
 
-/* Compiles to: */
+/* 컴파일 결과: */
 
 body {
   width: 100%;
@@ -370,18 +368,18 @@ body {
 }
 ```
 
-## Practice Less
+## Less 연습
 
-If you want to play with Less in your browser, check out:
+브라우저에서 Less를 사용해보고 싶다면 다음을 확인하십시오.
 * [Codepen](http://codepen.io/)
 * [LESS2CSS](http://lesscss.org/less-preview/)
 
-## Compatibility
+## 호환성
 
-Less can be used in any project as long as you have a program to compile it into CSS. You'll want to verify that the CSS you're using is compatible with your target browsers.
+Less는 CSS로 컴파일하는 프로그램만 있으면 모든 프로젝트에서 사용할 수 있습니다. 사용 중인 CSS가 대상 브라우저와 호환되는지 확인해야 합니다.
 
-[QuirksMode CSS](http://www.quirksmode.org/css/) and [CanIUse](http://caniuse.com) are great resources for checking compatibility.
+[QuirksMode CSS](http://www.quirksmode.org/css/) 및 [CanIUse](http://caniuse.com)는 호환성을 확인하는 데 유용한 자료입니다.
 
-## Further reading
-* [Official Documentation](http://lesscss.org/features/)
-* [Less CSS - Beginner's Guide](http://www.hongkiat.com/blog/less-basic/)
+## 더 읽을거리
+* [공식 문서](http://lesscss.org/features/)
+* [Less CSS - 초보자 가이드](http://www.hongkiat.com/blog/less-basic/)

--- a/ko/linker.md
+++ b/ko/linker.md
@@ -10,49 +10,49 @@ translators:
 filename: learn.ld
 ---
 
-**Position counter** - the linker has a special variable
-"`.`" (dot) always contains the current output position.
+**위치 카운터** - 링커에는 특수 변수가 있습니다.
+"`.`" (점)은 항상 현재 출력 위치를 포함합니다.
 
-`ADDR (section)` - returns the absolute address of the specified section. However
-this section must be defined before using the ADDR function.
+`ADDR (section)` - 지정된 섹션의 절대 주소를 반환합니다. 그러나
+이 섹션은 ADDR 함수를 사용하기 전에 정의되어야 합니다.
 
-`ALIGN (exp)` - returns the value of the position counter aligned to the border
-following the exp expression.
+`ALIGN (exp)` - exp 표현식 다음의 경계에 정렬된 위치 카운터의 값을
+반환합니다.
 
-`SIZEOF (section)` - returns the size of the section in bytes.
+`SIZEOF (section)` - 섹션의 크기를 바이트 단위로 반환합니다.
 
-`FILL (param)` - defines the fill pattern for the current section. All
-other unspecified regions within the section are filled with the value indicated
-in function argument.
+`FILL (param)` - 현재 섹션의 채우기 패턴을 정의합니다. 모든
+섹션 내의 다른 지정되지 않은 영역은 함수 인수에 표시된 값으로
+채워집니다.
 
-`KEEP (param)` - used to mark param as fatal.
+`KEEP (param)` - param을 치명적인 것으로 표시하는 데 사용됩니다.
 
-`ENTRY (func)` - defines the function that will be the entry point
-into the program.
+`ENTRY (func)` - 프로그램의 진입점이 될 함수를
+정의합니다.
 
 ```bash
-# Determine the entry point to the program
+# 프로그램의 진입점을 결정합니다.
 ENTRY(Reset_Handler)
 
-# Define a variable that contains the address of the top of the stack
+# 스택의 맨 위 주소를 포함하는 변수를 정의합니다.
 _estack = 0x20020000;
-# Define a variable that contains a heap size value
+# 힙 크기 값을 포함하는 변수를 정의합니다.
 _Min_Heap_Size = 0x200;
-# Define a variable that contains the value of the stack size
+# 스택 크기 값을 포함하는 변수를 정의합니다.
 _Min_Stack_Size = 0x400;
 
-# Description of the memory card available for this processor
+# 이 프로세서에서 사용할 수 있는 메모리 카드 설명
 # MEMORY
 # {
-#   MEMORY_DOMAIN_NAME (access rights) : ORIGIN = START_ADDRESS, LENGTH = SIZE
+#   MEMORY_DOMAIN_NAME (액세스 권한) : ORIGIN = START_ADDRESS, LENGTH = SIZE
 # }
-# In our example, the controller contains three memory areas:
-# RAM - starts with the address 0x20000000 and takes 128 KB;
-# CCMRAM - starts with the address 0x10000000 and occupies 64 KB;
-# FLASH - starts with the address 0x8000000; takes 1024 Kb;
-# Moreover, RAM memory access for reading, writing and execution.
-# CCMRAM memory is read-write only.
-# FLASH memory is available for reading and execution.
+# 이 예에서 컨트롤러에는 세 개의 메모리 영역이 있습니다:
+# RAM - 주소 0x20000000에서 시작하여 128KB를 차지합니다.
+# CCMRAM - 주소 0x10000000에서 시작하여 64KB를 차지합니다.
+# FLASH - 주소 0x8000000에서 시작하여 1024KB를 차지합니다.
+# 또한 RAM 메모리 액세스는 읽기, 쓰기 및 실행이 가능합니다.
+# CCMRAM 메모리는 읽기-쓰기만 가능합니다.
+# FLASH 메모리는 읽기 및 실행이 가능합니다.
 MEMORY
 {
     RAM    (xrw) : ORIGIN = 0x20000000,  LENGTH = 128K
@@ -60,135 +60,134 @@ MEMORY
     FLASH  (rx)  : ORIGIN = 0x8000000,   LENGTH = 1024K
 }
 
-# We describe output sections
+# 출력 섹션을 설명합니다.
 SECTIONS
 {
-  # The first section contains a table of interrupt vectors
+  # 첫 번째 섹션에는 인터럽트 벡터 테이블이 포함됩니다.
   .isr_vector :
   {
-    # Align the current position to the border of 4 bytes.
+    # 현재 위치를 4바이트 경계에 맞춥니다.
     . = ALIGN(4);
 
-    # There is an option --gc-sections, which allows you to collect garbage from unused
-    # input sections. And if there are sections that the garbage collector should not touch,
-    # you need to specify them as an argument to the KEEP () function (analogue of the keyword
-    # volatile).
-    # The entry (* (. Isr_vector)) means the .isr_vector sections in all object files. Because
-    # appeal to the section in general terms looks like this: (FILE_NAME (SECTION_NAME))
+    # 사용하지 않는 입력 섹션에서 가비지를 수집할 수 있는 --gc-sections 옵션이 있습니다.
+    # 그리고 가비지 수집기가 건드리지 않아야 하는 섹션이 있는 경우
+    # KEEP () 함수의 인수로 지정해야 합니다 (volatile 키워드와 유사).
+    # 항목 (* (. Isr_vector))은 모든 객체 파일의 .isr_vector 섹션을 의미합니다. 왜냐하면
+    # 일반적으로 섹션에 대한 호소는 다음과 같이 보입니다: (FILE_NAME (SECTION_NAME))
     KEEP(*(.isr_vector))
 
-    # Align the current position to the border of 4 bytes.
+    # 현재 위치를 4바이트 경계에 맞춥니다.
     . = ALIGN(4);
 
-    # The expression "> MEMORY AREA" indicates which area of memory will be placed
-    # this section. In our section, the .isr_vector section will be located in FLASH memory.
+    # 표현식 "> MEMORY AREA"는 어떤 메모리 영역이 배치될지를 나타냅니다.
+    # 이 섹션. 이 섹션에서 .isr_vector 섹션은 FLASH 메모리에 위치합니다.
   } >FLASH
 
-# TOTAL: The .isr_vector section that contains the table of interrupt vectors is aligned
-# on the border of 4 bytes, marked as inaccessible to the garbage collector and placed at the beginning
-# FLASH microcontroller memory.
+# 총계: 인터럽트 벡터 테이블을 포함하는 .isr_vector 섹션은
+# 4바이트 경계에 정렬되고, 가비지 수집기에 액세스할 수 없는 것으로 표시되며, 맨 처음에 배치됩니다.
+# FLASH 마이크로컨트롤러 메모리.
 
-  # The second section contains the program code.
+  # 두 번째 섹션에는 프로그램 코드가 포함됩니다.
   .text :
   {
-    # Align the current position to the border of 4 bytes.
+    # 현재 위치를 4바이트 경계에 맞춥니다.
     . = ALIGN(4);
 
-    # We indicate that in this section the .text areas of all
-    # object files
+    # 이 섹션에서 모든 객체 파일의 .text 영역을
+    # 나타냅니다.
     *(.text)
     *(.text*)
 
-    # Protect the .init and .fini sections from the garbage collector
+    # 가비지 수집기로부터 .init 및 .fini 섹션을 보호합니다.
     KEEP (*(.init))
     KEEP (*(.fini))
 
-    # Align the current position to the border of 4 bytes.
+    # 현재 위치를 4바이트 경계에 맞춥니다.
     . = ALIGN(4);
 
-    # The variable _etext is defined, which stores the address of the end of the .text section and which
-    # may be available in the source code of the program through the announcement
+    # 변수 _etext는 .text 섹션의 끝 주소를 저장하는 변수로 정의되며,
+    # 프로그램 소스 코드에서 다음 선언을 통해 사용할 수 있습니다.
     # volaile unsigned int extern _etext;
     _etext = .;
   } >FLASH
 
-# TOTAL: The .text section that contains the program code is aligned on the border of 4 bytes,
-# includes: all sections with program code in all object files and protected
-# from the garbage collector of the .init and .fini sections in all object files, located in FLASH
-# microcontroller memory immediately after the table of vectors.
-# The text, .init, and .fini sections. are located in memory in the order in which they
-# declared in the script.
+# 총계: 프로그램 코드를 포함하는 .text 섹션은 4바이트 경계에 정렬되고,
+# 모든 객체 파일의 모든 프로그램 코드 섹션과 모든 객체 파일의 .init 및 .fini 섹션의
+# 가비지 수집기로부터 보호되며, 벡터 테이블 바로 뒤에 FLASH
+# 마이크로컨트롤러 메모리에 위치합니다.
+# text, .init 및 .fini 섹션은 스크립트에 선언된 순서대로
+# 메모리에 위치합니다.
 
-  # The third section contains constant data.
+  # 세 번째 섹션에는 상수 데이터가 포함됩니다.
   .rodata :
   {
-    # Align the current position to the border of 4 bytes.
+    # 현재 위치를 4바이트 경계에 맞춥니다.
     . = ALIGN(4);
 
-    # We indicate that in this section areas .rodata will be stored
-    # object files
+    # 이 섹션 영역 .rodata가 저장될 것임을 나타냅니다.
+    # 객체 파일
     *(.rodata)
     *(.rodata*)
 
-    # Align the current position to the border of 4 bytes.
+    # 현재 위치를 4바이트 경계에 맞춥니다.
     . = ALIGN(4);
   } >FLASH
 
-  # Save the absolute address of the .data section in the _sidata variable
+  # _sidata 변수에 .data 섹션의 절대 주소를 저장합니다.
   _sidata = LOADADDR(.data);
 
-  # The fourth section contains initialized variables.
+  # 네 번째 섹션에는 초기화된 변수가 포함됩니다.
   .data :
   {
-    # Align the current position to the border of 4 bytes.
+    # 현재 위치를 4바이트 경계에 맞춥니다.
     . = ALIGN(4);
 
-    # Save the address of the current position (beginning of the section) in the variable _sdata
+    # 현재 위치(섹션 시작)의 주소를 _sdata 변수에 저장합니다.
     _sdata = .;
 
-    # We indicate that in this section the .data areas of all
-    # object files
+    # 이 섹션에서 모든 객체 파일의 .data 영역을
+    # 나타냅니다.
     *(.data)
     *(.data*)
 
-    # Align the current position to the border of 4 bytes.
+    # 현재 위치를 4바이트 경계에 맞춥니다.
     . = ALIGN(4);
 
-    # Save the address of the current position (end of section) in the variable _sdata
+    # 현재 위치(섹션 끝)의 주소를 _sdata 변수에 저장합니다.
     _edata = .;
 
-    # AT function indicates that this sector is stored in one memory area
-    # (in our case, FLASH), and it will be executed from another area of memory (in our case, RAM).
-    # There are two types of addresses:
-    # * VMA (Virtual memory address) - this is the run-time address at which the compiler expects
-    # see data.
-    # * LMA (Load memory address) is the address at which the linker stores data.
+    # AT 함수는 이 섹터가 한 메모리 영역에 저장됨을 나타냅니다.
+    # (이 경우 FLASH), 다른 메모리 영역(이 경우 RAM)에서 실행됩니다.
+    # 두 가지 유형의 주소가 있습니다:
+    # * VMA (가상 메모리 주소) - 컴파일러가 예상하는 런타임 주소입니다.
+    # 데이터를 봅니다.
+    # * LMA (로드 메모리 주소)는 링커가 데이터를 저장하는 주소입니다.
 
-    #Startup must code to copy the .data section from the LMA addresses to the VMA addresses.
+    # 시작 코드는 .data 섹션을 LMA 주소에서 VMA 주소로 복사해야 합니다.
 
   } >RAM AT> FLASH
 
-  # The fifth section contains zero-initialized variables.
+  # 다섯 번째 섹션에는 0으로 초기화된 변수가 포함됩니다.
   .bss :
   {
-    # Save the address of the current position (beginning of the section) in the variable _sbss and __bss_start__
+    # 현재 위치(섹션 시작)의 주소를 _sbss 및 __bss_start__ 변수에 저장합니다.
     _sbss = .;
     __bss_start__ = _sbss;
 
-    # We indicate that in this section the .bss areas of all
-    # object files
+    # 이 섹션에서 모든 객체 파일의 .bss 영역을
+    # 나타냅니다.
     *(.bss)
     *(.bss*)
 
-    # Align the current position to the border of 4 bytes.
+    # 현재 위치를 4바이트 경계에 맞춥니다.
     . = ALIGN(4);
 
-    # Save the address of the current position (beginning of the section) in the variable _ebss and __bss_end__
+    # 현재 위치(섹션 시작)의 주소를 _ebss 및 __bss_end__ 변수에 저장합니다.
     _ebss = .;
     __bss_end__ = _ebss;
   } >RAM
 
-  # The sixth section contains a bunch and a stack. It is located at the very end of RAM.
+  # 여섯 번째 섹션에는 힙과 스택이 포함됩니다. RAM의 맨 끝에 위치합니다.
   ._user_heap_stack :
   {
     . = ALIGN(4);

--- a/ko/make.md
+++ b/ko/make.md
@@ -9,134 +9,132 @@ contributors:
 filename: Makefile
 ---
 
-A Makefile defines a graph of rules for creating a target (or targets).
-Its purpose is to do the minimum amount of work needed to update a
-target to the most recent version of the source. Famously written over a
-weekend by Stuart Feldman in 1976, it is still widely used (particularly
-on Unix and Linux) despite many competitors and criticisms.
+Makefile은 대상(또는 대상들)을 생성하기 위한 규칙 그래프를 정의합니다.
+그 목적은 대상을 소스의 최신 버전으로 업데이트하는 데 필요한 최소한의 작업을
+수행하는 것입니다. 1976년 Stuart Feldman이 주말 동안 작성한 것으로 유명하며,
+많은 경쟁자와 비판에도 불구하고 (특히 Unix 및 Linux에서) 여전히 널리 사용됩니다.
 
-There are many varieties of make in existence, however this article
-assumes that we are using GNU make which is the standard on Linux.
+존재하는 make에는 여러 종류가 있지만, 이 글에서는 Linux의 표준인
+GNU make를 사용한다고 가정합니다.
 
 ```make
-# Comments can be written like this.
+# 주석은 이렇게 작성할 수 있습니다.
 
-# File should be named Makefile and then can be run as `make <target>`.
-# Otherwise we use `make -f "filename" <target>`.
+# 파일 이름은 Makefile이어야 하며, `make <target>`으로 실행할 수 있습니다.
+# 그렇지 않으면 `make -f "filename" <target>`을 사용합니다.
 
-# Warning - only use TABS to indent in Makefiles, never spaces!
+# 경고 - Makefile에서는 들여쓰기에 탭만 사용하고 공백은 절대 사용하지 마십시오!
 
 #-----------------------------------------------------------------------
-# Basics
+# 기본
 #-----------------------------------------------------------------------
 
-# Rules are of the format
+# 규칙은 다음과 같은 형식입니다.
 # target: <prerequisite>
-# where prerequisites are optional.
+# 여기서 prerequisite는 선택 사항입니다.
 
-# A rule - this rule will only run if file0.txt doesn't exist.
+# 규칙 - 이 규칙은 file0.txt가 존재하지 않을 경우에만 실행됩니다.
 file0.txt:
 	echo "foo" > file0.txt
-	# Even comments in these 'recipe' sections get passed to the shell.
-	# Try `make file0.txt` or simply `make` - first rule is the default.
+	# 이 '레시피' 섹션의 주석도 셸로 전달됩니다.
+	# `make file0.txt` 또는 단순히 `make`를 시도해보십시오 - 첫 번째 규칙이 기본값입니다.
 
-# This rule will only run if file0.txt is newer than file1.txt.
+# 이 규칙은 file0.txt가 file1.txt보다 최신일 경우에만 실행됩니다.
 file1.txt: file0.txt
 	cat file0.txt > file1.txt
-	# use the same quoting rules as in the shell.
+	# 셸에서와 동일한 인용 규칙을 사용합니다.
 	@cat file0.txt >> file1.txt
-	# @ stops the command from being echoed to stdout.
+	# @는 명령이 stdout에 에코되는 것을 방지합니다.
 	-@echo 'hello'
-	# - means that make will keep going in the case of an error.
-	# Try `make file1.txt` on the commandline.
+	# -는 오류가 발생하더라도 make가 계속 진행됨을 의미합니다.
+	# 명령줄에서 `make file1.txt`를 시도해보십시오.
 
-# A rule can have multiple targets and multiple prerequisites
+# 규칙은 여러 대상과 여러 전제 조건을 가질 수 있습니다.
 file2.txt file3.txt: file0.txt file1.txt
 	touch file2.txt
 	touch file3.txt
 
-# Make will complain about multiple recipes for the same rule. Empty
-# recipes don't count though and can be used to add new dependencies.
+# make는 동일한 규칙에 대한 여러 레시피에 대해 불평합니다.
+# 하지만 빈 레시피는 계산되지 않으며 새 종속성을 추가하는 데 사용할 수 있습니다.
 
 #-----------------------------------------------------------------------
-# Phony Targets
+# 포니 타겟
 #-----------------------------------------------------------------------
 
-# A phony target. Any target that isn't a file.
-# It will never be up to date so make will always try to run it.
+# 포니 타겟. 파일이 아닌 모든 타겟.
+# 절대 최신 상태가 아니므로 make는 항상 실행하려고 시도합니다.
 all: maker process
 
-# We can declare things out of order.
+# 순서에 상관없이 선언할 수 있습니다.
 maker:
 	touch ex0.txt ex1.txt
 
-# Can avoid phony rules breaking when a real file has the same name by
+# 실제 파일과 이름이 같을 때 포니 규칙이 깨지는 것을 방지할 수 있습니다.
 .PHONY: all maker process
-# This is a special target. There are several others.
+# 이것은 특별한 타겟입니다. 다른 여러 가지가 있습니다.
 
-# A rule with a dependency on a phony target will always run
+# 포니 타겟에 대한 종속성이 있는 규칙은 항상 실행됩니다.
 ex0.txt ex1.txt: maker
 
-# Common phony targets are: all make clean install ...
+# 일반적인 포니 타겟은 all make clean install ... 입니다.
 
 #-----------------------------------------------------------------------
-# Automatic Variables & Wildcards
+# 자동 변수 및 와일드카드
 #-----------------------------------------------------------------------
 
-process: file*.txt	#using a wildcard to match filenames
-	@echo $^	# $^ is a variable containing the list of prerequisites
-	@echo $@	# prints the target name
-	#(for multiple target rules, $@ is whichever caused the rule to run)
-	@echo $<	# the first prerequisite listed
-	@echo $?	# only the dependencies that are out of date
-	@echo $+	# all dependencies including duplicates (unlike normal)
-	#@echo $|	# all of the 'order only' prerequisites
+process: file*.txt	#파일 이름과 일치하도록 와일드카드 사용
+	@echo $^	# $^는 전제 조건 목록을 포함하는 변수입니다.
+	@echo $@	# 타겟 이름을 출력합니다.
+	#(여러 타겟 규칙의 경우, $@는 규칙을 실행하게 한 것입니다.)
+	@echo $<	# 나열된 첫 번째 전제 조건
+	@echo $?	# 최신이 아닌 종속성만
+	@echo $+	# 중복을 포함한 모든 종속성 (일반과 다름)
+	#@echo $|	# 모든 '순서 전용' 전제 조건
 
-# Even if we split up the rule dependency definitions, $^ will find them
+# 규칙 종속성 정의를 분리하더라도 $^는 그것들을 찾습니다.
 process: ex1.txt file0.txt
-# ex1.txt will be found but file0.txt will be deduplicated.
+# ex1.txt는 발견되지만 file0.txt는 중복 제거됩니다.
 
 #-----------------------------------------------------------------------
-# Patterns
+# 패턴
 #-----------------------------------------------------------------------
 
-# Can teach make how to convert certain files into other files.
+# 특정 파일을 다른 파일로 변환하는 방법을 make에 가르칠 수 있습니다.
 
 %.png: %.svg
 	inkscape --export-png $^
 
-# Pattern rules will only do anything if make decides to create the
-# target.
+# 패턴 규칙은 make가 타겟을 생성하기로 결정한 경우에만 작동합니다.
 
-# Directory paths are normally ignored when matching pattern rules. But
-# make will try to use the most appropriate rule available.
+# 디렉토리 경로는 일반적으로 패턴 규칙을 일치시킬 때 무시됩니다. 하지만
+# make는 사용 가능한 가장 적절한 규칙을 사용하려고 시도합니다.
 small/%.png: %.svg
 	inkscape --export-png --export-dpi 30 $^
 
-# make will use the last version for a pattern rule that it finds.
+# make는 찾은 패턴 규칙의 마지막 버전을 사용합니다.
 %.png: %.svg
 	@echo this rule is chosen
 
-# However make will use the first pattern rule that can make the target
+# 그러나 make는 타겟을 만들 수 있는 첫 번째 패턴 규칙을 사용합니다.
 %.png: %.ps
 	@echo this rule is not chosen if *.svg and *.ps are both present
 
-# make already has some pattern rules built-in. For instance, it knows
-# how to turn *.c files into *.o files.
+# make에는 이미 일부 패턴 규칙이 내장되어 있습니다. 예를 들어,
+# *.c 파일을 *.o 파일로 변환하는 방법을 알고 있습니다.
 
-# Older makefiles might use suffix rules instead of pattern rules
+# 이전 Makefile은 패턴 규칙 대신 접미사 규칙을 사용할 수 있습니다.
 .png.ps:
 	@echo this rule is similar to a pattern rule.
 
-# Tell make about the suffix rule
+# make에 접미사 규칙에 대해 알립니다.
 .SUFFIXES: .png
 
 #-----------------------------------------------------------------------
-# Variables
+# 변수
 #-----------------------------------------------------------------------
-# aka. macros
+# aka. 매크로
 
-# Variables are basically all string types
+# 변수는 기본적으로 모두 문자열 타입입니다.
 
 name = Ted
 name2="Sarah"
@@ -144,31 +142,31 @@ name2="Sarah"
 echo:
 	@echo $(name)
 	@echo ${name2}
-	@echo $name    # This won't work, treated as $(n)ame.
-	@echo $(name3) # Unknown variables are treated as empty strings.
+	@echo $name    # 이것은 작동하지 않으며, $(n)ame으로 처리됩니다.
+	@echo $(name3) # 알 수 없는 변수는 빈 문자열로 처리됩니다.
 
-# There are 4 places to set variables.
-# In order of priority from highest to lowest:
-# 1: commandline arguments
+# 변수를 설정하는 4가지 방법이 있습니다.
+# 우선 순위가 높은 순서대로:
+# 1: 명령줄 인수
 # 2: Makefile
-# 3: shell environment variables - make imports these automatically.
-# 4: make has some predefined variables
+# 3: 셸 환경 변수 - make는 이것들을 자동으로 가져옵니다.
+# 4: make에는 일부 미리 정의된 변수가 있습니다.
 
 name4 ?= Jean
-# Only set the variable if environment variable is not already defined.
+# 환경 변수가 아직 정의되지 않은 경우에만 변수를 설정합니다.
 
 override name5 = David
-# Stops commandline arguments from changing this variable.
+# 명령줄 인수가 이 변수를 변경하는 것을 중지합니다.
 
 name4 +=grey
-# Append values to variable (includes a space).
+# 변수에 값 추가 (공백 포함).
 
-# Pattern-specific variable values (GNU extension).
-echo: name2 = Sara # True within the matching rule
-	# and also within its remade recursive dependencies
-	# (except it can break when your graph gets too complicated!)
+# 패턴별 변수 값 (GNU 확장).
+echo: name2 = Sara # 일치하는 규칙 내에서 참
+	# 그리고 재귀적으로 재구성된 종속성 내에서도
+	# (그래프가 너무 복잡해지면 깨질 수 있음!)
 
-# Some variables defined automatically by make.
+# make에 의해 자동으로 정의된 일부 변수.
 echo_inbuilt:
 	echo $(CC)
 	echo ${CXX}
@@ -180,50 +178,50 @@ echo_inbuilt:
 	echo ${LDLIBS}
 
 #-----------------------------------------------------------------------
-# Variables 2
+# 변수 2
 #-----------------------------------------------------------------------
 
-# The first type of variables are evaluated each time they are used.
-# This can be expensive, so a second type of variable exists which is
-# only evaluated once. (This is a GNU make extension)
+# 첫 번째 유형의 변수는 사용될 때마다 평가됩니다.
+# 이것은 비용이 많이 들 수 있으므로 한 번만 평가되는 두 번째 유형의
+# 변수가 존재합니다. (이것은 GNU make 확장입니다)
 
 var := hello
 var2 ::= $(var) hello
-#:= and ::= are equivalent.
+#:=와 ::=는 동일합니다.
 
-# These variables are evaluated procedurally (in the order that they
-# appear), thus breaking with the rest of the language !
+# 이러한 변수는 절차적으로 평가되므로 (나타나는 순서대로),
+# 언어의 나머지 부분과 충돌합니다!
 
-# This doesn't work
+# 이것은 작동하지 않습니다.
 var3 ::= $(var4) and good luck
 var4 ::= good night
 
 #-----------------------------------------------------------------------
-# Functions
+# 함수
 #-----------------------------------------------------------------------
 
-# make has lots of functions available.
+# make에는 많은 함수가 있습니다.
 
 sourcefiles = $(wildcard *.c */*.c)
 objectfiles = $(patsubst %.c,%.o,$(sourcefiles))
 
-# Format is $(func arg0,arg1,arg2...)
+# 형식은 $(func arg0,arg1,arg2...)입니다.
 
-# Some examples
+# 일부 예제
 ls:	* src/*
 	@echo $(filter %.txt, $^)
 	@echo $(notdir $^)
 	@echo $(join $(dir $^),$(notdir $^))
 
 #-----------------------------------------------------------------------
-# Directives
+# 지시문
 #-----------------------------------------------------------------------
 
-# Include other makefiles, useful for platform specific code
+# 다른 makefile 포함, 플랫폼별 코드에 유용합니다.
 include foo.mk
 
 sport = tennis
-# Conditional compilation
+# 조건부 컴파일
 report:
 ifeq ($(sport),tennis)
 	@echo 'game, set, match'
@@ -231,7 +229,7 @@ else
 	@echo "They think it's all over; it is now"
 endif
 
-# There are also ifneq, ifdef, ifndef
+# ifneq, ifdef, ifndef도 있습니다.
 
 foo = true
 
@@ -240,8 +238,8 @@ bar = 'hello'
 endif
 ```
 
-### More Resources
+### 더 많은 자료
 
-- [GNU Make documentation](https://www.gnu.org/software/make/manual/make.html)
-- [Software Carpentry tutorial](https://swcarpentry.github.io/make-novice/)
-- [Makefile Tutorial By Example](https://makefiletutorial.com/#makefile-cookbook)
+- [GNU Make 문서](https://www.gnu.org/software/make/manual/make.html)
+- [Software Carpentry 튜토리얼](https://swcarpentry.github.io/make-novice/)
+- [예제로 배우는 Makefile 튜토리얼](https://makefiletutorial.com/#makefile-cookbook)

--- a/ko/mercurial.md
+++ b/ko/mercurial.md
@@ -8,70 +8,47 @@ contributors:
 filename: LearnMercurial.txt
 ---
 
-Mercurial is a free, distributed source control management tool. It offers
-you the power to efficiently handle projects of any size while using an
-intuitive interface. It is easy to use and hard to break, making it ideal for
-anyone working with versioned files.
+Mercurial은 무료 분산 소스 제어 관리 도구입니다.
+직관적인 인터페이스를 사용하면서 모든 크기의 프로젝트를 효율적으로 처리할 수 있는 강력한 기능을 제공합니다. 사용하기 쉽고 깨지기 어려워 버전 관리된 파일로 작업하는 모든 사람에게 이상적입니다.
 
-## Versioning Concepts
+## 버전 관리 개념
 
-### What is version control?
+### 버전 관리란 무엇인가?
 
-Version control is a system that keeps track fo changes to a set of file(s)
-and/or directorie(s) over time.
+버전 관리는 시간 경과에 따른 파일 및/또는 디렉토리 집합의 변경 사항을 추적하는 시스템입니다.
 
-### Why use Mercurial?
+### 왜 Mercurial을 사용하는가?
 
-* Distributed Architecture - Traditionally version control systems such as CVS
-and Subversion are a client server architecture with a central server to
-store the revision history of a project. Mercurial however is a truly
-distributed architecture, giving each developer a full local copy of the
-entire development history. It works independently of a central server.
-* Fast - Traditionally version control systems such as CVS and Subversion are a
-client server architecture with a central server to store the revision history
-of a project. Mercurial however is a truly distributed architecture, giving
-each developer a full local copy of the entire development history. It works
-independently of a central server.
-* Platform Independent - Mercurial was written to be highly platform
-independent. Much of Mercurial is written in Python, with small performance
-critical parts written in portable C. Binary releases are available for all
-major platforms.
-* Extensible - The functionality of Mercurial can be increased with extensions,
-either by activating the official ones which are shipped with Mercurial or
-downloading some [from the wiki](https://www.mercurial-scm.org/wiki/UsingExtensions) or by [writing your own](https://www.mercurial-scm.org/wiki/WritingExtensions). Extensions are written in
-Python and can change the workings of the basic commands, add new commands and
-access all the core functions of Mercurial.
-* Easy to use - The Mercurial command set is consistent with what subversion
-users would expect, so they are likely to feel right at home. Most dangerous
-actions are part of extensions that need to be enabled to be used.
-* Open Source - Mercurial is free software licensed under the terms of the [GNU
-General Public License Version 2](http://www.gnu.org/licenses/gpl-2.0.txt) or
-any later version.
+* 분산 아키텍처 - 전통적으로 CVS 및 Subversion과 같은 버전 제어 시스템은 프로젝트의 개정 기록을 저장하는 중앙 서버가 있는 클라이언트 서버 아키텍처입니다. 그러나 Mercurial은 진정한 분산 아키텍처로, 각 개발자에게 전체 개발 기록의 전체 로컬 복사본을 제공합니다. 중앙 서버와 독립적으로 작동합니다.
+* 빠름 - 전통적으로 CVS 및 Subversion과 같은 버전 제어 시스템은 프로젝트의 개정 기록을 저장하는 중앙 서버가 있는 클라이언트 서버 아키텍처입니다. 그러나 Mercurial은 진정한 분산 아키텍처로, 각 개발자에게 전체 개발 기록의 전체 로컬 복사본을 제공합니다. 중앙 서버와 독립적으로 작동합니다.
+* 플랫폼 독립적 - Mercurial은 플랫폼 독립적으로 작성되었습니다. Mercurial의 대부분은 Python으로 작성되었으며, 작은 성능이 중요한 부분은 이식 가능한 C로 작성되었습니다. 바이너리 릴리스는 모든 주요 플랫폼에서 사용할 수 있습니다.
+* 확장 가능 - Mercurial의 기능은 Mercurial과 함께 제공되는 공식 확장을 활성화하거나 [위키에서 다운로드](https://www.mercurial-scm.org/wiki/UsingExtensions)하거나 [직접 작성](https://www.mercurial-scm.org/wiki/WritingExtensions)하여 확장할 수 있습니다. 확장은 Python으로 작성되었으며 기본 명령의 작동 방식을 변경하고, 새 명령을 추가하고, Mercurial의 모든 핵심 기능에 액세스할 수 있습니다.
+* 사용하기 쉬움 - Mercurial 명령 세트는 Subversion 사용자가 기대하는 것과 일치하므로 집처럼 편안하게 느낄 것입니다. 대부분의 위험한 작업은 사용하려면 활성화해야 하는 확장의 일부입니다.
+* 오픈 소스 - Mercurial은 [GNU 일반 공중 사용 허가서 버전 2](http://www.gnu.org/licenses/gpl-2.0.txt) 또는 이후 버전의 조건에 따라 라이선스가 부여된 무료 소프트웨어입니다.
 
-## Terminology
+## 용어
 
-| Term | Definition |
+| 용어 | 정의 |
 | ------------- | ---------------------------------- |
-| Repository | A repository is a collection of revisions |
-| hgrc | A configuration file which stores the defaults for a repository. |
-| revision | A committed changeset: has a REV number |
-| changeset | Set of changes saved as diffs |
-| diff | Changes between file(s) |
-| tag | A named named revision |
-| parent(s) | Immediate ancestor(s) of a revision |
-| branch | A child of a revision |
-| head | A head is a changeset with no child changesets |
-| merge | The process of merging two HEADS |
-| tip | The latest revision in any branch |
-| patch | All of the diffs between two revisions |
-| bundle | Patch with permis­sions and rename support |
+| 저장소 | 저장소는 개정판 모음입니다. |
+| hgrc | 저장소의 기본값을 저장하는 구성 파일입니다. |
+| 개정판 | 커밋된 변경 집합: REV 번호가 있습니다. |
+| 변경 집합 | 차이점으로 저장된 변경 사항 집합 |
+| 차이점 | 파일 간의 변경 사항 |
+| 태그 | 명명된 개정판 |
+| 부모 | 개정판의 직계 조상 |
+| 브랜치 | 개정판의 자식 |
+| 헤드 | 헤드는 자식 변경 집합이 없는 변경 집합입니다. |
+| 병합 | 두 개의 HEAD를 병합하는 프로세스 |
+| 팁 | 모든 브랜치의 최신 개정판 |
+| 패치 | 두 개정판 간의 모든 차이점 |
+| 번들 | 권한 및 이름 바꾸기 지원이 포함된 패치 |
 
-## Commands
+## 명령어
 
 ### init
 
-Create a new repository in the given directory, the settings and stored
-information are in a directory named `.hg`.
+지정된 디렉토리에 새 저장소를 생성하며, 설정 및 저장된 정보는 `.hg`라는 디렉토리에 있습니다.
 
 ```bash
 $ hg init
@@ -79,13 +56,13 @@ $ hg init
 
 ### help
 
-Will give you access to a very detailed description of each command.
+각 명령어에 대한 매우 자세한 설명에 액세스할 수 있습니다.
 
 ```bash
-# Quickly check what commands are available
+# 사용 가능한 명령어를 빠르게 확인
 $ hg help
 
-# Get help on a specific command
+# 특정 명령어에 대한 도움말 얻기
 # hg help <command>
 $ hg help add
 $ hg help commit
@@ -94,264 +71,245 @@ $ hg help init
 
 ### status
 
-Show the differences between what is on disk and what is committed to the current
-branch or tag.
+디스크에 있는 것과 현재 브랜치 또는 태그에 커밋된 것 사이의 차이점을 표시합니다.
 
 ```bash
-# Will display the status of files
+# 파일 상태 표시
 $ hg status
 
-# Get help on the status subcommand
+# 상태 하위 명령어에 대한 도움말 얻기
 $ hg help status
 ```
 
 ### add
 
-Will add the specified files to the repository on the next commit.
+다음 커밋 시 지정된 파일을 저장소에 추가합니다.
 
 ```bash
-# Add a file in the current directory
+# 현재 디렉토리에 파일 추가
 $ hg add filename.rb
 
-# Add a file in a sub directory
+# 하위 디렉토리에 파일 추가
 $ hg add foo/bar/filename.rb
 
-# Add files by pattern
+# 패턴별로 파일 추가
 $ hg add *.rb
 ```
 
 ### branch
 
-Set or show the current branch name.
+현재 브랜치 이름을 설정하거나 표시합니다.
 
-*Branch names are permanent and global. Use 'hg bookmark' to create a
-light-weight bookmark instead. See 'hg help glossary' for more information
-about named branches and bookmarks.*
+*브랜치 이름은 영구적이고 전역적입니다. 대신 가벼운 북마크를 만들려면 'hg bookmark'를 사용하십시오. 명명된 브랜치와 북마크에 대한 자세한 내용은 'hg help glossary'를 참조하십시오.*
 
 ```bash
-# With no argument it shows the current branch name
+# 인수가 없으면 현재 브랜치 이름을 표시합니다.
 $ hg branch
 
-# With a name argument it will change the current branch.
+# 이름 인수가 있으면 현재 브랜치를 변경합니다.
 $ hg branch new_branch
-marked working directory as branch new_branch
-(branches are permanent and global, did you want a bookmark?)
+작업 디렉토리를 브랜치 new_branch로 표시했습니다.
+(브랜치는 영구적이고 전역적입니다. 북마크를 원하셨습니까?)
 ```
 
 ### tag
 
-Add one or more tags for the current or given revision.
+현재 또는 지정된 개정판에 하나 이상의 태그를 추가합니다.
 
-Tags are used to name particular revisions of the repository and are very
-useful to compare different revisions, to go back to significant earlier
-versions or to mark branch points as releases, etc. Changing an existing tag
-is normally disallowed; use -f/--force to override.
+태그는 저장소의 특정 개정판에 이름을 지정하는 데 사용되며, 다른 개정판을 비교하거나, 중요한 이전 버전으로 돌아가거나, 브랜치 지점을 릴리스로 표시하는 데 매우 유용합니다. 기존 태그를 변경하는 것은 일반적으로 허용되지 않습니다. 재정의하려면 -f/--force를 사용하십시오.
 
 ```bash
-# List tags
+# 태그 목록
 $ hg tags
 tip                                2:efc8222cd1fb
 v1.0                               0:37e9b57123b3
 
-# Create a new tag on the current revision
+# 현재 개정판에 새 태그 생성
 $ hg tag v1.1
 
-# Create a tag on a specific revision
+# 특정 개정판에 태그 생성
 $ hg tag -r efc8222cd1fb v1.1.1
 ```
 
 ### clone
 
-Create a copy of an existing repository in a new directory.
+기존 저장소의 복사본을 새 디렉토리에 생성합니다.
 
-If no destination directory name is specified, it defaults to the basename of
-the source.
+대상 디렉토리 이름이 지정되지 않은 경우 소스의 기본 이름으로 기본 설정됩니다.
 
 ```bash
-# Clone a remote repo to a local directory
+# 원격 저장소를 로컬 디렉토리로 복제
 $ hg clone https://some-mercurial-server.example.com/reponame
 
-# Clone a local repo to a remote server
+# 로컬 저장소를 원격 서버로 복제
 $ hg clone . ssh://username@some-mercurial-server.example.com/newrepo
 
-# Clone a local repo to a local repo
+# 로컬 저장소를 로컬 저장소로 복제
 $ hg clone . /tmp/some_backup_dir
 ```
 
 ### commit / ci
 
-Commit changes to the given files into the repository.
+지정된 파일의 변경 사항을 저장소에 커밋합니다.
 
 ```bash
-# Commit with a message
+# 메시지와 함께 커밋
 $ hg commit -m 'This is a commit message'
 
-# Commit all added / removed files in the current tree
+# 현재 트리의 모든 추가/제거된 파일 커밋
 $ hg commit -A 'Adding and removing all existing files in the tree'
 
-# amend the parent of the working directory with a new commit that contains the
-# changes in the parent in addition to those currently reported by 'hg status',
+# 'hg status'가 현재 보고하는 변경 사항 외에 부모의 변경 사항을
+# 포함하는 새 커밋으로 작업 디렉토리의 부모를 수정합니다.
 $ hg commit --amend -m "Correct message"
 ```
 
 ### diff
 
-Show differences between revisions for the specified files using the unified
-diff format.
+통합 diff 형식을 사용하여 지정된 파일에 대한 개정판 간의 차이점을 표시합니다.
 
 ```bash
-# Show the diff between the current directory and a previous revision
+# 현재 디렉토리와 이전 개정판 간의 차이점 표시
 $ hg diff -r 10
 
-# Show the diff between two previous revisions
+# 두 이전 개정판 간의 차이점 표시
 $ hg diff -r 30 -r 20
 ```
 
 ### grep
 
-Search revision history for a pattern in specified files.
+지정된 파일에서 패턴에 대한 개정 기록을 검색합니다.
 
 ```bash
-# Search files for a specific phrase
+# 특정 구문에 대한 파일 검색
 $ hg grep "TODO:"
 ```
 
 ### log / history
 
-Show revision history of entire repository or files. If no revision range is
-specified, the default is "tip:0" unless --follow is set, in which case the
-working directory parent is used as the starting revision.
+전체 저장소 또는 파일의 개정 기록을 표시합니다. 개정 범위가 지정되지 않은 경우 --follow가 설정되지 않은 한 기본값은 "tip:0"이며, 이 경우 작업 디렉토리 부모가 시작 개정판으로 사용됩니다.
 
 ```bash
-# Show the history of the entire repository
+# 전체 저장소의 기록 표시
 $ hg log
 
-# Show the history of a single file
+# 단일 파일의 기록 표시
 $ hg log myfile.rb
 
-# Show the revision changes as an ASCII art DAG with the most recent changeset
-# at the top.
+# 가장 최근 변경 집합이 맨 위에 있는 ASCII 아트 DAG로
+# 개정 변경 사항을 표시합니다.
 $ hg log -G
 ```
 
 ### merge
 
-Merge another revision into working directory.
+다른 개정판을 작업 디렉토리로 병합합니다.
 
 ```bash
-# Merge changesets to local repository
+# 로컬 저장소에 변경 집합 병합
 $ hg merge
 
-# Merge from a named branch or revision into the current local branch
+# 명명된 브랜치 또는 개정판에서 현재 로컬 브랜치로 병합
 $ hg merge branchname_or_revision
 
-# After successful merge, commit the changes
+# 성공적인 병합 후 변경 사항 커밋
 hg commit
 ```
 
 ### move / mv / rename
 
-Rename files; equivalent of copy + remove. Mark dest as copies of sources;
-mark sources for deletion. If dest is a directory, copies are put in that
-directory. If dest is a file, there can only be one source.
+파일 이름 바꾸기; 복사 + 제거와 동일합니다. 대상을 소스의 복사본으로 표시하고, 소스를 삭제하도록 표시합니다. 대상이 디렉토리인 경우 복사본이 해당 디렉토리에 배치됩니다. 대상이 파일인 경우 소스는 하나만 있을 수 있습니다.
 
 ```bash
-# Rename a single file
+# 단일 파일 이름 바꾸기
 $ hg mv foo.txt bar.txt
 
-# Rename a directory
+# 디렉토리 이름 바꾸기
 $ hg mv some_directory new_directory
 ```
 
 ### pull
 
-Pull changes from a remote repository to a local one.
+원격 저장소에서 로컬 저장소로 변경 사항을 가져옵니다.
 
 ```bash
-# List remote paths
+# 원격 경로 목록
 $ hg paths
 remote1 = http://path/to/remote1
 remote2 = http://path/to/remote2
 
-# Pull from remote 1
+# 원격 1에서 가져오기
 $ hg pull remote1
 
-# Pull from remote 2
+# 원격 2에서 가져오기
 $ hg pull remote2
 ```
 
 ### push
 
-Push changesets from the local repository to the specified destination.
+로컬 저장소의 변경 집합을 지정된 대상으로 푸시합니다.
 
 ```bash
-# List remote paths
+# 원격 경로 목록
 $ hg paths
 remote1 = http://path/to/remote1
 remote2 = http://path/to/remote2
 
-# Pull from remote 1
+# 원격 1에서 푸시
 $ hg push remote1
 
-# Pull from remote 2
+# 원격 2에서 푸시
 $ hg push remote2
 ```
 
 ### rebase
 
-Move changeset (and descendants) to a different branch.
+변경 집합(및 하위 항목)을 다른 브랜치로 이동합니다.
 
-Rebase uses repeated merging to graft changesets from one part of history
-(the source) onto another (the destination). This can be useful for
-linearizing *local* changes relative to a master development tree.
+리베이스는 반복적인 병합을 사용하여 기록의 한 부분(소스)에서 다른 부분(대상)으로 변경 집합을 이식합니다. 이는 마스터 개발 트리에 대한 *로컬* 변경 사항을 선형화하는 데 유용할 수 있습니다.
 
-* Draft the commits back to the source revision.
-* -s is the source, ie. what you are rebasing.
-* -d is the destination, which is where you are sending it.
+* 커밋을 소스 개정판으로 다시 초안으로 작성합니다.
+* -s는 소스, 즉 리베이스하는 대상입니다.
+* -d는 대상, 즉 보내는 곳입니다.
 
 ```bash
-# Put the commits into draft status
-# This will draft all subsequent commits on the relevant branch
+# 커밋을 초안 상태로 만듭니다.
+# 이것은 관련 브랜치의 모든 후속 커밋을 초안으로 만듭니다.
 $ hg phase --draft --force -r 1206
 
-# Rebase from from revision 102 over revision 208
+# 개정 102에서 개정 208로 리베이스
 $ hg rebase -s 102 -d 208
 ```
 
 ### revert
 
-Restore files to their checkout state. With no revision specified, revert the
-specified files or directories to the contents they had in the parent of the
-working directory. This restores the contents of files to an unmodified state
-and unschedules adds, removes, copies, and renames. If the working directory
-has two parents, you must explicitly specify a revision.
+파일을 체크아웃 상태로 복원합니다. 개정판이 지정되지 않은 경우 지정된 파일 또는 디렉토리를 작업 디렉토리의 부모에 있던 내용으로 되돌립니다. 이렇게 하면 파일의 내용을 수정되지 않은 상태로 복원하고 추가, 제거, 복사 및 이름 바꾸기를 예약 취소합니다. 작업 디렉토리에 두 개의 부모가 있는 경우 개정판을 명시적으로 지정해야 합니다.
 
 ```bash
-# Reset a specific file to its checked out state
+# 특정 파일을 체크아웃 상태로 재설정
 $ hg revert oops_i_did_it_again.txt
 
-# Revert a specific file to its checked out state without leaving a .orig file
-# around
+# .orig 파일을 남기지 않고 특정 파일을 체크아웃 상태로 되돌리기
 $ hg revert -C oops_i_did_it_again.txt
 
-# Revert all changes
+# 모든 변경 사항 되돌리기
 $ hg revert -a
 ```
 
 ### rm / remove
 
-Remove the specified files on the next commit.
+다음 커밋 시 지정된 파일을 제거합니다.
 
 ```bash
-# Remove a specific file
+# 특정 파일 제거
 $ hg remove go_away.txt
 
-# Remove a group of files by pattern
+# 패턴별로 파일 그룹 제거
 $ hg remove *.txt
 ```
 
-## Further information
+## 추가 정보
 
-* [Learning Mercurial in Workflows](https://www.mercurial-scm.org/guide)
-* [Mercurial Quick Start](https://www.mercurial-scm.org/wiki/QuickStart)
-* [Mercurial: The Definitive Guide by Bryan O'Sullivan](http://hgbook.red-bean.com/)
+* [워크플로에서 Mercurial 배우기](https://www.mercurial-scm.org/guide)
+* [Mercurial 빠른 시작](https://www.mercurial-scm.org/wiki/QuickStart)
+* [Mercurial: Bryan O'Sullivan의 결정판 가이드](http://hgbook.red-bean.com/)

--- a/ko/mongodb.md
+++ b/ko/mongodb.md
@@ -7,124 +7,120 @@ contributors:
   - ["Raj Piskala", "https://www.rajpiskala.ml/"]
 ---
 
-MongoDB is a NoSQL document database for high volume data storage.
+MongoDB는 대용량 데이터 저장을 위한 NoSQL 문서 데이터베이스입니다.
 
-MongoDB uses collections and documents for its storage. Each document consists
-of key-value pairs using JSON-like syntax, similar to a dictionary or JavaScript
-object.
+MongoDB는 저장을 위해 컬렉션과 문서를 사용합니다. 각 문서는
+딕셔너리나 JavaScript 객체와 유사하게 JSON과 유사한 구문을 사용하는
+키-값 쌍으로 구성됩니다.
 
-Likewise, as MongoDB is a NoSQL database, it uses its own query language, Mongo
-Query Language (MQL) which uses JSON for querying.
+마찬가지로 MongoDB는 NoSQL 데이터베이스이므로 자체 쿼리 언어인 Mongo
+Query Language (MQL)를 사용하며 쿼리에 JSON을 사용합니다.
 
-## Getting Started
+## 시작하기
 
-### Installation
+### 설치
 
-MongoDB can either be installed locally following the instructions
-[here](https://docs.mongodb.com/manual/installation/) or you can create a
-remotely-hosted free 512 MB cluster
-[here](https://www.mongodb.com/cloud/atlas/register). Links to videos with
-instructions on setup are at the bottom.
+MongoDB는 [여기](https://docs.mongodb.com/manual/installation/)의 지침에 따라
+로컬에 설치하거나 [여기](https://www.mongodb.com/cloud/atlas/register)에서
+원격으로 호스팅되는 무료 512MB 클러스터를 생성할 수 있습니다. 설정에 대한
+지침이 포함된 비디오 링크는 하단에 있습니다.
 
-This tutorial assumes that you have the MongoDB Shell from
-[here](https://www.mongodb.com/try/download/shell). You can also download the
-graphical tool, MongoDB Compass, down below from the same link.
+이 튜토리얼은 [여기](https://www.mongodb.com/try/download/shell)에서
+MongoDB 셸을 가지고 있다고 가정합니다. 동일한 링크에서 그래픽 도구인
+MongoDB Compass도 다운로드할 수 있습니다.
 
-### Components
+### 구성 요소
 
-After installing MongoDB, you will notice there are multiple command line tools.
-The three most important of which are:
+MongoDB를 설치한 후 여러 명령줄 도구가 있음을 알 수 있습니다.
+가장 중요한 세 가지는 다음과 같습니다:
 
-- `mongod` - The database server which is responsible for managing data and
-  handling queries
-- `mongos` - The sharding router, which is needed if data will be distributed
-  across multiple machines
-- `mongo` - The database shell (using JavaScript) through which we can configure
-  our database
+- `mongod` - 데이터 관리 및 쿼리 처리를 담당하는 데이터베이스 서버
+- `mongos` - 데이터가 여러 시스템에 분산될 경우 필요한 샤딩 라우터
+- `mongo` - 데이터베이스를 구성할 수 있는 데이터베이스 셸 (JavaScript 사용)
 
-Usually we start the `mongod` process and then use a separate terminal with
-`mongo` to access and modify our collections.
+일반적으로 `mongod` 프로세스를 시작한 다음 별도의 터미널에서 `mongo`를 사용하여
+컬렉션에 액세스하고 수정합니다.
 
 ### JSON & BSON
 
-While queries in MongoDB are made using a JSON-like\* format, MongoDB stores its
-documents internally in the Binary JSON (BSON format). BSON is not human
-readable like JSON as it's a binary encoding. However, this allows for end users
-to have access to more types than regular JSON, such as an integer or float
-type. Many other types, such as regular expressions, dates, or raw binary are
-supported too.
+MongoDB의 쿼리는 JSON과 유사한\* 형식으로 만들어지지만, MongoDB는
+내부적으로 문서를 이진 JSON (BSON 형식)으로 저장합니다. BSON은
+이진 인코딩이므로 JSON처럼 사람이 읽을 수 없습니다. 그러나 이를 통해
+최종 사용자는 정수 또는 부동 소수점 타입과 같이 일반 JSON보다 더 많은 타입에
+액세스할 수 있습니다. 정규식, 날짜 또는 원시 이진과 같은 다른 많은 타입도
+지원됩니다.
 
-[Here](https://docs.mongodb.com/manual/reference/bson-types/) is the full list
-of all types that are supported.
+[여기](https://docs.mongodb.com/manual/reference/bson-types/)는 지원되는
+모든 타입의 전체 목록입니다.
 
-- We refer JSON-like to mean JSON but with these extended types. For example,
-  you can make queries directly with a regular expression or timestamp in
-  MongoDB and you can receive data that has those types too.
+- JSON과 유사하다는 것은 이러한 확장된 타입을 가진 JSON을 의미합니다. 예를 들어,
+  MongoDB에서 정규식이나 타임스탬프로 직접 쿼리를 만들 수 있으며
+  해당 타입을 가진 데이터를 받을 수도 있습니다.
 
 ```js
 /////////////////////////////////////////////////////////
-/////////////////// Getting Started /////////////////////
+/////////////////// 시작하기 /////////////////////
 /////////////////////////////////////////////////////////
 
-// Start up the mongo database server
-// NOTE - You will need to do this in a separate terminal as the process will
-// take over the terminal. You may want to use the --fork option
+// mongo 데이터베이스 서버 시작
+// 참고 - 프로세스가 터미널을 차지하므로 별도의 터미널에서 이 작업을 수행해야 합니다.
+// --fork 옵션을 사용할 수 있습니다.
 mongod // --fork
 
-// Connecting to a remote Mongo server
+// 원격 Mongo 서버에 연결
 // mongo "mongodb+srv://host.ip.address/admin" --username your-username
 
-// Mongoshell has a proper JavaScript interpreter built in
+// Mongoshell에는 적절한 JavaScript 인터프리터가 내장되어 있습니다.
 3 + 2 // 5
 
-// Show available databases
-// MongoDB comes with the following databases built-in: admin, config, local
+// 사용 가능한 데이터베이스 표시
+// MongoDB에는 admin, config, local과 같은 데이터베이스가 내장되어 있습니다.
 show dbs
 
-// Switch to a new database (pre-existing or about to exist)
-// NOTE: There is no "create" command for a database in MongoDB.
-// The database is created upon data being inserted into a collection
+// 새 데이터베이스로 전환 (기존 또는 존재할 예정)
+// 참고: MongoDB에는 데이터베이스에 대한 "create" 명령이 없습니다.
+// 데이터베이스는 컬렉션에 데이터가 삽입될 때 생성됩니다.
 use employees
 
-// Create a new collection
-// NOTE: Inserting a document will implicitly create a collection anyways,
-// so this is not required
+// 새 컬렉션 생성
+// 참고: 문서를 삽입하면 암시적으로 컬렉션이 생성되므로
+// 필수는 아닙니다.
 db.createCollection('engineers')
 db.createCollection('doctors')
 
-// See what collections exist under employees
+// employees 아래에 어떤 컬렉션이 있는지 확인
 show collections
 
 /////////////////////////////////////////////////////////
-// Basic Create/Read/Update/Delete (CRUD) Operations: ///
+// 기본 생성/읽기/업데이트/삭제 (CRUD) 작업: ///
 /////////////////////////////////////////////////////////
 
-/////////////// Insert (Create) /////////////////////////
+/////////////// 삽입 (생성) /////////////////////////
 
-// Insert one employee into the database
-// Each insertion returns acknowledged true or false
-// Every document has a unique _id value assigned to it automatically
+// 데이터베이스에 한 명의 직원 삽입
+// 각 삽입은 acknowledged true 또는 false를 반환합니다.
+// 모든 문서에는 자동으로 고유한 _id 값이 할당됩니다.
 db.engineers.insertOne({ name: "Jane Doe", age: 21, gender: 'Female' })
 
-// Insert a list of employees into the `engineers` collection
-// Can insert as an array of objects
+// `engineers` 컬렉션에 직원 목록 삽입
+// 객체 배열로 삽입 가능
 db.engineers.insert([
   { name: "Foo Bar", age: 25, gender: 'Male' },
   { name: "Baz Qux", age: 27, gender: 'Other' },
 ])
 
-// MongoDB does not enforce a schema or structure for objects
-// Insert an empty object into the `engineers` collection
+// MongoDB는 객체에 대한 스키마나 구조를 강제하지 않습니다.
+// `engineers` 컬렉션에 빈 객체 삽입
 db.engineers.insertOne({})
 
-// Fields are optional and do not have to match rest of documents
+// 필드는 선택 사항이며 나머지 문서와 일치할 필요가 없습니다.
 db.engineers.insertOne({ name: "Your Name", gender: "Male" })
 
-// Types can vary and are preserved on insertion
-// This can require additional validation in some languages to prevent problems
+// 타입은 다를 수 있으며 삽입 시 유지됩니다.
+// 이로 인해 일부 언어에서는 문제를 방지하기 위해 추가 유효성 검사가 필요할 수 있습니다.
 db.engineers.insert({ name: ['Foo', 'Bar'], age: 3.14, gender: true })
 
-// Objects or arrays can be nested inside a document
+// 객체나 배열은 문서 내에 중첩될 수 있습니다.
 db.engineers.insertOne({
   name: "Your Name",
   gender: "Female",
@@ -138,8 +134,8 @@ db.engineers.insertOne({
   },
 })
 
-// We can override the _id field
-// Works fine
+// _id 필드를 재정의할 수 있습니다.
+// 문제없이 작동합니다.
 db.engineers.insertOne({
   _id: 1,
   name: "An Engineer",
@@ -147,9 +143,9 @@ db.engineers.insertOne({
   gender: "Female",
 })
 
-// Be careful, as _id must ALWAYS be unique for the collection otherwise
-// the insertion will fail
-// Fails with a WriteError indicating _id is a duplicate value
+// _id는 컬렉션에 대해 항상 고유해야 하므로 주의하십시오. 그렇지 않으면
+// 삽입이 실패합니다.
+// _id가 중복 값임을 나타내는 WriteError로 실패합니다.
 db.engineers.insertOne({
   _id: 1,
   name: "Another Engineer",
@@ -157,7 +153,7 @@ db.engineers.insertOne({
   gender: "Male",
 })
 
-// Works fine as this is a different collection
+// 이것은 다른 컬렉션이므로 문제없이 작동합니다.
 db.doctors.insertOne({
   _id: 1,
   name: "Some Doctor",
@@ -165,33 +161,33 @@ db.doctors.insertOne({
   gender: "Other",
 })
 
-/////////////////// Find (Read) ////////////////////////
-// Queries are in the form of db.collectionName.find(<filter>)
-// Where <filter> is an object
+/////////////////// 찾기 (읽기) ////////////////////////
+// 쿼리는 db.collectionName.find(<filter>) 형식입니다.
+// 여기서 <filter>는 객체입니다.
 
-// Show everything in our database so far, limited to a
-// maximum of 20 documents at a time
-// Press i to iterate this cursor to the next 20 documents
+// 지금까지 데이터베이스의 모든 것을 표시하며, 한 번에 최대
+// 20개의 문서로 제한됩니다.
+// 이 커서를 다음 20개의 문서로 반복하려면 i를 누릅니다.
 db.engineers.find({})
 
-// We can pretty print the result of any find() query
+// 모든 find() 쿼리의 결과를 예쁘게 출력할 수 있습니다.
 db.engineers.find({}).pretty()
 
-// MongoDB queries take in a JS object and search for documents with matching
-// key-value pairs
-// Returns the first document matching query
-// NOTE: Order of insertion is not preserved in the database, output can vary
+// MongoDB 쿼리는 JS 객체를 받아 일치하는 키-값 쌍을 가진 문서를
+// 검색합니다.
+// 쿼리와 일치하는 첫 번째 문서를 반환합니다.
+// 참고: 삽입 순서는 데이터베이스에 보존되지 않으므로 출력이 다를 수 있습니다.
 db.engineers.findOne({ name: 'Foo Bar' })
 
-// Returns all documents with the matching key-value properties as a cursor
-// (which can be converted to an array)
+// 일치하는 키-값 속성을 가진 모든 문서를 커서로 반환합니다.
+// (배열로 변환 가능)
 db.engineers.find({ age: 25 })
 
-// Type matters when it comes to queries
-// Returns nothing as all ages above are integer type
+// 쿼리에서는 타입이 중요합니다.
+// 위의 모든 나이는 정수 타입이므로 아무것도 반환하지 않습니다.
 db.engineers.find({ age: '25' })
 
-// find() supports nested objects and arrays just like create()
+// find()는 create()와 마찬가지로 중첩된 객체와 배열을 지원합니다.
 db.engineers.find({
   name: "Your Name",
   gender: "Female",
@@ -205,20 +201,20 @@ db.engineers.find({
   },
 })
 
-///////////////////////// Update ////////////////////////
-// Queries are in the form of db.collectionName.update(<filter>, <update>)
-// NOTE: <update> will always use the $set operator.
-// Several operators are covered later on in the tutorial.
+///////////////////////// 업데이트 ////////////////////////
+// 쿼리는 db.collectionName.update(<filter>, <update>) 형식입니다.
+// 참고: <update>는 항상 $set 연산자를 사용합니다.
+// 이 튜토리얼에서는 몇 가지 연산자를 다룹니다.
 
-// We can update a single object
+// 단일 객체를 업데이트할 수 있습니다.
 db.engineers.updateOne({ name: 'Foo Bar' }, { $set: { name: 'John Doe', age: 100 }})
 
-// Or update many objects at the same time
+// 또는 동시에 여러 객체를 업데이트합니다.
 db.engineers.update({ age: 25 }, { $set: { age: 26 }})
 
-// We can use { upsert: true } if we would like it to insert if the document doesn't already exist,
-// or to update if it does
-// Returns matched, upserted, modified count
+// 문서가 이미 존재하지 않으면 삽입하거나, 존재하면 업데이트하려면
+// { upsert: true }를 사용할 수 있습니다.
+// matched, upserted, modified 수를 반환합니다.
 db.engineers.update({ name: 'Foo Baz' },
   { $set:
     {
@@ -229,51 +225,50 @@ db.engineers.update({ name: 'Foo Baz' },
   { upsert: true }
 )
 
-/////////////////////// Delete /////////////////////////
-// Queries are in the form of db.collectionName.delete(<filter>)
+/////////////////////// 삭제 /////////////////////////
+// 쿼리는 db.collectionName.delete(<filter>) 형식입니다.
 
-// Delete first document matching query, always returns deletedCount
+// 쿼리와 일치하는 첫 번째 문서를 삭제하고, 항상 deletedCount를 반환합니다.
 db.engineers.deleteOne({ name: 'Foo Baz' })
 
-// Delete many documents at once
+// 동시에 여러 문서 삭제
 db.engineers.deleteMany({ gender: 'Male' })
 
-// NOTE: There are two methods db.collection.removeOne(<filter>) and
-// db.collection.removeMany(<filter>) that also delete objects but have a
-// slightly different return value.
-// They are not included here as they have been deprecated in the NodeJS driver.
+// 참고: db.collection.removeOne(<filter>) 및
+// db.collection.removeMany(<filter>) 메서드도 객체를 삭제하지만
+// 반환 값이 약간 다릅니다.
+// NodeJS 드라이버에서 더 이상 사용되지 않으므로 여기에 포함되지 않았습니다.
 
 /////////////////////////////////////////////////////////
-//////////////////// Operators //////////////////////////
+//////////////////// 연산자 //////////////////////////
 /////////////////////////////////////////////////////////
 
-// Operators in MongoDB have a $ prefix. For this tutorial, we are only looking
-// at comparison and logical operators, but there are many other types of
-// operators
+// MongoDB의 연산자는 $ 접두사를 가집니다. 이 튜토리얼에서는 비교 및
+// 논리 연산자만 다루지만, 다른 많은 종류의 연산자가 있습니다.
 
-//////////////// Comparison Operators ///////////////////
+//////////////// 비교 연산자 ///////////////////
 
-// Find all greater than or greater than equal to some condition
+// 어떤 조건보다 크거나 같음 찾기
 db.engineers.find({ age: { $gt: 25 }})
 db.engineers.find({ age: { $gte: 25 }})
 
-// Find all less than or less than equal to some condition
+// 어떤 조건보다 작거나 같음 찾기
 db.engineers.find({ age: { $lt: 25 }})
 db.engineers.find({ age: { $lte: 25 }})
 
-// Find all equal or not equal to
-// Note: the $eq operator is added implicitly in most queries
+// 같거나 같지 않음 찾기
+// 참고: $eq 연산자는 대부분의 쿼리에서 암시적으로 추가됩니다.
 db.engineers.find({ age: { $eq: 25 }})
 db.engineers.find({ age: { $ne: 25 }})
 
-// Find all that match any element in the array, or not in the array
+// 배열의 모든 요소와 일치하거나 배열에 없는 모든 요소 찾기
 db.engineers.find({ age: { $in: [ 20, 23, 24, 25 ]}})
 db.engineers.find({ age: { $nin: [ 20, 23, 24, 25 ]}})
 
-//////////////// Logical Operators ///////////////////
+//////////////// 논리 연산자 ///////////////////
 
-// Join two query clauses together
-// NOTE: MongoDB does this implicitly for most queries
+// 두 쿼리 절을 함께 연결
+// 참고: MongoDB는 대부분의 쿼리에서 이를 암시적으로 수행합니다.
 db.engineers.find({ $and: [
   gender: 'Female',
   age: {
@@ -281,7 +276,7 @@ db.engineers.find({ $and: [
   }
 ]})
 
-// Match either query condition
+// 쿼리 조건 중 하나와 일치
 db.engineers.find({ $or: [
   gender: 'Female',
   age: {
@@ -289,12 +284,12 @@ db.engineers.find({ $or: [
   }
 ]})
 
-// Negates the query
+// 쿼리 부정
 db.engineers.find({ $not: {
   gender: 'Female'
 }})
 
-// Must match none of the query conditions
+// 쿼리 조건 중 어느 것과도 일치하지 않아야 함
 db.engineers.find({ $nor [
   gender: 'Female',
   age: {
@@ -303,106 +298,102 @@ db.engineers.find({ $nor [
 ]})
 
 /////////////////////////////////////////////////////////
-//////////////// Database Operations: ///////////////////
+//////////////// 데이터베이스 작업: ///////////////////
 /////////////////////////////////////////////////////////
 
-// Delete (drop) the employees database
-// THIS WILL DELETE ALL DOCUMENTS IN THE DATABASE!
+// employees 데이터베이스 삭제 (drop)
+// 이 작업은 데이터베이스의 모든 문서를 삭제합니다!
 db.dropDatabase()
 
-// Create a new database with some data
+// 일부 데이터가 있는 새 데이터베이스 생성
 use example
 db.test.insertOne({ name: "Testing data, please ignore!", type: "Test" })
 
-// Quit Mongo shell
+// Mongo 셸 종료
 exit
 
-// Import/export database as BSON:
+// 데이터베이스를 BSON으로 가져오기/내보내기:
 
-// Mongodump to export data as BSON for all databases
-// Exported data is found in under "MongoDB Database Tools/bin/dump"
-// NOTE: If the command is not found, navigate to "MongoDB Database Tools/bin"
-// and use the executable from there mongodump
+// 모든 데이터베이스에 대해 BSON으로 데이터를 내보내는 Mongodump
+// 내보낸 데이터는 "MongoDB Database Tools/bin/dump" 아래에 있습니다.
+// 참고: 명령을 찾을 수 없는 경우 "MongoDB Database Tools/bin"으로 이동하여
+// 거기서 실행 파일 mongodump를 사용하십시오.
 
-// Mongorestore to restore data from BSON
+// BSON에서 데이터를 복원하는 Mongorestore
 mongorestore dump
 
-// Import/export database as JSON:
-// Mongoexport to export data as JSON for all databases
+// 데이터베이스를 JSON으로 가져오기/내보내기:
+// 모든 데이터베이스에 대해 JSON으로 데이터를 내보내는 Mongoexport
 mongoexport --collection=example
 
-// Mongoimport to export data as JSON for all databases
+// 모든 데이터베이스에 대해 JSON으로 데이터를 가져오는 Mongoimport
 mongoimport  --collection=example
 ```
 
-## Further Reading
+## 더 읽을거리
 
-### Setup Videos
+### 설정 비디오
 
-- [Install MongoDB - Windows 10](https://www.youtube.com/watch?v=85A6m1soKww)
-- [Install MongoDB - Mac](https://www.youtube.com/watch?v=DX15WbKidXY)
-- [Install MongoDB - Linux
+- [MongoDB 설치 - Windows 10](https://www.youtube.com/watch?v=85A6m1soKww)
+- [MongoDB 설치 - Mac](https://www.youtube.com/watch?v=DX15WbKidXY)
+- [MongoDB 설치 - Linux
   (Ubuntu)](https://www.youtube.com/watch?v=wD_2pojFWoE)
 
-### Input Validation
+### 입력 유효성 검사
 
-From the examples above, if input validation or structure is a concern, I would
-take a look at the following ORMs:
+위의 예제에서 입력 유효성 검사나 구조가 우려되는 경우 다음
+ORM을 살펴보는 것이 좋습니다.
 
-- [Mongoose (Node.js)](https://mongoosejs.com/docs/) - Input validation through
-  schemas that support types, required values, minimum and maximum values.
-- [MongoEngine (Python)](http://mongoengine.org/) - Similar to Mongoose, but I
-  found it somewhat limited in my experience
-- [MongoKit (Python)](https://github.com/namlook/mongokit) - Another great
-  alternative to MongoEngine that I find easier to use than MongoEngine
+- [Mongoose (Node.js)](https://mongoosejs.com/docs/) -
+  타입, 필수 값, 최소 및 최대 값을 지원하는 스키마를 통한 입력 유효성 검사.
+- [MongoEngine (Python)](http://mongoengine.org/) - Mongoose와 유사하지만
+  제 경험상 다소 제한적이었습니다.
+- [MongoKit (Python)](https://github.com/namlook/mongokit) - MongoEngine보다
+  사용하기 쉬운 또 다른 훌륭한 대안
 
-For statically strongly typed languages (e.g. Java, C++, Rust), input validation
-usually doesn't require a library as they define types and structure at compile
-time.
+정적으로 강력한 타입 언어(예: Java, C++, Rust)의 경우, 컴파일 타임에
+타입과 구조를 정의하므로 입력 유효성 검사에 라이브러리가 필요하지 않습니다.
 
-### Resources
+### 자료
 
-If you have the time to spare, I would strongly recommend the courses on
-[MongoDB University](https://university.mongodb.com/). They're by MongoDB
-themselves and go into much more detail while still being concise. They're a mix
-of videos and quiz questions and this was how I gained my knowledge of MongoDB.
+시간이 있다면 [MongoDB University](https://university.mongodb.com/)의
+과정을 강력히 추천합니다. MongoDB에서 직접 제공하며 간결하면서도
+훨씬 더 자세한 내용을 다룹니다. 비디오와 퀴즈 질문이 혼합되어 있으며,
+이것이 제가 MongoDB에 대한 지식을 얻은 방법입니다.
 
-I would recommend the following video series for learning MongoDB:
+MongoDB 학습을 위해 다음 비디오 시리즈를 추천합니다.
 
-- [MongoDB Crash Course - Traversy
+- [MongoDB 속성 과정 - Traversy
   Media](https://www.youtube.com/watch?v=-56x56UppqQ)
-- [MongoDB Tutorial for Beginners -
+- [초보자를 위한 MongoDB 튜토리얼 -
   Amigoscode](https://www.youtube.com/watch?v=Www6cTUymCY)
 
-Language-specific ones that I used before:
+제가 이전에 사용했던 언어별 자료:
 
-- [Build A REST API With Node.js, Express, & MongoDB - Web Dev
+- [Node.js, Express, & MongoDB로 REST API 구축 - Web Dev
   Simplified](https://www.youtube.com/watch?v=fgTGADljAeg)
-- [MongoDB with Python Crash Course - Tutorial for Beginners -
+- [Python과 MongoDB 속성 과정 - 초보자를 위한 튜토리얼 -
   FreeCodeCamp](https://www.youtube.com/watch?v=E-1xI85Zog8)
-- [How to Use MongoDB with Java - Random
+- [Java와 MongoDB 사용 방법 - Random
   Coder](https://www.youtube.com/watch?v=reYPUvu2Giw)
-- [An Introduction to Using MongoDB with Rust -
+- [Rust와 MongoDB 사용 소개 -
   MongoDB](https://www.youtube.com/watch?v=qFlftfLGwPM)
 
-Most of the information above was cross-referenced with the [MongoDB
-docs](https://www.mongodb.com/). Here are the docs for each section:
+위의 정보 대부분은 [MongoDB
+docs](https://www.mongodb.com/)와 교차 참조되었습니다. 각 섹션에 대한 문서는 다음과 같습니다.
 
-- [MongoDB Types](https://docs.mongodb.com/manual/reference/bson-types/) - List
-  of all types that MongoDB supports natively
-- [MongoDB Operators](https://docs.mongodb.com/manual/reference/operator/) -
-  List of operators MongoDB supports natively
+- [MongoDB 타입](https://docs.mongodb.com/manual/reference/bson-types/) -
+  MongoDB가 기본적으로 지원하는 모든 타입 목록
+- [MongoDB 연산자](https://docs.mongodb.com/manual/reference/operator/) -
+  MongoDB가 기본적으로 지원하는 연산자 목록
 - [MongoDB CRUD](https://docs.mongodb.com/manual/reference/command/nav-crud/) -
-  Commands for create, read, update, delete
+  생성, 읽기, 업데이트, 삭제에 대한 명령어
 
-If you've been enjoying MongoDB so far and want to explore intermediate
-features, I would look at
-[aggregation](https://docs.mongodb.com/manual/reference/command/nav-aggregation/),
-[indexing](https://docs.mongodb.com/manual/indexes/), and
-[sharding](https://docs.mongodb.com/manual/sharding/).
+지금까지 MongoDB를 즐겼다면, 중급 기능을 탐색하고 싶을 것입니다.
+[집계](https://docs.mongodb.com/manual/reference/command/nav-aggregation/),
+[인덱싱](https://docs.mongodb.com/manual/indexes/),
+[샤딩](https://docs.mongodb.com/manual/sharding/)을 살펴보는 것이 좋습니다.
 
-- Aggregation - useful for creating advanced queries to be executed by the
-  database
-- Indexing allows for caching, which allows for much faster execution of queries
-- Sharding allows for horizontal data scaling and distribution between multiple
-  machines.
+- 집계 - 데이터베이스에서 실행될 고급 쿼리를 만드는 데 유용합니다.
+- 인덱싱은 캐싱을 허용하여 쿼리 실행 속도를 훨씬 빠르게 합니다.
+- 샤딩은 수평적 데이터 확장 및 여러 시스템 간의 분산을 허용합니다.

--- a/ko/nim.md
+++ b/ko/nim.md
@@ -8,72 +8,72 @@ contributors:
     - ["Dennis Felsing", "https://dennis.felsing.org"]
 ---
 
-Nim (formerly Nimrod) is a statically typed, imperative programming language
-that gives the programmer power without compromises on runtime efficiency.
+Nim (이전 Nimrod)은 정적으로 타입이 지정된 명령형 프로그래밍 언어로,
+런타임 효율성을 타협하지 않으면서 프로그래머에게 강력한 기능을 제공합니다.
 
-Nim is efficient, expressive, and elegant.
+Nim은 효율적이고 표현력이 풍부하며 우아합니다.
 
 ```nim
-# Single-line comments start with a #
+# 한 줄 주석은 #으로 시작합니다.
 
 #[
-  This is a multiline comment.
-  In Nim, multiline comments can be nested, beginning with #[
-  ... and ending with ]#
+  이것은 여러 줄 주석입니다.
+  Nim에서 여러 줄 주석은 #[로 시작하여
+  ... ]#로 끝나는 중첩이 가능합니다.
 ]#
 
 discard """
-This can also work as a multiline comment.
-Or for unparsable, broken code
+이것은 여러 줄 주석으로도 작동할 수 있습니다.
+또는 구문 분석할 수 없거나 깨진 코드에 대해서도 마찬가지입니다.
 """
 
-var                     # Declare (and assign) variables,
-  letter: char = 'n'    # with or without type annotations
+var                     # 변수 선언 (및 할당),
+  letter: char = 'n'    # 타입 주석 포함 또는 미포함
   lang = "N" & "im"
   nLength: int = len(lang)
   boat: float
   truth: bool = false
 
-let            # Use let to declare and bind variables *once*.
-  legs = 400   # legs is immutable.
-  arms = 2_000 # _ are ignored and are useful for long numbers.
+let            # let을 사용하여 변수를 *한 번* 선언하고 바인딩합니다.
+  legs = 400   # legs는 불변입니다.
+  arms = 2_000 # _는 무시되며 긴 숫자에 유용합니다.
   aboutPi = 3.15
 
-const            # Constants are computed at compile time. This provides
-  debug = true   # performance and is useful in compile time expressions.
+const            # 상수는 컴파일 타임에 계산됩니다. 이는
+  debug = true   # 성능을 제공하며 컴파일 타임 표현식에 유용합니다.
   compileBadCode = false
 
-when compileBadCode:            # `when` is a compile time `if`
-  legs = legs + 1               # This error will never be compiled.
-  const input = readline(stdin) # Const values must be known at compile time.
+when compileBadCode:            # `when`은 컴파일 타임 `if`입니다.
+  legs = legs + 1               # 이 오류는 절대 컴파일되지 않습니다.
+  const input = readline(stdin) # const 값은 컴파일 타임에 알려져 있어야 합니다.
 
-discard 1 > 2 # Note: The compiler will complain if the result of an expression
-              # is unused. `discard` bypasses this.
+discard 1 > 2 # 참고: 컴파일러는 표현식의 결과가 사용되지 않으면
+              # 불평합니다. `discard`는 이것을 우회합니다.
 
 
 #
-# Data Structures
+# 데이터 구조
 #
 
-# Tuples
+# 튜플
 
 var
-  child: tuple[name: string, age: int]   # Tuples have *both* field names
-  today: tuple[sun: string, temp: float] # *and* order.
+  child: tuple[name: string, age: int]   # 튜플은 *필드 이름과*
+  today: tuple[sun: string, temp: float] # *순서를* 모두 가집니다.
 
-child = (name: "Rudiger", age: 2) # Assign all at once with literal ()
-today.sun = "Overcast"            # or individual fields.
-today[1] = 70.1                   # or by index.
+child = (name: "Rudiger", age: 2) # 리터럴 ()로 한 번에 모두 할당
+today.sun = "Overcast"            # 또는 개별 필드.
+today[1] = 70.1                   # 또는 인덱스로.
 
-let impostor = ("Rudiger", 2) # Two tuples are the same as long as they have
-assert child == impostor      # the same type and the same contents
+let impostor = ("Rudiger", 2) # 두 튜플은 동일한 타입과 동일한 내용을
+assert child == impostor      # 가지는 한 동일합니다.
 
-# Sequences
+# 시퀀스
 
 var
   drinks: seq[string]
 
-drinks = @["Water", "Juice", "Chocolate"] # @[V1,..,Vn] is the sequence literal
+drinks = @["Water", "Juice", "Chocolate"] # @[V1,..,Vn]은 시퀀스 리터럴입니다.
 
 drinks.add("Milk")
 
@@ -83,97 +83,97 @@ if "Milk" in drinks:
 let myDrink = drinks[2]
 
 #
-# Defining Types
+# 타입 정의
 #
 
-# Defining your own types puts the compiler to work for you. It's what makes
-# static typing powerful and useful.
+# 자신만의 타입을 정의하면 컴파일러가 당신을 위해 일하게 됩니다. 이것이
+# 정적 타이핑을 강력하고 유용하게 만드는 것입니다.
 
 type
-  Name = string # A type alias gives you a new type that is interchangeable
-  Age = int     # with the old type but is more descriptive.
-  Person = tuple[name: Name, age: Age] # Define data structures too.
+  Name = string # 타입 별칭은 이전 타입과 상호 교환 가능하지만
+  Age = int     # 더 설명적인 새 타입을 제공합니다.
+  Person = tuple[name: Name, age: Age] # 데이터 구조도 정의합니다.
   AnotherSyntax = tuple
     fieldOne: string
     secondField: int
 
 var
   john: Person = (name: "John B.", age: 17)
-  newage: int = 18 # It would be better to use Age than int
+  newage: int = 18 # int보다 Age를 사용하는 것이 더 좋습니다.
 
-john.age = newage # But still works because int and Age are synonyms
+john.age = newage # 하지만 int와 Age는 동의어이므로 여전히 작동합니다.
 
 type
-  Cash = distinct int    # `distinct` makes a new type incompatible with its
-  Desc = distinct string # base type.
+  Cash = distinct int    # `distinct`는 기본 타입과 호환되지 않는 새 타입을
+  Desc = distinct string # 만듭니다.
 
 var
-  money: Cash = 100.Cash # `.Cash` converts the int to our type
+  money: Cash = 100.Cash # `.Cash`는 int를 우리 타입으로 변환합니다.
   description: Desc  = "Interesting".Desc
 
 when compileBadCode:
-  john.age  = money        # Error! age is of type int and money is Cash
-  john.name = description  # Compiler says: "No way!"
+  john.age  = money        # 오류! age는 int 타입이고 money는 Cash입니다.
+  john.name = description  # 컴파일러가 "안돼!"라고 말합니다.
 
 #
-# More Types and Data Structures
+# 더 많은 타입 및 데이터 구조
 #
 
-# Objects are similar to tuples, but they *require* names of the fields
+# 객체는 튜플과 유사하지만 필드 이름이 *필수*입니다.
 
 type
-  Room = ref object # reference to an object, useful for big objects or
-    windows: int    # objects inside objects
-    doors: int = 1  # Change the default value of a field (since Nim 2.0)
+  Room = ref object # 객체에 대한 참조, 큰 객체나
+    windows: int    # 객체 내부의 객체에 유용합니다.
+    doors: int = 1  # 필드의 기본값 변경 (Nim 2.0부터)
   House = object
     address: string
     rooms: seq[Room]
 
 var
-  defaultHouse = House() # initialize with default values
-  defaultRoom = Room() # create new instance of ref object with default values
+  defaultHouse = House() # 기본값으로 초기화
+  defaultRoom = Room() # 기본값으로 ref 객체의 새 인스턴스 생성
 
-  # Create and initialize instances with given values
+  # 주어진 값으로 인스턴스 생성 및 초기화
   sesameRoom = Room(windows: 4, doors: 2)
   sesameHouse = House(address: "123 Sesame St.", rooms: @[sesameRoom])
 
-# Enumerations allow a type to have one of a limited number of values
+# 열거형은 타입이 제한된 수의 값 중 하나를 갖도록 허용합니다.
 
 type
   Color = enum cRed, cBlue, cGreen
-  Direction = enum # Alternative formatting
+  Direction = enum # 대체 서식
     dNorth
     dWest
     dEast
     dSouth
 var
-  orient = dNorth # `orient` is of type Direction, with the value `dNorth`
-  pixel = cGreen # `pixel` is of type Color, with the value `cGreen`
+  orient = dNorth # `orient`는 Direction 타입이며 값은 `dNorth`입니다.
+  pixel = cGreen # `pixel`은 Color 타입이며 값은 `cGreen`입니다.
 
-discard dNorth > dEast # Enums are usually an "ordinal" type
+discard dNorth > dEast # 열거형은 보통 "순서" 타입입니다.
 
-# Subranges specify a limited valid range
+# 서브레인지는 제한된 유효 범위를 지정합니다.
 
 type
-  DieFaces = range[1..20] # Only an int from 1 to 20 is a valid value
+  DieFaces = range[1..20] # 1에서 20까지의 int만 유효한 값입니다.
 var
   my_roll: DieFaces = 13
 
 when compileBadCode:
-  my_roll = 23 # Error!
+  my_roll = 23 # 오류!
 
-# Arrays
+# 배열
 
 type
-  RollCounter = array[DieFaces, int]  # Arrays are fixed length and
-  DirNames = array[Direction, string] # indexed by any ordinal type.
+  RollCounter = array[DieFaces, int]  # 배열은 고정 길이이며
+  DirNames = array[Direction, string] # 모든 순서 타입으로 인덱싱됩니다.
   Truths = array[42..44, bool]
 var
   counter: RollCounter
   directions: DirNames
   possible: Truths
 
-possible = [false, false, false] # Literal arrays are created with [V1,..,Vn]
+possible = [false, false, false] # 리터럴 배열은 [V1,..,Vn]으로 생성됩니다.
 possible[42] = true
 
 directions[dNorth] = "Ahh. The Great White North!"
@@ -185,12 +185,12 @@ counter[my_roll] += 1
 
 var anotherArray = ["Default index", "starts at", "0"]
 
-# More data structures are available, including tables, sets, lists, queues,
-# and crit bit trees.
+# 테이블, 세트, 리스트, 큐, 크릿 비트 트리 등 더 많은 데이터 구조를
+# 사용할 수 있습니다.
 # http://nim-lang.org/docs/lib.html#collections-and-algorithms
 
 #
-# IO and Control Flow
+# IO 및 제어 흐름
 #
 
 # `case`, `readLine()`
@@ -211,10 +211,10 @@ echo "I'm thinking of a number between 41 and 43. Guess which!"
 let number: int = 42
 var
   raw_guess: string
-  guess: int # Variables in Nim are always initialized with a zero value
+  guess: int # Nim의 변수는 항상 0 값으로 초기화됩니다.
 while guess != number:
   raw_guess = readLine(stdin)
-  if raw_guess == "": continue # Skip this iteration
+  if raw_guess == "": continue # 이 반복 건너뛰기
   guess = str.parseInt(raw_guess)
   if guess == 1001:
     echo("AAAAAAGGG!")
@@ -227,10 +227,10 @@ while guess != number:
     echo("Yeeeeeehaw!")
 
 #
-# Iteration
+# 반복
 #
 
-for i, elem in ["Yes", "No", "Maybe so"]: # Or just `for elem in`
+for i, elem in ["Yes", "No", "Maybe so"]: # 또는 그냥 `for elem in`
   echo(elem, " is at index: ", i)
 
 for k, v in items(@[(person: "You", power: 100), (person: "Me", power: 9000)]):
@@ -240,18 +240,18 @@ let myString = """
 an <example>
 `string` to
 play with
-""" # Multiline raw string
+""" # 여러 줄 원시 문자열
 
 for line in splitLines(myString):
   echo(line)
 
-for i, c in myString:       # Index and letter. Or `for j in` for just letter
-  if i mod 2 == 0: continue # Compact `if` form
+for i, c in myString:       # 인덱스와 문자. 또는 그냥 문자에 대해 `for j in`
+  if i mod 2 == 0: continue # 간결한 `if` 형식
   elif c == 'X': break
   else: echo(c)
 
 #
-# Procedures
+# 프로시저
 #
 
 type Answer = enum aYes, aNo
@@ -261,12 +261,12 @@ proc ask(question: string): Answer =
   while true:
     case readLine(stdin)
     of "y", "Y", "yes", "Yes":
-      return Answer.aYes  # Enums can be qualified
+      return Answer.aYes  # 열거형은 한정될 수 있습니다.
     of "n", "N", "no", "No":
       return Answer.aNo
     else: echo("Please be clear: yes or no")
 
-proc addSugar(amount: int = 2) = # Default amount is 2, returns nothing
+proc addSugar(amount: int = 2) = # 기본 양은 2이며 아무것도 반환하지 않습니다.
   assert(amount > 0 and amount < 9000, "Crazy Sugar")
   for a in 1..amount:
     echo(a, " sugar...")
@@ -277,29 +277,29 @@ of aYes:
 of aNo:
   echo "Oh do take a little!"
   addSugar()
-# No need for an `else` here. Only `yes` and `no` are possible.
+# 여기서 `else`는 필요 없습니다. `yes`와 `no`만 가능합니다.
 
 #
 # FFI
 #
 
-# Because Nim compiles to C, FFI is easy:
+# Nim은 C로 컴파일되므로 FFI가 쉽습니다.
 
 proc strcmp(a, b: cstring): cint {.importc: "strcmp", nodecl.}
 
 let cmp = strcmp("C?", "Easy!")
 ```
 
-Additionally, Nim separates itself from its peers with metaprogramming,
-performance, and compile-time features.
+또한 Nim은 메타프로그래밍, 성능 및 컴파일 타임 기능으로
+동료들과 차별화됩니다.
 
-## Further Reading
+## 더 읽을거리
 
-* [Home Page](http://nim-lang.org)
-* [Download](http://nim-lang.org/download.html)
-* [Community](http://nim-lang.org/community.html)
+* [홈페이지](http://nim-lang.org)
+* [다운로드](http://nim-lang.org/download.html)
+* [커뮤니티](http://nim-lang.org/community.html)
 * [FAQ](http://nim-lang.org/question.html)
-* [Documentation](http://nim-lang.org/documentation.html)
-* [Manual](http://nim-lang.org/docs/manual.html)
-* [Standard Library](http://nim-lang.org/docs/lib.html)
-* [Rosetta Code](http://rosettacode.org/wiki/Category:Nim)
+* [문서](http://nim-lang.org/documentation.html)
+* [매뉴얼](http://nim-lang.org/docs/manual.html)
+* [표준 라이브러리](http://nim-lang.org/docs/lib.html)
+* [로제타 코드](http://rosettacode.org/wiki/Category:Nim)

--- a/ko/niva.md
+++ b/ko/niva.md
@@ -7,40 +7,40 @@ contributors:
     - ["gavr", "https://github.com/gavr123456789"]
 ---
 
-## Intro
-Niva is a simple language that takes a lot of inspiration from Smalltalk.
-But leaning towards the functional side and static typed.
-Everything is still an object, but instead of classes, interfaces, inheritance, and abstract classes,
-we have tagged unions, which is the only way to achieve polymorphism.
+## 소개
+Niva는 Smalltalk에서 많은 영감을 받은 간단한 언어입니다.
+그러나 함수형 측면과 정적 타입에 더 가깝습니다.
+모든 것은 여전히 객체이지만 클래스, 인터페이스, 상속 및 추상 클래스 대신
+다형성을 달성하는 유일한 방법인 태그된 유니온이 있습니다.
 
 
-For example, everything except the declaration is sending messages to objects.
-`1 + 2` is not a + operator, but a `... + Int` message for `Int` object.
-(there are no extra costs for that)
+예를 들어, 선언을 제외한 모든 것은 객체에 메시지를 보내는 것입니다.
+`1 + 2`는 + 연산자가 아니라 `Int` 객체에 대한 `... + Int` 메시지입니다.
+(추가 비용은 없습니다)
 
-C-like: `1.inc()`
+C와 유사: `1.inc()`
 Niva: `1 inc`
 
-In essence, niva is highly minimalistic, like its ancestor Smalltalk.
-It introduces types, unions, and associated methods.
-There are no functions.
+본질적으로 niva는 조상인 Smalltalk처럼 매우 미니멀리즘적입니다.
+유형, 유니온 및 관련 메서드를 도입합니다.
+함수는 없습니다.
 
-Install:
+설치:
 ```bash
 git clone https://github.com/gavr123456789/Niva.git
 cd Niva
 ./gradlew buildJvmNiva
-# LSP here https://github.com/gavr123456789/niva-vscode-bundle
+# LSP 여기 https://github.com/gavr123456789/niva-vscode-bundle
 ```
 
-## The Basics
+## 기본
 
-#### Variable
-Variables are immutable by default.
-There is no special keyword for declaring a variable.
+#### 변수
+변수는 기본적으로 불변입니다.
+변수를 선언하는 특별한 키워드는 없습니다.
 
 ```Scala
-// this is a comment
+// 이것은 주석입니다
 int = 1
 str = "qwf"
 boolean = true
@@ -57,51 +57,51 @@ list = {1 2 3}
 set = #(1 2 3)
 map = #{1 'a' 2 'b'}
 
-// declare a mutable variable
+// 가변 변수 선언
 mut x = 5
-x <- 6 // mutate
+x <- 6 // 변경
 ```
 
-#### Messages
+#### 메시지
 ```Scala
-// hello world is a one liner
-"Hello world" echo // echo is a message for String obj
+// hello world는 한 줄입니다
+"Hello world" echo // echo는 String 객체에 대한 메시지입니다
 
 
-// There are 3 types of messages
-1 inc // 2         unary
-1 + 2 // 3         binary
-"abc" at: 0 // 'a' keyword
+// 3가지 유형의 메시지가 있습니다
+1 inc // 2         단항
+1 + 2 // 3         이항
+"abc" at: 0 // 'a' 키워드
 
 
-// they can be chained
+// 연결할 수 있습니다
 1 inc inc inc dec // 3
 1 + 1 + 2 - 3 // 1
 1 to: 3 do: [it echo] // 1 2 3
-// the last one here to:do: is a single message
-// to chain 2 keyword messages you need to wrap it in parentheses
+// 여기 마지막 to:do:는 단일 메시지입니다
+// 2개의 키워드 메시지를 연결하려면 괄호로 묶어야 합니다
 ("123456" drop: 1) dropLast: 2 // "234"
-the comma `,` is syntactic sugar for the same effect
+쉼표 ,는 동일한 효과를 위한 구문 설탕입니다
 "123456" drop: 1, dropLast: 2 // "234"
 
-// you can mix them
+// 혼합할 수 있습니다
 1 inc + 3 dec - "abc" count // 2 + 2 - 3 -> 1
 "123" + "456" drop: 1 + 1   // "123456" drop: 2 -> "3456"
 
-// everything except type and message declarations are message sends in niva
-// for example `if` is a message for Boolean object that takes a lambda
+// niva에서 타입 및 메시지 선언을 제외한 모든 것은 메시지 전송입니다
+// 예를 들어 `if`는 람다를 받는 Boolean 객체에 대한 메시지입니다
 1 > 2 ifTrue: ["wow" echo]
-// expression
+// 표현식
 base = 1 > 2 ifTrue: ["heh"] ifFalse: ["qwf"]
-// same for while
+// while도 마찬가지
 mut q = 0
 [q > 10] whileTrue: [q <- q inc]
-// all of this is zero cost because of inlining at compile time
+// 이 모든 것은 컴파일 타임에 인라이닝되기 때문에 비용이 없습니다
 ```
 
-#### Type
-New lines are not significant in niva
-Type declarations look like keyword messages consisting of fields and types
+#### 타입
+niva에서 새 줄은 중요하지 않습니다
+타입 선언은 필드와 타입으로 구성된 키워드 메시지처럼 보입니다
 ```Scala
 type Square side: Int
 
@@ -110,93 +110,93 @@ type Person
   age: Int
 ```
 
-#### Create instance
-Creating an object is the same keyword message as when declaring it, but with values in place of types.
+#### 인스턴스 생성
+객체를 생성하는 것은 선언할 때와 동일한 키워드 메시지이지만 타입 대신 값이 있습니다.
 ```Scala
 square = Square side: 42
 alice = Person name: "Alice" age: 24
 
-// destruct fields by names
+// 이름으로 필드 분해
 {age name} = alice
 ```
 
-#### Access fields
-Getting fields is the same as sending a unary message with its name to the object
+#### 필드 액세스
+필드를 가져오는 것은 객체에 이름으로 단항 메시지를 보내는 것과 같습니다
 ```Scala
-// get age, add 1 and print it
+// 나이를 가져와 1을 더하고 출력합니다
 alice age inc echo // 25
 ```
 
-#### Method for type:
-Everything is an object, just like in Smalltalk, so everything can have a method declared.
-Here, we add a `double` method to `Int` and then use it inside the `perimeter` method of `Square`.
+#### 타입에 대한 메서드:
+Smalltalk에서처럼 모든 것이 객체이므로 모든 것에 메서드를 선언할 수 있습니다.
+여기에서는 Int에 `double` 메서드를 추가한 다음 Square의 `perimeter` 메서드 내에서 사용합니다.
 
 ```Scala
 Int double = this + this
 Square perimeter = side double
 
 square = Square side: 42
-square perimeter // call
+square perimeter // 호출
 
 
-// explicit return type
+// 명시적 반환 타입
 Int double2 -> Int = this * 2
 
-// with body
+// 본문 포함
 Int double3 -> Int = [
     result = this * 2
-    ^ result // ^ is return
+    ^ result // ^는 반환입니다
 ]
 ```
 
 
-#### Keyword message declaration
+#### 키워드 메시지 선언
 ```Scala
 type Range from: Int to: Int
-// keyword message with one arg `to`
+// `to`라는 하나의 인수가 있는 키워드 메시지
 Int to::Int = Range from: this to: to
 
 1 to: 2 // Range
 ```
-#### Type constructor
-A type constructor functions as a message for the type itself rather than to a specific instance.
+#### 타입 생성자
+타입 생성자는 특정 인스턴스가 아닌 타입 자체에 대한 메시지로 작동합니다.
 ```Scala
 constructor Float pi = 3.14
 x = Float pi // 3.14
 ```
 
-It can be useful for initializing fields with default values.
+기본값으로 필드를 초기화하는 데 유용할 수 있습니다.
 ```Scala
 type Point x: Int y: Int
 constructor Point atStart = Point x: 0 y: 0
 
 p1 = Point x: 0 y: 0
 p2 = Point atStart
-// constructor is just a usual message, so it can have params
+// 생성자는 일반적인 메시지이므로 매개변수를 가질 수 있습니다
 constructor Point y::Int = Point x: 0 y: y
 p3 = Point y: 20 // x: 0 y: 20
 ```
 
 
-#### Conditions
-If, like everything else, is the usual sending of a message to a Boolean object.
-It takes one or two lambda arguments.
+#### 조건
+If는 다른 모든 것과 마찬가지로 Boolean 객체에 메시지를 보내는 일반적인 방법입니다.
+하나 또는 두 개의 람다 인수를 받습니다.
 ```Scala
 false ifTrue: ["yay" echo]
 1 < 2 ifTrue: ["yay" echo]
 1 > 2 ifTrue: ["yay" echo] ifFalse: ["oh no" echo]
 
-// `ifTrue:ifFalse:` message can be used as expression
+// `ifTrue:ifFalse:` 메시지는 표현식으로 사용할 수 있습니다
 str = 42 % 2 == 0
     ifTrue: ["even"]
     ifFalse: ["odd"]
 // str == "even"
 ```
 
-#### Cycles
-There is no special syntax for cycles.
-It's just keyword messages that take codeblocks as parameters.
-(it's zero cost thanks for inlining)
+#### 순환
+순환에 대한 특별한 구문은 없습니다.
+코드 블록을 매개변수로 받는 키워드 메시지일 뿐입니다.
+(인라이닝 덕분에 비용이 없습니다)
 ```Scala
 {1 2 3} forEach: [ it echo ] // 1 2 3
 1..10 forEach: [ it echo ]
@@ -204,27 +204,27 @@ It's just keyword messages that take codeblocks as parameters.
 mut c = 10
 [c > 0] whileTrue: [ c <- c dec ]
 
-c <- 3 // reset c
+c <- 3 // c 재설정
 [c > 0] whileTrue: [
     c <- c dec
     c echo // 3 2 1
 ]
 ```
-`whileTrue:` is a message for lambda object of the type:
+`whileTrue:`는 다음 타입의 람다 객체에 대한 메시지입니다:
 `[ -> Boolean] whileTrue::[ -> Unit]`
 
-#### Matching
-there is special syntax for matching, since niva heavily utilize tagged unions
+#### 매칭
+niva는 태그된 유니온을 많이 활용하므로 매칭에 대한 특별한 구문이 있습니다
 ```Scala
 x = "Alice"
-// matching on x
+// x에 대한 매칭
 | x
 | "Bob" => "Hi Bob!"
 | "Alice" => "Hi Alice!"
 |=> "Hi guest"
 
 
-// It can be used as expression as well
+// 표현식으로도 사용할 수 있습니다
 y = | "b"
     | "a" => 1
     | "b" => 2
@@ -232,12 +232,12 @@ y = | "b"
 y echo // 2
 ```
 
-#### Tagged unions
+#### 태그된 유니온
 
 ```Scala
 union Color = Red | Blue | Green
 
-// branches can have fields
+// 브랜치는 필드를 가질 수 있습니다
 union Shape =
     | Rectangle width: Int height: Int
     | Circle    radius: Double
@@ -245,87 +245,87 @@ union Shape =
 constructor Double pi = 3.14
 Double square = this * this
 
-// match on this(Shape)
+// this(Shape)에 대한 매칭
 Shape getArea -> Double =
     | this
     | Rectangle => width * height, toDouble
     | Circle => Double pi * radius square
 
-// There is exhaustiveness checking, so when you add a new branch
-// all the matches will become errors until all cases processed
+// 완전성 검사가 있으므로 새 브랜치를 추가하면
+// 모든 케이스가 처리될 때까지 모든 매치가 오류가 됩니다
 
 Shape getArea -> Double = | this
     | Rectangle => width * height, toDouble
-// ERROR: Not all possible variants have been checked (Circle)
+// 오류: 모든 가능한 변형이 확인되지 않았습니다 (Circle)
 ```
 
-#### Collections
+#### 컬렉션
 ```Scala
-// commas are optional
+// 쉼표는 선택 사항입니다
 list = {1 2 3}
 map = #{'a' 1 'b' 2}
 map2 = #{'a' 1, 'b' 2, 'c' 3}
 set = #(1 2 3)
 
-// common collection operations
+// 일반적인 컬렉션 작업
 {1 2 3 4 5}
   map: [it inc],
   filter: [it % 2 == 0],
   forEach: [it echo] // 2 4 6
 
-// iteration on map
+// 맵 반복
 map forEach: [key, value ->
   key echo
   value echo
 ]
 ```
 
-#### Nullability
-By default, variables cannot be assigned a null value.
-To allow this, nullable types are used, indicated by a question mark at the end of the type.
-You may already be familiar with this concept from TypeScript, Kotlin, or Swift.
+#### Null 가능성
+기본적으로 변수에는 null 값을 할당할 수 없습니다.
+이를 허용하려면 타입 끝에 물음표로 표시되는 nullable 타입을 사용합니다.
+TypeScript, Kotlin 또는 Swift에서 이 개념에 익숙할 수 있습니다.
 ```Scala
 x::Int? = null
 q = x unpackOrPANIC
 
-// do something if it's not null
+// null이 아닌 경우 무언가 수행
 x unpack: [it echo]
 
-// same but provide a backup value
+// 동일하지만 백업 값 제공
 w = x unpack: [it inc] or: -1
 
-// just unpack or backup value
+// 그냥 언패킹하거나 백업 값
 e = x unpackOrValue: -1
 ```
 
-#### Handling the error
+#### 오류 처리
 ```Scala
-// exit the program with stack trace
+// 스택 추적으로 프로그램 종료
 x = file read orPANIC
 x = file read orValue: "no file"
 ```
-Errors work like effects, look for more in [Error handling](https://gavr123456789.github.io/niva-site/error-handling.html)
+오류는 효과처럼 작동합니다. 자세한 내용은 [오류 처리](https://gavr123456789.github.io/niva-site/error-handling.html)를 참조하십시오.
 
-## Misc
+## 기타
 
-#### Local arg names
+#### 로컬 인수 이름
 ```Scala
 Int from: x::Int to: y::Int = this + x + y
 ```
 
-#### Syntax sugar for this
+#### this에 대한 구문 설탕
 ```Scala
 Person foo = [
     .bar
-    this bar // same thing
+    this bar // 같은 것
 ]
 ```
 
-#### Compile time reflection
-You can get string representation of any argument from a call site.
+#### 컴파일 타임 리플렉션
+호출 사이트에서 모든 인수의 문자열 표현을 가져올 수 있습니다.
 ```Scala
 Int bar::Int baz::String = [
-    // getting string representation from call side
+    // 호출 사이드에서 문자열 표현 가져오기
     a = Compiler getName: 0
     b = Compiler getName: 1
     c = Compiler getName: 2
@@ -335,14 +335,14 @@ Int bar::Int baz::String = [
 ]
 
 variable = 42
-// call side
+// 호출 사이드
 1 + 1
     bar: variable
     baz: "str"
 ```
 
-Links:
-- [Site](https://gavr123456789.github.io/niva-site/reference.html)
+링크:
+- [사이트](https://gavr123456789.github.io/niva-site/reference.html)
 - [GitHub](https://github.com/gavr123456789/Niva)
 - [LSP](https://github.com/gavr123456789/vaLSe)
-- [VSC plugin](https://github.com/gavr123456789/niva-vscode-bundle)
+- [VSC 플러그인](https://github.com/gavr123456789/niva-vscode-bundle)

--- a/ko/nix.md
+++ b/ko/nix.md
@@ -9,27 +9,25 @@ contributors:
     - ["Javier Candeira", "https://candeira.com/"]
 ---
 
-Nix is a simple functional language developed for the
-[Nix package manager](https://nixos.org/nix/) and
-[NixOS](https://nixos.org/).
+Nix는 [Nix 패키지 관리자](https://nixos.org/nix/) 및
+[NixOS](https://nixos.org/)를 위해 개발된 간단한 함수형 언어입니다.
 
-You can evaluate Nix expressions using
 [nix-instantiate](https://nixos.org/nix/manual/#sec-nix-instantiate)
-or [`nix repl`](https://nixos.org/nix/manual/#ssec-relnotes-2.0).
+또는 [`nix repl`](https://nixos.org/nix/manual/#ssec-relnotes-2.0)를 사용하여 Nix 표현식을 평가할 수 있습니다.
 
 ```nix
 with builtins; [
 
-  #  Comments
+  #  주석
   #=========================================
 
-  # Inline comments look like this.
+  # 인라인 주석은 이렇습니다.
 
-  /* Multi-line comments
-     look like this. */
+  /* 여러 줄 주석은
+     이렇습니다. */
 
 
-  #  Booleans
+  #  불리언
   #=========================================
 
   (true && false)               # And
@@ -38,45 +36,45 @@ with builtins; [
   (true || false)               # Or
   #=> true
 
-  (if 3 < 4 then "a" else "b")  # Conditional
+  (if 3 < 4 then "a" else "b")  # 조건문
   #=> "a"
 
 
-  #  Integers and Floats
+  #  정수와 부동 소수점
   #=========================================
 
-  # There are two numeric types: integers and floats
+  # 두 가지 숫자 타입이 있습니다: 정수와 부동 소수점
 
-  1 0 42 (-3)       # Some integers
+  1 0 42 (-3)       # 일부 정수
 
-  123.43 .27e13     # A couple of floats
+  123.43 .27e13     # 두 개의 부동 소수점
 
-  # Operations will preserve numeric type
+  # 연산은 숫자 타입을 유지합니다
 
-  (4 + 6 + 12 - 2)  # Addition
+  (4 + 6 + 12 - 2)  # 덧셈
   #=> 20
   (4 - 2.5)
   #=> 1.5
 
-  (7 / 2)           # Division
+  (7 / 2)           # 나눗셈
   #=> 3
   (7 / 2.0)
   #=> 3.5
 
 
-  #  Strings
+  #  문자열
   #=========================================
 
-  "Strings literals are in double quotes."
+  "문자열 리터럴은 큰따옴표 안에 있습니다."
 
   "
-    String literals can span
-    multiple lines.
+    문자열 리터럴은 여러 줄에 걸쳐
+    있을 수 있습니다.
   "
 
   ''
-    This is called an "indented string" literal.
-    It intelligently strips leading whitespace.
+    이것은 "들여쓰기된 문자열" 리터럴이라고 합니다.
+    선행 공백을 지능적으로 제거합니다.
   ''
 
   ''
@@ -85,53 +83,52 @@ with builtins; [
   ''
   #=> "a\n  b"
 
-  ("ab" + "cd")   # String concatenation
+  ("ab" + "cd")   # 문자열 연결
   #=> "abcd"
 
-  # String interpolation (formerly known as "antiquotation") lets you embed values into strings.
+  # 문자열 보간(이전에는 "antiquotation"으로 알려짐)을 사용하면 문자열에 값을 포함할 수 있습니다.
   ("Your home directory is ${getEnv "HOME"}")
   #=> "Your home directory is /home/alice"
 
 
-  #  Paths
+  #  경로
   #=========================================
 
-  # Nix has a primitive data type for paths.
+  # Nix에는 경로에 대한 기본 데이터 타입이 있습니다.
   /tmp/tutorials/learn.nix
 
-  # A relative path is resolved to an absolute path at parse
-  # time, relative to the file in which it occurs.
+  # 상대 경로는 구문 분석 시 절대 경로로 확인되며,
+  # 해당 경로가 발생하는 파일을 기준으로 합니다.
   tutorials/learn.nix
   #=> /the-base-path/tutorials/learn.nix
 
-  # A path must contain at least one slash, so a relative
-  # path for a file in the same directory needs a ./ prefix,
+  # 같은 디렉토리의 파일에 대한 상대 경로는
+  # ./ 접두사가 필요합니다.
   ./learn.nix
   #=> /the-base-path/learn.nix
 
-  # The / operator must be surrounded by whitespace if
-  # you want it to signify division.
+  # 나눗셈을 의미하려면 / 연산자를
+  # 공백으로 둘러싸야 합니다.
 
-  7/2        # This is a path literal
-  (7 / 2)    # This is integer division
+  7/2        # 이것은 경로 리터럴입니다
+  (7 / 2)    # 이것은 정수 나눗셈입니다
 
 
-  #  Imports
+  #  가져오기
   #=========================================
 
-  # A nix file contains a single top-level expression with no free
-  # variables. An import expression evaluates to the value of the
-  # file that it imports.
+  # nix 파일에는 자유 변수가 없는 단일 최상위 표현식이 포함됩니다.
+  # 가져오기 표현식은 가져오는 파일의 값으로 평가됩니다.
   (import /tmp/foo.nix)
 
-  # Imports can also be specified by strings.
+  # 가져오기는 문자열로도 지정할 수 있습니다.
   (import "/tmp/foo.nix")
 
-  # Import paths must be absolute. Path literals
-  # are automatically resolved, so this is fine.
+  # 가져오기 경로는 절대 경로여야 합니다. 경로 리터럴은
+  # 자동으로 확인되므로 괜찮습니다.
   (import ./foo.nix)
 
-  # But this does not happen with strings.
+  # 그러나 이것은 문자열에서는 발생하지 않습니다.
   (import "./foo.nix")
   #=> error: string ‘foo.nix’ doesn't represent an absolute path
 
@@ -139,50 +136,49 @@ with builtins; [
   #  Let
   #=========================================
 
-  # `let` blocks allow us to bind values to variables.
+  # `let` 블록을 사용하면 값을 변수에 바인딩할 수 있습니다.
   (let x = "a"; in
     x + x + x)
   #=> "aaa"
 
-  # Bindings can refer to each other, and their order does not matter.
+  # 바인딩은 서로 참조할 수 있으며 순서는 중요하지 않습니다.
   (let y = x + "b";
        x = "a"; in
     y + "c")
   #=> "abc"
 
-  # Inner bindings shadow outer bindings.
+  # 내부 바인딩은 외부 바인딩을 가립니다.
   (let a = 1; in
     let a = 2; in
       a)
   #=> 2
 
 
-  #  Functions
+  #  함수
   #=========================================
 
-  (n: n + 1)      # Function that adds 1
+  (n: n + 1)      # 1을 더하는 함수
 
-  ((n: n + 1) 5)  # That same function, applied to 5
+  ((n: n + 1) 5)  # 5에 적용된 동일한 함수
   #=> 6
 
-  # There is no syntax for named functions, but they
-  # can be bound by `let` blocks like any other value.
+  # 명명된 함수에 대한 구문은 없지만,
+  # 다른 값과 마찬가지로 `let` 블록으로 바인딩할 수 있습니다.
   (let succ = (n: n + 1); in succ 5)
   #=> 6
 
-  # A function has exactly one argument.
-  # Multiple arguments can be achieved with currying.
+  # 함수에는 정확히 하나의 인수가 있습니다.
+  # 커링을 통해 여러 인수를 얻을 수 있습니다.
   ((x: y: x + "-" + y) "a" "b")
   #=> "a-b"
 
-  # We can also have named function arguments,
-  # which we'll get to later after we introduce sets.
+  # 나중에 집합을 소개한 후 명명된 함수 인수를 가질 수도 있습니다.
 
 
-  #  Lists
+  #  리스트
   #=========================================
 
-  # Lists are denoted by square brackets.
+  # 리스트는 대괄호로 표시됩니다.
 
   (length [1 2 3 "x"])
   #=> 4
@@ -210,38 +206,38 @@ with builtins; [
   #=> [ 1 2 ]
 
 
-  #  Sets
+  #  집합
   #=========================================
 
-  # A "set" is an unordered mapping with string keys.
+  # "집합"은 문자열 키를 사용하는 정렬되지 않은 매핑입니다.
   { foo = [1 2]; bar = "x"; }
 
-  # The . operator pulls a value out of a set.
+  # . 연산자는 집합에서 값을 꺼냅니다.
   { a = 1; b = 2; }.a
   #=> 1
 
-  # The ? operator tests whether a key is present in a set.
+  # ? 연산자는 집합에 키가 있는지 테스트합니다.
   ({ a = 1; b = 2; } ? a)
   #=> true
   ({ a = 1; b = 2; } ? c)
   #=> false
 
-  # The // operator merges two sets.
+  # // 연산자는 두 집합을 병합합니다.
   ({ a = 1; } // { b = 2; })
   #=> { a = 1; b = 2; }
 
-  # Values on the right override values on the left.
+  # 오른쪽 값이 왼쪽 값을 재정의합니다.
   ({ a = 1; b = 2; } // { a = 3; c = 4; })
   #=> { a = 3; b = 2; c = 4; }
 
-  # The rec keyword denotes a "recursive set",
-  # in which attributes can refer to each other.
+  # rec 키워드는 "재귀 집합"을 나타내며,
+  # 속성이 서로 참조할 수 있습니다.
   (let a = 1; in     { a = 2; b = a; }.b)
   #=> 1
   (let a = 1; in rec { a = 2; b = a; }.b)
   #=> 2
 
-  # Nested sets can be defined in a piecewise fashion.
+  # 중첩된 집합은 부분적으로 정의할 수 있습니다.
   {
     a.b   = 1;
     a.c.d = 2;
@@ -249,15 +245,15 @@ with builtins; [
   }.a.c
   #=> { d = 2; e = 3; }
 
-  # Sets are immutable, so you can't redefine an attribute:
+  # 집합은 불변이므로 속성을 재정의할 수 없습니다:
   {
     a = { b = 1; };
     a.b = 2;
   }
   #=> attribute 'a.b' at (string):3:5 already defined at (string):2:11
 
-  # However, an attribute's set members can also be defined piecewise
-  # way even if the attribute itself has been directly assigned.
+  # 그러나 속성 자체가 직접 할당되었더라도
+  # 속성의 집합 멤버는 부분적으로 정의할 수 있습니다.
   {
     a = { b = 1; };
     a.c = 2;
@@ -268,68 +264,66 @@ with builtins; [
   #  With
   #=========================================
 
-  # The body of a `with` block is evaluated with
-  # a set's mappings bound to variables.
+  # `with` 블록의 본문은 집합의 매핑이
+  # 변수에 바인딩된 상태로 평가됩니다.
   (with { a = 1; b = 2; };
     a + b)
   # => 3
 
-  # Inner bindings shadow outer bindings.
+  # 내부 바인딩은 외부 바인딩을 가립니다.
   (with { a = 1; b = 2; };
     (with { a = 5; };
       a + b))
   #=> 7
 
-  # This first line of tutorial starts with "with builtins;"
-  # because builtins is a set that contains all of the built-in
-  # functions (length, head, tail, filter, etc.). This saves
-  # us from having to write, for example, "builtins.length"
-  # instead of just "length".
+  # 이 튜토리얼의 첫 줄은 "with builtins;"으로 시작합니다.
+  # builtins는 모든 내장 함수(length, head, tail, filter 등)를
+  # 포함하는 집합이기 때문입니다. 이렇게 하면 예를 들어
+  # "builtins.length" 대신 "length"만 작성할 수 있습니다.
 
 
-  #  Set patterns
+  #  집합 패턴
   #=========================================
 
-  # Sets are useful when we need to pass multiple values
-  # to a function.
+  # 집합은 여러 값을 함수에 전달해야 할 때 유용합니다.
   (args: args.x + "-" + args.y) { x = "a"; y = "b"; }
   #=> "a-b"
 
-  # This can be written more clearly using set patterns.
+  # 이것은 집합 패턴을 사용하여 더 명확하게 작성할 수 있습니다.
   ({x, y}: x + "-" + y) { x = "a"; y = "b"; }
   #=> "a-b"
 
-  # By default, the pattern fails on sets containing extra keys.
+  # 기본적으로 패턴은 추가 키가 포함된 집합에서 실패합니다.
   ({x, y}: x + "-" + y) { x = "a"; y = "b"; z = "c"; }
   #=> error: anonymous function called with unexpected argument ‘z’
 
-  # Adding ", ..." allows ignoring extra keys.
+  # ", ..."를 추가하면 추가 키를 무시할 수 있습니다.
   ({x, y, ...}: x + "-" + y) { x = "a"; y = "b"; z = "c"; }
   #=> "a-b"
 
-  # The entire set can be bound to a variable using `@`
+  # 전체 집합은 `@`를 사용하여 변수에 바인딩할 수 있습니다.
   (args@{x, y}: args.x + "-" + args.y) { x = "a"; y = "b"; }
   #=> "a-b"
 
-  #  Errors
+  #  오류
   #=========================================
 
-  # `throw` causes evaluation to abort with an error message.
+  # `throw`는 오류 메시지와 함께 평가를 중단시킵니다.
   (2 + (throw "foo"))
   #=> error: foo
 
-  # `tryEval` catches thrown errors.
+  # `tryEval`은 throw된 오류를 잡습니다.
   (tryEval 42)
   #=> { success = true; value = 42; }
   (tryEval (2 + (throw "foo")))
   #=> { success = false; value = false; }
 
-  # `abort` is like throw, but it's fatal; it cannot be caught.
+  # `abort`는 throw와 같지만 치명적입니다. 잡을 수 없습니다.
   (tryEval (abort "foo"))
   #=> error: evaluation aborted with the following error message: ‘foo’
 
-  # `assert` evaluates to the given value if true;
-  # otherwise it throws a catchable exception.
+  # `assert`는 true이면 주어진 값으로 평가되고,
+  # 그렇지 않으면 잡을 수 있는 예외를 throw합니다.
   (assert 1 < 2; 42)
   #=> 42
   (assert 1 > 2; 42)
@@ -338,42 +332,42 @@ with builtins; [
   #=> { success = false; value = false; }
 
 
-  #  Impurity
+  #  불순물
   #=========================================
 
-  # Because repeatability of builds is critical to the Nix package
-  # manager, functional purity is emphasized in the Nix language
-  # used to describe Nix packages. But there are a few impurities.
+  # 빌드의 반복성은 Nix 패키지 관리자에게 중요하기 때문에,
+  # Nix 패키지를 설명하는 데 사용되는 Nix 언어에서는
+  # 함수형 순수성이 강조됩니다. 그러나 몇 가지 불순물이 있습니다.
 
-  # You can refer to environment variables.
+  # 환경 변수를 참조할 수 있습니다.
   (getEnv "HOME")
   #=> "/home/alice"
 
-  # The trace function is used for debugging. It prints the first
-  # argument to stderr and evaluates to the second argument.
+  # trace 함수는 디버깅에 사용됩니다. 첫 번째 인수를
+  # stderr에 출력하고 두 번째 인수로 평가됩니다.
   (trace 1 2)
   #=> trace: 1
   #=> 2
 
-  # You can write files into the Nix store. Although impure, this is
-  # fairly safe because the file name is derived from the hash of
-  # its contents. You can read files from anywhere. In this example,
-  # we write a file into the store, and then read it back out.
+  # Nix 저장소에 파일을 쓸 수 있습니다. 불순하지만,
+  # 파일 이름이 내용의 해시에서 파생되므로
+  # 상당히 안전합니다. 어디서든 파일을 읽을 수 있습니다. 이 예에서는
+  # 저장소에 파일을 쓰고 다시 읽습니다.
   (let filename = toFile "foo.txt" "hello!"; in
     [filename (readFile filename)])
   #=> [ "/nix/store/ayh05aay2anx135prqp0cy34h891247x-foo.txt" "hello!" ]
 
-  # We can also download files into the Nix store.
+  # Nix 저장소에 파일을 다운로드할 수도 있습니다.
   (fetchurl "https://example.com/package-1.2.3.tgz")
   #=> "/nix/store/2drvlh8r57f19s9il42zg89rdr33m2rm-package-1.2.3.tgz"
 
 ]
 ```
 
-### Further Reading
+### 더 읽을거리
 
-* [Nix Manual - Nix expression language](https://nixos.org/nix/manual/#ch-expression-language)
-* [James Fisher - Nix by example - Part 1: The Nix expression language](https://medium.com/@MrJamesFisher/nix-by-example-a0063a1a4c55)
-* [Susan Potter - Nix Cookbook - Nix By Example](https://ops.functionalalgebra.com/nix-by-example/)
-* [Zero to Nix - Nix Tutorial](https://zero-to-nix.com/)
-* [Rommel Martinez - A Gentle Introduction to the Nix Family](https://web.archive.org/web/20210121042658/https://ebzzry.io/en/nix/#nix)
+* [Nix 매뉴얼 - Nix 표현 언어](https://nixos.org/nix/manual/#ch-expression-language)
+* [James Fisher - 예제로 배우는 Nix - 1부: Nix 표현 언어](https://medium.com/@MrJamesFisher/nix-by-example-a0063a1a4c55)
+* [Susan Potter - Nix 요리책 - 예제로 배우는 Nix](https://ops.functionalalgebra.com/nix-by-example/)
+* [Zero to Nix - Nix 튜토리얼](https://zero-to-nix.com/)
+* [Rommel Martinez - Nix 제품군에 대한 부드러운 소개](https://web.archive.org/web/20210121042658/https://ebzzry.io/en/nix/#nix)

--- a/ko/objective-c.md
+++ b/ko/objective-c.md
@@ -11,191 +11,192 @@ contributors:
 filename: LearnObjectiveC.m
 ---
 
-Objective-C is the main programming language used by Apple for the macOS and iOS operating systems and their respective frameworks, Cocoa and Cocoa Touch.
-It is a general-purpose, object-oriented programming language that adds Smalltalk-style messaging to the C programming language.
+Objective-C는 macOS 및 iOS 운영 체제와 해당 프레임워크인 Cocoa 및 Cocoa Touch에서 Apple이 사용하는 주요 프로그래밍 언어입니다.
+C 프로그래밍 언어에 Smalltalk 스타일 메시징을 추가한 범용 객체 지향 프로그래밍 언어입니다.
 
 ```objective-c
-// Single-line comments start with //
+// 한 줄 주석은 //로 시작합니다.
 
 /*
-Multi-line comments look like this
+여러 줄 주석은
+이와 같습니다.
 */
 
-// XCode supports pragma mark directive that improve jump bar readability
-#pragma mark Navigation Functions // New tag on jump bar named 'Navigation Functions'
-#pragma mark - Navigation Functions // Same tag, now with a separator
+// XCode는 점프 바 가독성을 향상시키는 pragma mark 지시문을 지원합니다.
+#pragma mark Navigation Functions // 'Navigation Functions'라는 새 태그가 점프 바에 표시됩니다.
+#pragma mark - Navigation Functions // 동일한 태그, 이제 구분 기호가 있습니다.
 
-// Imports the Foundation headers with #import
-// Use <> to import global files (in general frameworks)
-// Use "" to import local files (from project)
+// #import로 Foundation 헤더를 가져옵니다.
+// 전역 파일을 가져오려면 <>를 사용합니다(일반적으로 프레임워크).
+// 로컬 파일을 가져오려면 ""를 사용합니다(프로젝트에서).
 #import <Foundation/Foundation.h>
 #import "MyClass.h"
 
-// If you enable modules for iOS >= 7.0 or OS X >= 10.9 projects in
-// Xcode 5 you can import frameworks like that:
+// Xcode 5에서 iOS >= 7.0 또는 OS X >= 10.9 프로젝트에 대해 모듈을 활성화하면
+// 다음과 같이 프레임워크를 가져올 수 있습니다.
 @import Foundation;
 
-// Your program's entry point is a function called
-// main with an integer return type
+// 프로그램의 진입점은 정수 반환 타입의
+// main이라는 함수입니다.
 int main (int argc, const char * argv[])
 {
-    // Create an autorelease pool to manage the memory into the program
+    // 프로그램의 메모리를 관리하기 위해 자동 해제 풀을 생성합니다.
     NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
-    // If using automatic reference counting (ARC), use @autoreleasepool instead:
+    // 자동 참조 계산(ARC)을 사용하는 경우 대신 @autoreleasepool을 사용합니다.
     @autoreleasepool {
 
-    // Use NSLog to print lines to the console
-    NSLog(@"Hello World!"); // Print the string "Hello World!"
+    // NSLog를 사용하여 콘솔에 줄을 출력합니다.
+    NSLog(@"Hello World!"); // "Hello World!" 문자열을 출력합니다.
 
     ///////////////////////////////////////
-    // Types & Variables
+    // 타입 및 변수
     ///////////////////////////////////////
 
-    // Primitive declarations
+    // 기본 타입 선언
     int myPrimitive1  = 1;
     long myPrimitive2 = 234554664565;
 
-    // Object declarations
-    // Put the * in front of the variable names for strongly-typed object declarations
-    MyClass *myObject1 = nil;  // Strong typing
-    id       myObject2 = nil;  // Weak typing
-    // %@ is an object
-    // 'description' is a convention to display the value of the Objects
-    NSLog(@"%@ and %@", myObject1, [myObject2 description]); // prints => "(null) and (null)"
+    // 객체 선언
+    // 강력한 타입의 객체 선언을 위해 변수 이름 앞에 *를 붙입니다.
+    MyClass *myObject1 = nil;  // 강력한 타이핑
+    id       myObject2 = nil;  // 약한 타이핑
+    // %@는 객체입니다.
+    // 'description'은 객체의 값을 표시하는 관례입니다.
+    NSLog(@"%@ and %@", myObject1, [myObject2 description]); // => "(null) and (null)" 출력
 
-    // String
+    // 문자열
     NSString *worldString = @"World";
-    NSLog(@"Hello %@!", worldString); // prints => "Hello World!"
-    // NSMutableString is a mutable version of the NSString object
+    NSLog(@"Hello %@!", worldString); // => "Hello World!" 출력
+    // NSMutableString은 NSString 객체의 가변 버전입니다.
     NSMutableString *mutableString = [NSMutableString stringWithString:@"Hello"];
     [mutableString appendString:@" World!"];
-    NSLog(@"%@", mutableString); // prints => "Hello World!"
+    NSLog(@"%@", mutableString); // => "Hello World!" 출력
 
-    // Character literals
+    // 문자 리터럴
     NSNumber *theLetterZNumber = @'Z';
-    char theLetterZ            = [theLetterZNumber charValue]; // or 'Z'
+    char theLetterZ            = [theLetterZNumber charValue]; // 또는 'Z'
     NSLog(@"%c", theLetterZ);
 
-    // Integral literals
+    // 정수 리터럴
     NSNumber *fortyTwoNumber = @42;
-    int fortyTwo             = [fortyTwoNumber intValue]; // or 42
+    int fortyTwo             = [fortyTwoNumber intValue]; // 또는 42
     NSLog(@"%i", fortyTwo);
 
     NSNumber *fortyTwoUnsignedNumber = @42U;
-    unsigned int fortyTwoUnsigned    = [fortyTwoUnsignedNumber unsignedIntValue]; // or 42
+    unsigned int fortyTwoUnsigned    = [fortyTwoUnsignedNumber unsignedIntValue]; // 또는 42
     NSLog(@"%u", fortyTwoUnsigned);
 
     NSNumber *fortyTwoShortNumber = [NSNumber numberWithShort:42];
-    short fortyTwoShort           = [fortyTwoShortNumber shortValue]; // or 42
+    short fortyTwoShort           = [fortyTwoShortNumber shortValue]; // 또는 42
     NSLog(@"%hi", fortyTwoShort);
 
     NSNumber *fortyOneShortNumber   = [NSNumber numberWithShort:41];
-    unsigned short fortyOneUnsigned = [fortyOneShortNumber unsignedShortValue]; // or 41
+    unsigned short fortyOneUnsigned = [fortyOneShortNumber unsignedShortValue]; // 또는 41
     NSLog(@"%u", fortyOneUnsigned);
 
     NSNumber *fortyTwoLongNumber = @42L;
-    long fortyTwoLong            = [fortyTwoLongNumber longValue]; // or 42
+    long fortyTwoLong            = [fortyTwoLongNumber longValue]; // 또는 42
     NSLog(@"%li", fortyTwoLong);
 
     NSNumber *fiftyThreeLongNumber   = @53L;
-    unsigned long fiftyThreeUnsigned = [fiftyThreeLongNumber unsignedLongValue]; // or 53
+    unsigned long fiftyThreeUnsigned = [fiftyThreeLongNumber unsignedLongValue]; // 또는 53
     NSLog(@"%lu", fiftyThreeUnsigned);
 
-    // Floating point literals
+    // 부동 소수점 리터럴
     NSNumber *piFloatNumber = @3.141592654F;
-    float piFloat           = [piFloatNumber floatValue]; // or 3.141592654f
-    NSLog(@"%f", piFloat); // prints => 3.141592654
-    NSLog(@"%5.2f", piFloat); // prints => " 3.14"
+    float piFloat           = [piFloatNumber floatValue]; // 또는 3.141592654f
+    NSLog(@"%f", piFloat); // => 3.141592654 출력
+    NSLog(@"%5.2f", piFloat); // => " 3.14" 출력
 
     NSNumber *piDoubleNumber = @3.1415926535;
-    double piDouble          = [piDoubleNumber doubleValue]; // or 3.1415926535
+    double piDouble          = [piDoubleNumber doubleValue]; // 또는 3.1415926535
     NSLog(@"%f", piDouble);
-    NSLog(@"%4.2f", piDouble); // prints => "3.14"
+    NSLog(@"%4.2f", piDouble); // => "3.14" 출력
 
-    // NSDecimalNumber is a fixed-point class that's more precise than float or double
+    // NSDecimalNumber는 float 또는 double보다 더 정밀한 고정 소수점 클래스입니다.
     NSDecimalNumber *oneDecNum = [NSDecimalNumber decimalNumberWithString:@"10.99"];
     NSDecimalNumber *twoDecNum = [NSDecimalNumber decimalNumberWithString:@"5.002"];
-    // NSDecimalNumber isn't able to use standard +, -, *, / operators so it provides its own:
+    // NSDecimalNumber는 표준 +, -, *, / 연산자를 사용할 수 없으므로 자체 연산자를 제공합니다.
     [oneDecNum decimalNumberByAdding:twoDecNum];
     [oneDecNum decimalNumberBySubtracting:twoDecNum];
     [oneDecNum decimalNumberByMultiplyingBy:twoDecNum];
     [oneDecNum decimalNumberByDividingBy:twoDecNum];
-    NSLog(@"%@", oneDecNum); // prints => 10.99 as NSDecimalNumber is immutable
+    NSLog(@"%@", oneDecNum); // => NSDecimalNumber는 불변이므로 10.99 출력
 
-    // BOOL literals
+    // BOOL 리터럴
     NSNumber *yesNumber = @YES;
     NSNumber *noNumber  = @NO;
-    // or
+    // 또는
     BOOL yesBool = YES;
     BOOL noBool  = NO;
-    NSLog(@"%i", yesBool); // prints => 1
+    NSLog(@"%i", yesBool); // => 1 출력
 
-    // Array object
-    // May contain different data types, but must be an Objective-C object
+    // 배열 객체
+    // 다른 데이터 타입을 포함할 수 있지만 Objective-C 객체여야 합니다.
     NSArray *anArray      = @[@1, @2, @3, @4];
     NSNumber *thirdNumber = anArray[2];
-    NSLog(@"Third number = %@", thirdNumber); // prints => "Third number = 3"
-    // Since Xcode 7, NSArray objects can be typed (Generics)
+    NSLog(@"Third number = %@", thirdNumber); // => "Third number = 3" 출력
+    // Xcode 7부터 NSArray 객체는 타입을 지정할 수 있습니다 (제네릭).
     NSArray<NSString *> *stringArray = @[@"hello", @"world"];
-    // NSMutableArray is a mutable version of NSArray, allowing you to change
-    // the items in the array and to extend or shrink the array object.
-    // Convenient, but not as efficient as NSArray.
+    // NSMutableArray는 NSArray의 가변 버전으로,
+    // 배열의 항목을 변경하거나 배열 객체를 확장하거나 축소할 수 있습니다.
+    // 편리하지만 NSArray만큼 효율적이지는 않습니다.
     NSMutableArray *mutableArray = [NSMutableArray arrayWithCapacity:2];
     [mutableArray addObject:@"Hello"];
     [mutableArray addObject:@"World"];
     [mutableArray removeObjectAtIndex:0];
-    NSLog(@"%@", [mutableArray objectAtIndex:0]); // prints => "World"
+    NSLog(@"%@", [mutableArray objectAtIndex:0]); // => "World" 출력
 
-    // Dictionary object
+    // 딕셔너리 객체
     NSDictionary *aDictionary = @{ @"key1" : @"value1", @"key2" : @"value2" };
     NSObject *valueObject     = aDictionary[@"A Key"];
-    NSLog(@"Object = %@", valueObject); // prints => "Object = (null)"
-    // Since Xcode 7, NSDictionary objects can be typed (Generics)
+    NSLog(@"Object = %@", valueObject); // => "Object = (null)" 출력
+    // Xcode 7부터 NSDictionary 객체는 타입을 지정할 수 있습니다 (제네릭).
     NSDictionary<NSString *, NSNumber *> *numberDictionary = @{@"a": @1, @"b": @2};
-    // NSMutableDictionary also available as a mutable dictionary object
+    // NSMutableDictionary도 가변 딕셔너리 객체로 사용할 수 있습니다.
     NSMutableDictionary *mutableDictionary = [NSMutableDictionary dictionaryWithCapacity:2];
     [mutableDictionary setObject:@"value1" forKey:@"key1"];
     [mutableDictionary setObject:@"value2" forKey:@"key2"];
     [mutableDictionary removeObjectForKey:@"key1"];
 
-    // Change types from Mutable To Immutable
-    //In general [object mutableCopy] will make the object mutable whereas [object copy] will make the object immutable
+    // 가변에서 불변으로 타입 변경
+    // 일반적으로 [object mutableCopy]는 객체를 가변으로 만들고 [object copy]는 객체를 불변으로 만듭니다.
     NSMutableDictionary *aMutableDictionary = [aDictionary mutableCopy];
     NSDictionary *mutableDictionaryChanged = [mutableDictionary copy];
 
 
-    // Set object
+    // 세트 객체
     NSSet *set = [NSSet setWithObjects:@"Hello", @"Hello", @"World", nil];
-    NSLog(@"%@", set); // prints => {(Hello, World)} (may be in different order)
-    // Since Xcode 7, NSSet objects can be typed (Generics)
+    NSLog(@"%@", set); // => {(Hello, World)} 출력 (순서가 다를 수 있음)
+    // Xcode 7부터 NSSet 객체는 타입을 지정할 수 있습니다 (제네릭).
     NSSet<NSString *> *stringSet = [NSSet setWithObjects:@"hello", @"world", nil];
-    // NSMutableSet also available as a mutable set object
+    // NSMutableSet도 가변 세트 객체로 사용할 수 있습니다.
     NSMutableSet *mutableSet = [NSMutableSet setWithCapacity:2];
     [mutableSet addObject:@"Hello"];
     [mutableSet addObject:@"Hello"];
-    NSLog(@"%@", mutableSet); // prints => {(Hello)}
+    NSLog(@"%@", mutableSet); // => {(Hello)} 출력
 
     ///////////////////////////////////////
-    // Operators
+    // 연산자
     ///////////////////////////////////////
 
-    // The operators works like in the C language
-    // For example:
+    // 연산자는 C 언어처럼 작동합니다.
+    // 예:
     2 + 5; // => 7
     4.2f + 5.1f; // => 9.3f
     3 == 2; // => 0 (NO)
     3 != 2; // => 1 (YES)
-    1 && 1; // => 1 (Logical and)
-    0 || 1; // => 1 (Logical or)
-    ~0x0F; // => 0xF0 (bitwise negation)
-    0x0F & 0xF0; // => 0x00 (bitwise AND)
-    0x01 << 1; // => 0x02 (bitwise left shift (by 1))
+    1 && 1; // => 1 (논리 AND)
+    0 || 1; // => 1 (논리 OR)
+    ~0x0F; // => 0xF0 (비트 부정)
+    0x0F & 0xF0; // => 0x00 (비트 AND)
+    0x01 << 1; // => 0x02 (비트 왼쪽 시프트 (1만큼))
 
     ///////////////////////////////////////
-    // Control Structures
+    // 제어 구조
     ///////////////////////////////////////
 
-    // If-Else statement
+    // If-Else 문
     if (NO)
     {
         NSLog(@"I am never run");
@@ -207,7 +208,7 @@ int main (int argc, const char * argv[])
         NSLog(@"I print");
     }
 
-    // Switch statement
+    // Switch 문
     switch (2)
     {
         case 0:
@@ -224,182 +225,182 @@ int main (int argc, const char * argv[])
         } break;
     }
 
-    // While loops statements
+    // While 루프 문
     int ii = 0;
     while (ii < 4)
     {
-        NSLog(@"%d,", ii++); // ii++ increments ii in-place, after using its value
-    } // prints => "0,"
+        NSLog(@"%d,", ii++); // ii++는 값을 사용한 후 ii를 제자리에서 증가시킵니다.
+    } // => "0,"
       //           "1,"
       //           "2,"
-      //           "3,"
+      //           "3," 출력
 
-    // For loops statements
+    // For 루프 문
     int jj;
     for (jj=0; jj < 4; jj++)
     {
         NSLog(@"%d,", jj);
-    } // prints => "0,"
+    } // => "0,"
       //           "1,"
       //           "2,"
-      //           "3,"
+      //           "3," 출력
 
-    // Foreach statements
+    // Foreach 문
     NSArray *values = @[@0, @1, @2, @3];
     for (NSNumber *value in values)
     {
         NSLog(@"%@,", value);
-    } // prints => "0,"
+    } // => "0,"
       //           "1,"
       //           "2,"
-      //           "3,"
+      //           "3," 출력
 
-    // Object for loop statement. Can be used with any Objective-C object type
+    // 객체 for 루프 문. 모든 Objective-C 객체 타입과 함께 사용할 수 있습니다.
     for (id item in values) {
         NSLog(@"%@,", item);
-    } // prints => "0,"
+    } // => "0,"
       //           "1,"
       //           "2,"
-      //           "3,"
+      //           "3," 출력
 
-    // Try-Catch-Finally statements
+    // Try-Catch-Finally 문
     @try
     {
-        // Your statements here
+        // 여기에 문장을 작성합니다.
         @throw [NSException exceptionWithName:@"FileNotFoundException"
                             reason:@"File Not Found on System" userInfo:nil];
-    } @catch (NSException * e) // use: @catch (id exceptionName) to catch all objects.
+    } @catch (NSException * e) // 모든 객체를 잡으려면 @catch (id exceptionName)를 사용합니다.
     {
         NSLog(@"Exception: %@", e);
     } @finally
     {
         NSLog(@"Finally. Time to clean up.");
-    } // prints => "Exception: File Not Found on System"
-      //           "Finally. Time to clean up."
+    } // => "Exception: File Not Found on System"
+      //           "Finally. Time to clean up." 출력
 
-    // NSError objects are useful for function arguments to populate on user mistakes.
+    // NSError 객체는 사용자 실수 시 채울 함수 인수에 유용합니다.
     NSError *error = [NSError errorWithDomain:@"Invalid email." code:4 userInfo:nil];
 
     ///////////////////////////////////////
-    // Objects
+    // 객체
     ///////////////////////////////////////
 
-    // Create an object instance by allocating memory and initializing it
-    // An object is not fully functional until both steps have been completed
+    // 메모리를 할당하고 초기화하여 객체 인스턴스를 생성합니다.
+    // 객체는 두 단계가 모두 완료될 때까지 완전히 작동하지 않습니다.
     MyClass *myObject = [[MyClass alloc] init];
 
-    // The Objective-C model of object-oriented programming is based on message
-    // passing to object instances
-    // In Objective-C one does not simply call a method; one sends a message
+    // Objective-C의 객체 지향 프로그래밍 모델은 객체 인스턴스에
+    // 메시지를 전달하는 것을 기반으로 합니다.
+    // Objective-C에서는 단순히 메서드를 호출하는 것이 아니라 메시지를 보냅니다.
     [myObject instanceMethodWithParameter:@"Steve Jobs"];
 
-    // Clean up the memory you used into your program
+    // 프로그램에서 사용한 메모리를 정리합니다.
     [pool drain];
 
-    // End of @autoreleasepool
+    // @autoreleasepool의 끝
     }
 
-    // End the program
+    // 프로그램 종료
     return 0;
 }
 
 ///////////////////////////////////////
-// Classes And Functions
+// 클래스 및 함수
 ///////////////////////////////////////
 
-// Declare your class in a header file (MyClass.h):
-// Class declaration syntax:
+// 헤더 파일(MyClass.h)에 클래스를 선언합니다.
+// 클래스 선언 구문:
 // @interface ClassName : ParentClassName <ImplementedProtocols>
 // {
-//    type name; <= variable declarations;
+//    type name; <= 변수 선언;
 // }
-// @property type name; <= property declarations
-// -/+ (type) Method declarations; <= Method declarations
+// @property type name; <= 프로퍼티 선언
+// -/+ (type) 메서드 선언; <= 메서드 선언
 // @end
-@interface MyClass : NSObject <MyProtocol> // NSObject is Objective-C's base object class.
+@interface MyClass : NSObject <MyProtocol> // NSObject는 Objective-C의 기본 객체 클래스입니다.
 {
-    // Instance variable declarations (can exist in either interface or implementation file)
-    int count; // Protected access by default.
-    @private id data; // Private access (More convenient to declare in implementation file)
+    // 인스턴스 변수 선언 (인터페이스 또는 구현 파일에 있을 수 있음)
+    int count; // 기본적으로 Protected 액세스.
+    @private id data; // Private 액세스 (구현 파일에 선언하는 것이 더 편리함)
     NSString *name;
 }
-// Convenient notation for public access variables to auto generate a setter method
-// By default, setter method name is 'set' followed by @property variable name
-@property int propInt; // Setter method name = 'setPropInt'
-@property (copy) id copyId; // (copy) => Copy the object during assignment
-// (readonly) => Cannot set value outside @interface
-@property (readonly) NSString *roString; // Use @synthesize in @implementation to create accessor
-// You can customize the getter and setter names instead of using default 'set' name:
+// setter 메서드를 자동으로 생성하기 위한 public 액세스 변수의 편리한 표기법
+// 기본적으로 setter 메서드 이름은 'set' 뒤에 @property 변수 이름이 옵니다.
+@property int propInt; // Setter 메서드 이름 = 'setPropInt'
+@property (copy) id copyId; // (copy) => 할당 중에 객체 복사
+// (readonly) => @interface 외부에서 값을 설정할 수 없음
+@property (readonly) NSString *roString; // 접근자를 생성하려면 @implementation에서 @synthesize 사용
+// 기본 'set' 이름 대신 getter 및 setter 이름을 사용자 정의할 수 있습니다.
 @property (getter=lengthGet, setter=lengthSet:) int length;
 
-// Methods
+// 메서드
 +/- (return type)methodSignature:(Parameter Type *)parameterName;
 
-// + for class methods:
+// + 클래스 메서드용:
 + (NSString *)classMethod;
 + (MyClass *)myClassFromHeight:(NSNumber *)defaultHeight;
 
-// - for instance methods:
+// - 인스턴스 메서드용:
 - (NSString *)instanceMethodWithParameter:(NSString *)string;
 - (NSNumber *)methodAParameterAsString:(NSString*)string andAParameterAsNumber:(NSNumber *)number;
 
-// Constructor methods with arguments:
+// 인수가 있는 생성자 메서드:
 - (id)initWithDistance:(int)defaultDistance;
-// Objective-C method names are very descriptive. Always name methods according to their arguments
+// Objective-C 메서드 이름은 매우 설명적입니다. 항상 인수에 따라 메서드 이름을 지정하십시오.
 
-@end // States the end of the interface
+@end // 인터페이스의 끝을 나타냅니다.
 
 
-// To access public variables from the implementation file, @property generates a setter method
-// automatically. Method name is 'set' followed by @property variable name:
-MyClass *myClass = [[MyClass alloc] init]; // create MyClass object instance
+// 구현 파일에서 public 변수에 액세스하려면 @property가 setter 메서드를
+// 자동으로 생성합니다. 메서드 이름은 'set' 뒤에 @property 변수 이름이 옵니다.
+MyClass *myClass = [[MyClass alloc] init]; // MyClass 객체 인스턴스 생성
 [myClass setCount:10];
-NSLog(@"%d", [myClass count]); // prints => 10
-// Or using the custom getter and setter method defined in @interface:
+NSLog(@"%d", [myClass count]); // => 10 출력
+// 또는 @interface에 정의된 사용자 정의 getter 및 setter 메서드 사용:
 [myClass lengthSet:32];
-NSLog(@"%i", [myClass lengthGet]); // prints => 32
-// For convenience, you may use dot notation to set and access object instance variables:
+NSLog(@"%i", [myClass lengthGet]); // => 32 출력
+// 편의를 위해 점 표기법을 사용하여 객체 인스턴스 변수를 설정하고 액세스할 수 있습니다.
 myClass.count = 45;
-NSLog(@"%i", myClass.count); // prints => 45
+NSLog(@"%i", myClass.count); // => 45 출력
 
-// Call class methods:
+// 클래스 메서드 호출:
 NSString *classMethodString = [MyClass classMethod];
 MyClass *classFromName = [MyClass myClassFromName:@"Hello"];
 
-// Call instance methods:
-MyClass *myClass = [[MyClass alloc] init]; // Create MyClass object instance
+// 인스턴스 메서드 호출:
+MyClass *myClass = [[MyClass alloc] init]; // MyClass 객체 인스턴스 생성
 NSString *stringFromInstanceMethod = [myClass instanceMethodWithParameter:@"Hello"];
 
-// Selectors
-// Way to dynamically represent methods. Used to call methods of a class, pass methods
-// through functions to tell other classes they should call it, and to save methods
-// as a variable
-// SEL is the data type. @selector() returns a selector from method name provided
-// methodAParameterAsString:andAParameterAsNumber: is method name for method in MyClass
+// 선택자
+// 메서드를 동적으로 표현하는 방법. 클래스의 메서드를 호출하고, 메서드를
+// 함수를 통해 전달하여 다른 클래스가 호출해야 함을 알리고, 메서드를
+// 변수로 저장하는 데 사용됩니다.
+// SEL은 데이터 타입입니다. @selector()는 제공된 메서드 이름에서 선택자를 반환합니다.
+// methodAParameterAsString:andAParameterAsNumber:는 MyClass의 메서드 이름입니다.
 SEL selectorVar = @selector(methodAParameterAsString:andAParameterAsNumber:);
-if ([myClass respondsToSelector:selectorVar]) { // Checks if class contains method
-    // Must put all method arguments into one object to send to performSelector function
+if ([myClass respondsToSelector:selectorVar]) { // 클래스에 메서드가 포함되어 있는지 확인
+    // performSelector 함수에 보내기 위해 모든 메서드 인수를 하나의 객체에 넣어야 합니다.
     NSArray *arguments = [NSArray arrayWithObjects:@"Hello", @4, nil];
-    [myClass performSelector:selectorVar withObject:arguments]; // Calls the method
+    [myClass performSelector:selectorVar withObject:arguments]; // 메서드 호출
 } else {
-    // NSStringFromSelector() returns a NSString of the method name of a given selector
+    // NSStringFromSelector()는 주어진 선택자의 메서드 이름을 NSString으로 반환합니다.
     NSLog(@"MyClass does not have method: %@", NSStringFromSelector(selectedVar));
 }
 
-// Implement the methods in an implementation (MyClass.m) file:
+// 구현(MyClass.m) 파일에서 메서드를 구현합니다.
 @implementation MyClass {
-    long distance; // Private access instance variable
+    long distance; // Private 액세스 인스턴스 변수
     NSNumber *height;
 }
 
-// To access a public variable from the interface file, use '_' followed by variable name:
-_count = 5; // References "int count" from MyClass interface
-// Access variables defined in implementation file:
-distance = 18; // References "long distance" from MyClass implementation
-// To use @property variable in implementation, use @synthesize to create accessor variable:
-@synthesize roString = _roString; // _roString available now in @implementation
+// 인터페이스 파일에서 public 변수에 액세스하려면 '_' 뒤에 변수 이름을 사용합니다.
+_count = 5; // MyClass 인터페이스의 "int count" 참조
+// 구현 파일에 정의된 변수에 액세스:
+distance = 18; // MyClass 구현의 "long distance" 참조
+// 구현에서 @property 변수를 사용하려면 @synthesize를 사용하여 접근자 변수를 만듭니다.
+@synthesize roString = _roString; // _roString은 이제 @implementation에서 사용할 수 있습니다.
 
-// Called before calling any class methods or instantiating any objects
+// 클래스 메서드를 호출하거나 객체를 인스턴스화하기 전에 호출됩니다.
 + (void)initialize
 {
     if (self == [MyClass class]) {
@@ -407,24 +408,24 @@ distance = 18; // References "long distance" from MyClass implementation
     }
 }
 
-// Counterpart to initialize method. Called when an object's reference count is zero
+// initialize 메서드의 반대. 객체의 참조 카운트가 0일 때 호출됩니다.
 - (void)dealloc
 {
-    [height release]; // If not using ARC, make sure to release class variable objects
-    [super dealloc];  // and call parent class dealloc
+    [height release]; // ARC를 사용하지 않는 경우 클래스 변수 객체를 해제해야 합니다.
+    [super dealloc];  // 그리고 부모 클래스 dealloc 호출
 }
 
-// Constructors are a way of creating instances of a class
-// This is a default constructor which is called when the object is initialized.
+// 생성자는 클래스의 인스턴스를 만드는 방법입니다.
+// 이것은 객체가 초기화될 때 호출되는 기본 생성자입니다.
 - (id)init
 {
-    if ((self = [super init])) // 'super' used to access methods from parent class
+    if ((self = [super init])) // 'super'는 부모 클래스에서 메서드를 액세스하는 데 사용됩니다.
     {
-        self.count = 1; // 'self' used for object to call itself
+        self.count = 1; // 'self'는 객체가 자신을 호출하는 데 사용됩니다.
     }
     return self;
 }
-// Can create constructors that contain arguments:
+// 인수가 포함된 생성자를 만들 수 있습니다.
 - (id)initWithDistance:(int)defaultDistance
 {
     distance = defaultDistance;
@@ -452,37 +453,37 @@ distance = 18; // References "long distance" from MyClass implementation
     return @42;
 }
 
-// Objective-C does not have private method declarations, but you can simulate them.
-// To simulate a private method, create the method in the @implementation but not in the @interface.
+// Objective-C에는 private 메서드 선언이 없지만 시뮬레이션할 수 있습니다.
+// private 메서드를 시뮬레이션하려면 @implementation에 메서드를 만들고 @interface에는 만들지 마십시오.
 - (NSNumber *)secretPrivateMethod {
     return @72;
 }
-[self secretPrivateMethod]; // Calls private method
+[self secretPrivateMethod]; // private 메서드 호출
 
-// Methods declared into MyProtocol
+// MyProtocol에 선언된 메서드
 - (void)myProtocolMethod
 {
-    // statements
+    // 문장
 }
 
-@end // States the end of the implementation
+@end // 구현의 끝을 나타냅니다.
 
 ///////////////////////////////////////
-// Categories
+// 카테고리
 ///////////////////////////////////////
-// A category is a group of methods designed to extend a class. They allow you to add new methods
-// to an existing class for organizational purposes. This is not to be mistaken with subclasses.
-// Subclasses are meant to CHANGE functionality of an object while categories instead ADD
-// functionality to an object.
-// Categories allow you to:
-// -- Add methods to an existing class for organizational purposes.
-// -- Allow you to extend Objective-C object classes (ex: NSString) to add your own methods.
-// -- Add ability to create protected and private methods to classes.
-// NOTE: Do not override methods of the base class in a category even though you have the ability
-// to. Overriding methods may cause compiler errors later between different categories and it
-// ruins the purpose of categories to only ADD functionality. Subclass instead to override methods.
+// 카테고리는 클래스를 확장하도록 설계된 메서드 그룹입니다. 조직적인 목적으로
+// 기존 클래스에 새 메서드를 추가할 수 있습니다. 이것은 하위 클래스와 혼동해서는 안 됩니다.
+// 하위 클래스는 객체의 기능을 변경하는 반면 카테고리는 객체에 기능을
+// 추가합니다.
+// 카테고리를 사용하면 다음을 수행할 수 있습니다.
+// -- 조직적인 목적으로 기존 클래스에 메서드를 추가합니다.
+// -- Objective-C 객체 클래스(예: NSString)를 확장하여 자신만의 메서드를 추가할 수 있습니다.
+// -- 클래스에 보호 및 비공개 메서드를 만드는 기능을 추가합니다.
+// 참고: 카테고리에서 기본 클래스의 메서드를 재정의하지 마십시오.
+// 재정의하면 나중에 다른 카테고리 간에 컴파일러 오류가 발생할 수 있으며
+// 기능을 추가만 하는 카테고리의 목적을 망칩니다. 메서드를 재정의하려면 대신 하위 클래스를 사용하십시오.
 
-// Here is a simple Car base class.
+// 다음은 간단한 Car 기본 클래스입니다.
 @interface Car : NSObject
 
 @property NSString *make;
@@ -493,7 +494,7 @@ distance = 18; // References "long distance" from MyClass implementation
 
 @end
 
-// And the simple Car base class implementation:
+// 그리고 간단한 Car 기본 클래스 구현:
 #import "Car.h"
 
 @implementation Car
@@ -510,22 +511,22 @@ distance = 18; // References "long distance" from MyClass implementation
 
 @end
 
-// Now, if we wanted to create a Truck object, we would instead create a subclass of Car as it would
-// be changing the functionality of the Car to behave like a truck. But lets say we want to just add
-// functionality to this existing Car. A good example would be to clean the car. So we would create
-// a category to add these cleaning methods:
+// 이제 Truck 객체를 만들고 싶다면 Car의 하위 클래스를 만들어
+// Car의 기능을 트럭처럼 동작하도록 변경합니다. 하지만 기존 Car에
+// 기능을 추가하고 싶다고 가정해 봅시다. 좋은 예는 차를 청소하는 것입니다. 따라서
+// 이러한 청소 메서드를 추가하기 위해 카테고리를 만듭니다.
 // @interface filename: Car+Clean.h (BaseClassName+CategoryName.h)
-#import "Car.h" // Make sure to import base class to extend.
+#import "Car.h" // 확장할 기본 클래스를 가져와야 합니다.
 
-@interface Car (Clean) // The category name is inside () following the name of the base class.
+@interface Car (Clean) // 카테고리 이름은 기본 클래스 이름 뒤에 () 안에 있습니다.
 
-- (void)washWindows; // Names of the new methods we are adding to our Car object.
+- (void)washWindows; // Car 객체에 추가하는 새 메서드의 이름.
 - (void)wax;
 
 @end
 
 // @implementation filename: Car+Clean.m (BaseClassName+CategoryName.m)
-#import "Car+Clean.h" // Import the Clean category's @interface file.
+#import "Car+Clean.h" // Clean 카테고리의 @interface 파일을 가져옵니다.
 
 @implementation Car (Clean)
 
@@ -538,9 +539,9 @@ distance = 18; // References "long distance" from MyClass implementation
 
 @end
 
-// Any Car object instance has the ability to use a category. All they need to do is import it:
-#import "Car+Clean.h" // Import as many different categories as you want to use.
-#import "Car.h" // Also need to import base class to use it's original functionality.
+// 모든 Car 객체 인스턴스는 카테고리를 사용할 수 있습니다. 가져오기만 하면 됩니다.
+#import "Car+Clean.h" // 사용하려는 만큼 다른 카테고리를 가져옵니다.
+#import "Car.h" // 원래 기능을 사용하려면 기본 클래스도 가져와야 합니다.
 
 int main (int argc, const char * argv[]) {
     @autoreleasepool {
@@ -548,60 +549,60 @@ int main (int argc, const char * argv[]) {
         mustang.color = @"Red";
         mustang.make = @"Ford";
 
-        [mustang turnOn]; // Use methods from base Car class.
-        [mustang washWindows]; // Use methods from Car's Clean category.
+        [mustang turnOn]; // 기본 Car 클래스의 메서드 사용.
+        [mustang washWindows]; // Car의 Clean 카테고리 메서드 사용.
     }
     return 0;
 }
 
-// Objective-C does not have protected method declarations but you can simulate them.
-// Create a category containing all of the protected methods, then import it ONLY into the
-// @implementation file of a class belonging to the Car class:
-@interface Car (Protected) // Naming category 'Protected' to remember methods are protected.
+// Objective-C에는 보호된 메서드 선언이 없지만 시뮬레이션할 수 있습니다.
+// 보호된 메서드를 시뮬레이션하려면 모든 보호된 메서드를 포함하는 카테고리를 만든 다음
+// Car 클래스에 속한 클래스의 @implementation 파일에만 가져옵니다.
+@interface Car (Protected) // 메서드가 보호됨을 기억하기 위해 카테고리 이름을 'Protected'로 지정합니다.
 
-- (void)lockCar; // Methods listed here may only be created by Car objects.
+- (void)lockCar; // 여기에 나열된 메서드는 Car 객체만 만들 수 있습니다.
 
 @end
-//To use protected methods, import the category, then implement the methods:
-#import "Car+Protected.h" // Remember, import in the @implementation file only.
+// 보호된 메서드를 사용하려면 카테고리를 가져온 다음 메서드를 구현합니다.
+#import "Car+Protected.h" // @implementation 파일에만 가져오는 것을 기억하십시오.
 
 @implementation Car
 
 - (void)lockCar {
-    NSLog(@"Car locked."); // Instances of Car can't use lockCar because it's not in the @interface.
+    NSLog(@"Car locked."); // Car 인스턴스는 @interface에 없기 때문에 lockCar를 사용할 수 없습니다.
 }
 
 @end
 
 ///////////////////////////////////////
-// Extensions
+// 확장
 ///////////////////////////////////////
-// Extensions allow you to override public access property attributes and methods of an @interface.
+// 확장을 사용하면 @interface의 public 액세스 프로퍼티 속성 및 메서드를 재정의할 수 있습니다.
 // @interface filename: Shape.h
-@interface Shape : NSObject // Base Shape class extension overrides below.
+@interface Shape : NSObject // 기본 Shape 클래스 확장은 아래에서 재정의됩니다.
 
 @property (readonly) NSNumber *numOfSides;
 
 - (int)getNumOfSides;
 
 @end
-// You can override numOfSides variable or getNumOfSides method to edit them with an extension:
+// numOfSides 변수 또는 getNumOfSides 메서드를 재정의하여 확장으로 편집할 수 있습니다.
 // @implementation filename: Shape.m
 #import "Shape.h"
-// Extensions live in the same file as the class @implementation.
-@interface Shape () // () after base class name declares an extension.
+// 확장은 클래스 @implementation과 동일한 파일에 있습니다.
+@interface Shape () // 기본 클래스 이름 뒤의 ()는 확장을 선언합니다.
 
-@property (copy) NSNumber *numOfSides; // Make numOfSides copy instead of readonly.
--(NSNumber)getNumOfSides; // Make getNumOfSides return a NSNumber instead of an int.
--(void)privateMethod; // You can also create new private methods inside of extensions.
+@property (copy) NSNumber *numOfSides; // numOfSides를 readonly 대신 copy로 만듭니다.
+-(NSNumber)getNumOfSides; // getNumOfSides가 int 대신 NSNumber를 반환하도록 합니다.
+-(void)privateMethod; // 확장 내에서 새 private 메서드를 만들 수도 있습니다.
 
 @end
-// The main @implementation:
+// 주 @implementation:
 @implementation Shape
 
 @synthesize numOfSides = _numOfSides;
 
--(NSNumber)getNumOfSides { // All statements inside of extension must be in the @implementation.
+-(NSNumber)getNumOfSides { // 확장 내의 모든 문장은 @implementation에 있어야 합니다.
     return _numOfSides;
 }
 -(void)privateMethod {
@@ -610,9 +611,9 @@ int main (int argc, const char * argv[]) {
 
 @end
 
-// Starting in Xcode 7.0, you can create Generic classes,
-// allowing you to provide greater type safety and clarity
-// without writing excessive boilerplate.
+// Xcode 7.0부터 제네릭 클래스를 만들 수 있어
+// 과도한 상용구 작성 없이 더 나은 타입 안전성과 명확성을
+// 제공할 수 있습니다.
 @interface Result<__covariant A> : NSObject
 
 - (void)handleSuccess:(void(^)(A))success
@@ -622,12 +623,12 @@ int main (int argc, const char * argv[]) {
 
 @end
 
-// we can now declare instances of this class like
+// 이제 이 클래스의 인스턴스를 다음과 같이 선언할 수 있습니다.
 Result<NSNumber *> *result;
 Result<NSArray *> *result;
 
-// Each of these cases would be equivalent to rewriting Result's interface
-// and substituting the appropriate type for A
+// 이러한 각 경우는 Result의 인터페이스를 다시 작성하고
+// A에 적절한 타입을 대체하는 것과 동일합니다.
 @interface Result : NSObject
 - (void)handleSuccess:(void(^)(NSArray *))success
               failure:(void(^)(NSError *))failure;
@@ -640,75 +641,75 @@ Result<NSArray *> *result;
 @property (nonatomic) NSNumber * object;
 @end
 
-// It should be obvious, however, that writing one
-//  Class to solve a problem is always preferable to writing two
+// 그러나 문제를 해결하기 위해 하나의 클래스를 작성하는 것이
+// 두 개를 작성하는 것보다 항상 선호된다는 것은 명백해야 합니다.
 
-// Note that Clang will not accept generic types in @implementations,
-// so your @implemnation of Result would have to look like this:
+// Clang은 @implementation에서 제네릭 타입을 허용하지 않으므로
+// Result의 @implemnation은 다음과 같아야 합니다.
 
 @implementation Result
 
 - (void)handleSuccess:(void (^)(id))success
               failure:(void (^)(NSError *))failure {
-  // Do something
+  // 무언가 수행
 }
 
 @end
 
 
 ///////////////////////////////////////
-// Protocols
+// 프로토콜
 ///////////////////////////////////////
-// A protocol declares methods that can be implemented by any class.
-// Protocols are not classes themselves. They simply define an interface
-// that other objects are responsible for implementing.
+// 프로토콜은 모든 클래스에서 구현할 수 있는 메서드를 선언합니다.
+// 프로토콜은 클래스 자체가 아닙니다. 다른 객체가 구현할 책임이 있는
+// 인터페이스를 정의할 뿐입니다.
 // @protocol filename: "CarUtilities.h"
-@protocol CarUtilities <NSObject> // <NSObject> => Name of another protocol this protocol includes.
-    @property BOOL engineOn; // Adopting class must @synthesize all defined @properties and
-    - (void)turnOnEngine; // all defined methods.
+@protocol CarUtilities <NSObject> // <NSObject> => 이 프로토콜이 포함하는 다른 프로토콜의 이름.
+    @property BOOL engineOn; // 채택하는 클래스는 모든 정의된 @properties를 @synthesize해야 하며
+    - (void)turnOnEngine; // 모든 정의된 메서드를 구현해야 합니다.
 @end
-// Below is an example class implementing the protocol.
-#import "CarUtilities.h" // Import the @protocol file.
+// 아래는 프로토콜을 구현하는 예제 클래스입니다.
+#import "CarUtilities.h" // @protocol 파일을 가져옵니다.
 
-@interface Car : NSObject <CarUtilities> // Name of protocol goes inside <>
-    // You don't need the @property or method names here for CarUtilities. Only @implementation does.
-- (void)turnOnEngineWithUtilities:(id <CarUtilities>)car; // You can use protocols as data too.
+@interface Car : NSObject <CarUtilities> // 프로토콜의 이름은 <> 안에 들어갑니다.
+    // CarUtilities에 대한 @property 또는 메서드 이름은 여기에 필요하지 않습니다. @implementation만 필요합니다.
+- (void)turnOnEngineWithUtilities:(id <CarUtilities>)car; // 프로토콜을 데이터로 사용할 수도 있습니다.
 @end
-// The @implementation needs to implement the @properties and methods for the protocol.
+// @implementation은 프로토콜에 대한 @properties 및 메서드를 구현해야 합니다.
 @implementation Car : NSObject <CarUtilities>
 
-@synthesize engineOn = _engineOn; // Create a @synthesize statement for the engineOn @property.
+@synthesize engineOn = _engineOn; // engineOn @property에 대한 @synthesize 문을 만듭니다.
 
-- (void)turnOnEngine { // Implement turnOnEngine however you would like. Protocols do not define
-    _engineOn = YES; // how you implement a method, it just requires that you do implement it.
+- (void)turnOnEngine { // 원하는 대로 turnOnEngine을 구현합니다. 프로토콜은
+    _engineOn = YES; // 메서드를 구현하는 방법을 정의하지 않고 구현해야 한다는 것만 요구합니다.
 }
-// You may use a protocol as data as you know what methods and variables it has implemented.
+// 프로토콜을 데이터로 사용할 수 있습니다. 어떤 메서드와 변수가 구현되었는지 알기 때문입니다.
 - (void)turnOnEngineWithCarUtilities:(id <CarUtilities>)objectOfSomeKind {
-    [objectOfSomeKind engineOn]; // You have access to object variables
-    [objectOfSomeKind turnOnEngine]; // and the methods inside.
-    [objectOfSomeKind engineOn]; // May or may not be YES. Class implements it however it wants.
+    [objectOfSomeKind engineOn]; // 객체 변수에 액세스할 수 있습니다.
+    [objectOfSomeKind turnOnEngine]; // 그리고 내부의 메서드.
+    [objectOfSomeKind engineOn]; // YES일 수도 있고 아닐 수도 있습니다. 클래스는 원하는 대로 구현합니다.
 }
 
 @end
-// Instances of Car now have access to the protocol.
+// Car 인스턴스는 이제 프로토콜에 액세스할 수 있습니다.
 Car *carInstance = [[Car alloc] init];
 [carInstance setEngineOn:NO];
 [carInstance turnOnEngine];
 if ([carInstance engineOn]) {
-    NSLog(@"Car engine is on."); // prints => "Car engine is on."
+    NSLog(@"Car engine is on."); // => "Car engine is on." 출력
 }
-// Make sure to check if an object of type 'id' implements a protocol before calling protocol methods:
+// 'id' 타입의 객체가 프로토콜 메서드를 호출하기 전에 프로토콜을 구현하는지 확인하십시오.
 if ([myClass conformsToProtocol:@protocol(CarUtilities)]) {
     NSLog(@"This does not run as the MyClass class does not implement the CarUtilities protocol.");
 } else if ([carInstance conformsToProtocol:@protocol(CarUtilities)]) {
     NSLog(@"This does run as the Car class implements the CarUtilities protocol.");
 }
-// Categories may implement protocols as well: @interface Car (CarCategory) <CarUtilities>
-// You may implement many protocols: @interface Car : NSObject <CarUtilities, CarCleaning>
-// NOTE: If two or more protocols rely on each other, make sure to forward-declare them:
+// 카테고리도 프로토콜을 구현할 수 있습니다: @interface Car (CarCategory) <CarUtilities>
+// 여러 프로토콜을 구현할 수 있습니다: @interface Car : NSObject <CarUtilities, CarCleaning>
+// 참고: 둘 이상의 프로토콜이 서로 의존하는 경우 전방 선언해야 합니다.
 #import "Brother.h"
 
-@protocol Brother; // Forward-declare statement. Without it, compiler will throw error.
+@protocol Brother; // 전방 선언 문. 이것이 없으면 컴파일러가 오류를 발생시킵니다.
 
 @protocol Sister <NSObject>
 
@@ -716,10 +717,10 @@ if ([myClass conformsToProtocol:@protocol(CarUtilities)]) {
 
 @end
 
-// See the problem is that Sister relies on Brother, and Brother relies on Sister.
+// 문제는 Sister가 Brother에 의존하고 Brother가 Sister에 의존한다는 것입니다.
 #import "Sister.h"
 
-@protocol Sister; // These lines stop the recursion, resolving the issue.
+@protocol Sister; // 이 줄은 재귀를 중지하여 문제를 해결합니다.
 
 @protocol Brother <NSObject>
 
@@ -729,93 +730,93 @@ if ([myClass conformsToProtocol:@protocol(CarUtilities)]) {
 
 
 ///////////////////////////////////////
-// Blocks
+// 블록
 ///////////////////////////////////////
-// Blocks are statements of code, just like a function, that are able to be used as data.
-// Below is a simple block with an integer argument that returns the argument plus 4.
+// 블록은 데이터로 사용할 수 있는 함수와 같은 코드 문입니다.
+// 아래는 정수 인수를 받아 인수에 4를 더한 값을 반환하는 간단한 블록입니다.
 ^(int n) {
     return n + 4;
 }
-int (^addUp)(int n); // Declare a variable to store a block.
-void (^noParameterBlockVar)(void); // Example variable declaration of block with no arguments.
-// Blocks have access to variables in the same scope. But the variables are readonly and the
-// value passed to the block is the value of the variable when the block is created.
-int outsideVar = 17; // If we edit outsideVar after declaring addUp, outsideVar is STILL 17.
-__block long mutableVar = 3; // __block makes variables writable to blocks, unlike outsideVar.
-addUp = ^(int n) { // Remove (int n) to have a block that doesn't take in any parameters.
+int (^addUp)(int n); // 블록을 저장할 변수를 선언합니다.
+void (^noParameterBlockVar)(void); // 인수가 없는 블록의 예제 변수 선언.
+// 블록은 동일한 범위의 변수에 액세스할 수 있습니다. 그러나 변수는 읽기 전용이며
+// 블록에 전달되는 값은 블록이 생성될 때 변수의 값입니다.
+int outsideVar = 17; // addUp을 선언한 후 outsideVar를 편집해도 outsideVar는 여전히 17입니다.
+__block long mutableVar = 3; // __block은 outsideVar와 달리 변수를 블록에 쓸 수 있도록 합니다.
+addUp = ^(int n) { // 매개변수를 받지 않는 블록을 가지려면 (int n)을 제거합니다.
     NSLog(@"You may have as many lines in a block as you would like.");
-    NSSet *blockSet; // Also, you can declare local variables.
-    mutableVar = 32; // Assigning new value to __block variable.
-    return n + outsideVar; // Return statements are optional.
+    NSSet *blockSet; // 또한 지역 변수를 선언할 수 있습니다.
+    mutableVar = 32; // __block 변수에 새 값을 할당합니다.
+    return n + outsideVar; // 반환 문은 선택 사항입니다.
 }
-int addUp = addUp(10 + 16); // Calls block code with arguments.
-// Blocks are often used as arguments to functions to be called later, or for callbacks.
+int addUp = addUp(10 + 16); // 인수로 블록 코드를 호출합니다.
+// 블록은 나중에 호출되거나 콜백을 위해 함수의 인수로 자주 사용됩니다.
 @implementation BlockExample : NSObject
 
  - (void)runBlock:(void (^)(NSString))block {
     NSLog(@"Block argument returns nothing and takes in a NSString object.");
-    block(@"Argument given to block to execute."); // Calling block.
+    block(@"Argument given to block to execute."); // 블록 호출.
  }
 
  @end
 
 
 ///////////////////////////////////////
-// Memory Management
+// 메모리 관리
 ///////////////////////////////////////
 /*
-For each object used in an application, memory must be allocated for that object. When the application
-is done using that object, memory must be deallocated to ensure application efficiency.
-Objective-C does not use garbage collection and instead uses reference counting. As long as
-there is at least one reference to an object (also called "owning" an object), then the object
-will be available to use (known as "ownership").
+애플리케이션에서 사용되는 각 객체에 대해 해당 객체에 대한 메모리를 할당해야 합니다. 애플리케이션이
+해당 객체 사용을 마치면 애플리케이션 효율성을 보장하기 위해 메모리를 해제해야 합니다.
+Objective-C는 가비지 컬렉션을 사용하지 않고 대신 참조 계산을 사용합니다.
+객체에 대한 참조가 하나 이상 있는 한(객체를 "소유"한다고도 함), 객체는
+사용할 수 있습니다("소유권"이라고 함).
 
-When an instance owns an object, its reference counter is increments by one. When the
-object is released, the reference counter decrements by one. When reference count is zero,
-the object is removed from memory.
+인스턴스가 객체를 소유하면 참조 카운터가 1 증가합니다. 객체가
+해제되면 참조 카운터가 1 감소합니다. 참조 카운트가 0이 되면
+객체는 메모리에서 제거됩니다.
 
-With all object interactions, follow the pattern of:
-(1) create the object, (2) use the object, (3) then free the object from memory.
+모든 객체 상호 작용에서 다음 패턴을 따르십시오.
+(1) 객체 생성, (2) 객체 사용, (3) 메모리에서 객체 해제.
 */
 
-MyClass *classVar = [MyClass alloc]; // 'alloc' sets classVar's reference count to one. Returns pointer to object
-[classVar release]; // Decrements classVar's reference count
-// 'retain' claims ownership of existing object instance and increments reference count. Returns pointer to object
-MyClass *newVar = [classVar retain]; // If classVar is released, object is still in memory because newVar is owner
-[classVar autorelease]; // Removes ownership of object at end of @autoreleasepool block. Returns pointer to object
+MyClass *classVar = [MyClass alloc]; // 'alloc'은 classVar의 참조 카운트를 1로 설정합니다. 객체에 대한 포인터를 반환합니다.
+[classVar release]; // classVar의 참조 카운트를 감소시킵니다.
+// 'retain'은 기존 객체 인스턴스의 소유권을 주장하고 참조 카운트를 증가시킵니다. 객체에 대한 포인터를 반환합니다.
+MyClass *newVar = [classVar retain]; // classVar가 해제되어도 newVar가 소유자이므로 객체는 여전히 메모리에 있습니다.
+[classVar autorelease]; // @autoreleasepool 블록 끝에서 객체의 소유권을 제거합니다. 객체에 대한 포인터를 반환합니다.
 
-// @property can use 'retain' and 'assign' as well for small convenient definitions
-@property (retain) MyClass *instance; // Release old value and retain a new one (strong reference)
-@property (assign) NSSet *set; // Pointer to new value without retaining/releasing old (weak reference)
+// @property는 작은 편리한 정의를 위해 'retain' 및 'assign'을 사용할 수 있습니다.
+@property (retain) MyClass *instance; // 이전 값을 해제하고 새 값을 유지합니다(강한 참조).
+@property (assign) NSSet *set; // 이전 값을 유지/해제하지 않고 새 값에 대한 포인터(약한 참조).
 
-// Automatic Reference Counting (ARC)
-// Because memory management can be a pain, Xcode 4.2 and iOS 4 introduced Automatic Reference Counting (ARC).
-// ARC is a compiler feature that inserts retain, release, and autorelease automatically for you, so when using ARC,
-// you must not use retain, release, or autorelease
+// 자동 참조 계산(ARC)
+// 메모리 관리가 번거로울 수 있으므로 Xcode 4.2 및 iOS 4에서 자동 참조 계산(ARC)이 도입되었습니다.
+// ARC는 retain, release 및 autorelease를 자동으로 삽입하는 컴파일러 기능이므로 ARC를 사용하는 경우
+// retain, release 또는 autorelease를 사용해서는 안 됩니다.
 MyClass *arcMyClass = [[MyClass alloc] init];
-// ... code using arcMyClass
-// Without ARC, you will need to call: [arcMyClass release] after you're done using arcMyClass. But with ARC,
-// there is no need. It will insert this release statement for you
+// ... arcMyClass를 사용하는 코드
+// ARC가 없으면 arcMyClass 사용을 마친 후 [arcMyClass release]를 호출해야 합니다. 그러나 ARC를 사용하면
+// 그럴 필요가 없습니다. 이 해제 문을 자동으로 삽입합니다.
 
-// As for the 'assign' and 'retain' @property attributes, with ARC you use 'weak' and 'strong'
-@property (weak) MyClass *weakVar; // 'weak' does not take ownership of object. If original instance's reference count
-// is set to zero, weakVar will automatically receive value of nil to avoid application crashing
-@property (strong) MyClass *strongVar; // 'strong' takes ownership of object. Ensures object will stay in memory to use
+// 'assign' 및 'retain' @property 속성의 경우 ARC를 사용하여 'weak' 및 'strong'을 사용합니다.
+@property (weak) MyClass *weakVar; // 'weak'은 객체의 소유권을 갖지 않습니다. 원래 인스턴스의 참조 카운트가
+// 0으로 설정되면 weakVar는 애플리케이션 충돌을 피하기 위해 자동으로 nil 값을 받습니다.
+@property (strong) MyClass *strongVar; // 'strong'은 객체의 소유권을 갖습니다. 객체가 메모리에 남아 있도록 보장합니다.
 
-// For regular variables (not @property declared variables), use the following:
-__strong NSString *strongString; // Default. Variable is retained in memory until it leaves it's scope
-__weak NSSet *weakSet; // Weak reference to existing object. When existing object is released, weakSet is set to nil
-__unsafe_unretained NSArray *unsafeArray; // Like __weak, but unsafeArray not set to nil when existing object is released
+// 일반 변수(@property로 선언되지 않은 변수)의 경우 다음을 사용합니다.
+__strong NSString *strongString; // 기본값. 변수는 범위를 벗어날 때까지 메모리에 유지됩니다.
+__weak NSSet *weakSet; // 기존 객체에 대한 약한 참조. 기존 객체가 해제되면 weakSet은 nil로 설정됩니다.
+__unsafe_unretained NSArray *unsafeArray; // __weak와 같지만 기존 객체가 해제될 때 unsafeArray는 nil로 설정되지 않습니다.
 ```
 
-## Further Reading
+## 더 읽을거리
 
-[Wikipedia Objective-C](http://en.wikipedia.org/wiki/Objective-C)
+[위키백과 Objective-C](http://en.wikipedia.org/wiki/Objective-C)
 
-[Programming with Objective-C. Apple PDF book](https://developer.apple.com/library/ios/documentation/cocoa/conceptual/ProgrammingWithObjectiveC/ProgrammingWithObjectiveC.pdf)
+[Objective-C로 프로그래밍하기. Apple PDF 책](https://developer.apple.com/library/ios/documentation/cocoa/conceptual/ProgrammingWithObjectiveC/ProgrammingWithObjectiveC.pdf)
 
-[Programming with Objective-C for iOS](https://developer.apple.com/library/ios/documentation/General/Conceptual/DevPedia-CocoaCore/ObjectiveC.html)
+[iOS용 Objective-C로 프로그래밍하기](https://developer.apple.com/library/ios/documentation/General/Conceptual/DevPedia-CocoaCore/ObjectiveC.html)
 
-[Programming with Objective-C for Mac OSX](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/Introduction/Introduction.html)
+[Mac OSX용 Objective-C로 프로그래밍하기](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/Introduction/Introduction.html)
 
-[iOS For High School Students: Getting Started](http://www.raywenderlich.com/5600/ios-for-high-school-students-getting-started)
+[고등학생을 위한 iOS: 시작하기](http://www.raywenderlich.com/5600/ios-for-high-school-students-getting-started)

--- a/ko/odin.md
+++ b/ko/odin.md
@@ -7,23 +7,20 @@ contributors:
 filename: learnodin.odin
 ---
 
-Odin was created by Bill "gingerBill" Hall. It is a general-purpose systems
-programming language that emphasizes simplicity, readability, and performance
-without garbage collection. Odin bills itself as "the C alternative for the
-joy of programming."
+Odin은 Bill "gingerBill" Hall에 의해 만들어졌습니다. 가비지 컬렉션 없이 단순성, 가독성 및 성능을 강조하는 범용 시스템 프로그래밍 언어입니다. Odin은 자신을 "프로그래밍의 즐거움을 위한 C 대안"이라고 소개합니다.
 
 ```
-// Single line comments start with two slashes.
+// 한 줄 주석은 두 개의 슬래시로 시작합니다.
 
 /*
-   Multiline comments start with slash-star,
-   and end with star-slash. They can be nested!
+   여러 줄 주석은 슬래시-별표로 시작하고,
+   별표-슬래시로 끝납니다. 중첩될 수 있습니다!
    /*
-       Like this!
+       이처럼!
    */
 */
 
-// This is the classic "hello world" program in Odin.
+// 이것은 Odin의 고전적인 "hello world" 프로그램입니다.
 package main
 
 import "core:fmt"
@@ -33,125 +30,125 @@ main :: proc() {
 }
 
 ////////////////////////////////////////////////////
-## 1. Basic Data Types and Operators
+## 1. 기본 데이터 타입 및 연산자
 ////////////////////////////////////////////////////
 
-// Integers - Odin has explicit sized integer types
-x: i32 = 42          // 32-bit signed integer
-y: u64 = 100         // 64-bit unsigned integer
-z: int = 123         // Platform-dependent integer (usually i64)
+// 정수 - Odin은 명시적인 크기의 정수 타입을 가집니다
+x: i32 = 42          // 32비트 부호 있는 정수
+y: u64 = 100         // 64비트 부호 없는 정수
+z: int = 123         // 플랫폼 종속 정수 (보통 i64)
 
-// You can use underscores for readability in numbers
+// 가독성을 위해 숫자에 밑줄을 사용할 수 있습니다
 big_number := 1_000_000
 
-// Floating point numbers
-pi: f32 = 3.14159    // 32-bit float
-e: f64 = 2.71828     // 64-bit float (default for float literals)
+// 부동 소수점 숫자
+pi: f32 = 3.14159    // 32비트 부동 소수점
+e: f64 = 2.71828     // 64비트 부동 소수점 (부동 소수점 리터럴의 기본값)
 
-// Boolean
+// 불리언
 is_true: bool = true
 is_false: bool = false
 
-// Rune (Unicode character)
+// 룬 (유니코드 문자)
 letter: rune = 'A'
 emoji: rune = '🚀'
 
-// Strings
+// 문자열
 name: string = "Odin Programming"
-raw_string := `C:\Windows\System32`  // Raw string with backticks
+raw_string := `C:\Windows\System32`  // 백틱을 사용한 원시 문자열
 
-// String length (in bytes, not characters!)
+// 문자열 길이 (문자가 아닌 바이트 단위!)
 length := len(name)
 
-// Arithmetic operators work as you'd expect
+// 산술 연산자는 예상대로 작동합니다
 result := 10 + 5    // 15
 diff := 10 - 5      // 5
 product := 10 * 5   // 50
 quotient := 10 / 5  // 2
 remainder := 10 % 3 // 1
 
-// Comparison operators
+// 비교 연산자
 is_equal := 10 == 10        // true
 not_equal := 10 != 5        // true
 greater := 10 > 5           // true
 less_equal := 5 <= 10       // true
 
-// Logical operators
+// 논리 연산자
 and_result := true && false  // false
 or_result := true || false   // true
 not_result := !true          // false
 
-// Bitwise operators
+// 비트 연산자
 bit_and := 0b1010 & 0b1100   // 0b1000
 bit_or := 0b1010 | 0b1100    // 0b1110
-bit_xor := 0b1010 ~ 0b1100   // 0b0110 (note: ~ is XOR in Odin)
-bit_not := ~0b1010           // bitwise NOT
+bit_xor := 0b1010 ~ 0b1100   // 0b0110 (참고: Odin에서 ~는 XOR입니다)
+bit_not := ~0b1010           // 비트 NOT
 
 ////////////////////////////////////////////////////
-## 2. Variables and Constants
+## 2. 변수와 상수
 ////////////////////////////////////////////////////
 
-// Variable declaration with type inference
-some_number := 42            // Type inferred as int
-some_text := "Hello"         // Type inferred as string
+// 타입 추론을 사용한 변수 선언
+some_number := 42            // int로 타입 추론됨
+some_text := "Hello"         // string으로 타입 추론됨
 
-// Explicit type declaration
+// 명시적 타입 선언
 explicit_int: int = 42
 explicit_float: f64 = 3.14
 
-// Uninitialized variables are zero-initialized
-uninitialized_int: int       // Defaults to 0
-uninitialized_bool: bool     // Defaults to false
-uninitialized_string: string // Defaults to ""
+// 초기화되지 않은 변수는 0으로 초기화됩니다
+uninitialized_int: int       // 기본값 0
+uninitialized_bool: bool     // 기본값 false
+uninitialized_string: string // 기본값 ""
 
-// Constants are defined with ::
+// 상수는 ::로 정의됩니다
 PI :: 3.14159
 MESSAGE :: "This is a constant"
 
-// Typed constants
+// 타입이 있는 상수
 TYPED_CONSTANT : f32 : 2.71828
 
-// Multiple assignment
+// 다중 할당
 a, b := 10, 20
-a, b = b, a  // Swap values
+a, b = b, a  // 값 교환
 
 ////////////////////////////////////////////////////
-## 3. Arrays and Slices
+## 3. 배열과 슬라이스
 ////////////////////////////////////////////////////
 
-// Fixed-size arrays
+// 고정 크기 배열
 numbers: [5]int = {1, 2, 3, 4, 5}
 chars: [3]rune = {'A', 'B', 'C'}
 
-// Array with inferred size
+// 크기가 추론된 배열
 inferred := [..]int{10, 20, 30, 40}
 
-// Zero-initialized array
-zeros: [10]int  // All elements are 0
+// 0으로 초기화된 배열
+zeros: [10]int  // 모든 요소는 0입니다
 
-// Accessing array elements
+// 배열 요소 접근
 first := numbers[0]     // 1
 last := numbers[4]      // 5
 array_length := len(numbers)  // 5
 
-// Slices - dynamic views into arrays
-slice: []int = {1, 2, 3, 4, 5}  // Slice literal
-array_slice := numbers[1:4]     // Slice of array from index 1 to 3
-full_slice := numbers[:]        // Slice of entire array
+// 슬라이스 - 배열에 대한 동적 뷰
+slice: []int = {1, 2, 3, 4, 5}  // 슬라이스 리터럴
+array_slice := numbers[1:4]     // 인덱스 1에서 3까지의 배열 슬라이스
+full_slice := numbers[:]        // 전체 배열의 슬라이스
 
-// Dynamic arrays - can grow and shrink
+// 동적 배열 - 커지거나 작아질 수 있음
 dynamic_array: [dynamic]int
 append(&dynamic_array, 1)
-append(&dynamic_array, 2, 3, 4)  // Append multiple elements
+append(&dynamic_array, 2, 3, 4)  // 여러 요소 추가
 
-// Remember to clean up dynamic arrays
+// 동적 배열을 정리하는 것을 잊지 마십시오
 defer delete(dynamic_array)
 
 ////////////////////////////////////////////////////
-## 4. Control Flow
+## 4. 제어 흐름
 ////////////////////////////////////////////////////
 
-// If statements
+// If 문
 age := 25
 if age >= 18 {
     fmt.println("Adult")
@@ -161,48 +158,48 @@ if age >= 18 {
     fmt.println("Child")
 }
 
-// For loops - Odin's only loop construct
-// C-style for loop
+// For 루프 - Odin의 유일한 루프 구조
+// C 스타일 for 루프
 for i := 0; i < 10; i += 1 {
     fmt.println(i)
 }
 
-// While-style loop
+// While 스타일 루프
 counter := 0
 for counter < 5 {
     fmt.println(counter)
     counter += 1
 }
 
-// Infinite loop
+// 무한 루프
 for {
-    // This runs forever (until break)
-    break  // Exit the loop
+    // 이것은 영원히 실행됩니다 (break까지)
+    break  // 루프 종료
 }
 
-// Iterating over arrays/slices with index
+// 인덱스로 배열/슬라이스 반복
 numbers_array := [3]int{10, 20, 30}
 for value, index in numbers_array {
     fmt.printf("Index %d: Value %d\n", index, value)
 }
 
-// Iterating over just values
+// 값만 반복
 for value in numbers_array {
     fmt.println(value)
 }
 
-// Switch statements
+// Switch 문
 day := "Monday"
 switch day {
 case "Monday", "Tuesday", "Wednesday", "Thursday", "Friday":
     fmt.println("Weekday")
 case "Saturday", "Sunday":
     fmt.println("Weekend")
-case:  // Default case
+case:  // 기본 케이스
     fmt.println("Unknown day")
 }
 
-// Switch with no condition (like if-else chain)
+// 조건 없는 Switch (if-else 체인과 같음)
 switch {
 case age < 13:
     fmt.println("Child")
@@ -213,28 +210,28 @@ case:
 }
 
 ////////////////////////////////////////////////////
-## 5. Procedures (Functions)
+## 5. 프로시저 (함수)
 ////////////////////////////////////////////////////
 
-// Basic procedure definition
+// 기본 프로시저 정의
 add :: proc(a: int, b: int) -> int {
     return a + b
 }
 
-// Procedure with multiple return values
+// 다중 반환 값이 있는 프로시저
 divide :: proc(a: int, b: int) -> (int, bool) {
     if b == 0 {
-        return 0, false  // Division by zero
+        return 0, false  // 0으로 나누기
     }
     return a / b, true
 }
 
-// Using the procedure
+// 프로시저 사용
 sum := add(5, 3)                    // 8
 quotient, ok := divide(10, 2)       // 5, true
 quotient_bad, ok_bad := divide(10, 0) // 0, false
 
-// Procedure with default parameters (using overloading)
+// 기본 매개변수가 있는 프로시저 (오버로딩 사용)
 greet :: proc(name: string) {
     fmt.printf("Hello, %s!\n", name)
 }
@@ -243,7 +240,7 @@ greet :: proc() {
     greet("World")
 }
 
-// Variadic procedures (variable number of arguments)
+// 가변 프로시저 (가변 개수의 인수)
 sum_all :: proc(numbers: ..int) -> int {
     total := 0
     for number in numbers {
@@ -255,48 +252,48 @@ sum_all :: proc(numbers: ..int) -> int {
 result_sum := sum_all(1, 2, 3, 4, 5)  // 15
 
 ////////////////////////////////////////////////////
-## 6. Structs
+## 6. 구조체
 ////////////////////////////////////////////////////
 
-// Struct definition
+// 구조체 정의
 Person :: struct {
     name: string,
     age:  int,
     height: f32,
 }
 
-// Creating struct instances
+// 구조체 인스턴스 생성
 person1 := Person{
     name = "Alice",
     age = 30,
     height = 5.6,
 }
 
-// Partial initialization (remaining fields are zero-initialized)
+// 부분 초기화 (나머지 필드는 0으로 초기화됨)
 person2 := Person{
     name = "Bob",
-    // age and height default to 0
+    // age와 height는 기본적으로 0입니다
 }
 
-// Accessing struct fields
+// 구조체 필드 접근
 fmt.printf("%s is %d years old\n", person1.name, person1.age)
 
-// Modifying struct fields
+// 구조체 필드 수정
 person1.age = 31
 
-// Procedure that works with structs
-celebrate_birthday :: proc(person: ^Person) {  // ^ means pointer
+// 구조체와 함께 작동하는 프로시저
+celebrate_birthday :: proc(person: ^Person) {  // ^는 포인터를 의미합니다
     person.age += 1
     fmt.printf("Happy birthday! %s is now %d\n", person.name, person.age)
 }
 
-celebrate_birthday(&person1)  // Pass address with &
+celebrate_birthday(&person1)  // &로 주소 전달
 
 ////////////////////////////////////////////////////
-## 7. Enums and Unions
+## 7. 열거형과 유니온
 ////////////////////////////////////////////////////
 
-// Enums
+// 열거형
 Color :: enum {
     RED,
     GREEN,
@@ -306,14 +303,14 @@ Color :: enum {
 
 my_color := Color.RED
 
-// Enums with explicit values
+// 명시적 값을 가진 열거형
 Status :: enum u8 {
     OK = 0,
     ERROR = 1,
     WARNING = 2,
 }
 
-// Unions (tagged unions)
+// 유니온 (태그된 유니온)
 Shape :: union {
     Circle: struct { radius: f32 },
     Rectangle: struct { width, height: f32 },
@@ -322,7 +319,7 @@ Shape :: union {
 
 my_shape := Shape(Circle{{radius = 5.0}})
 
-// Pattern matching with unions
+// 유니온을 사용한 패턴 매칭
 switch shape in my_shape {
 case Circle:
     fmt.printf("Circle with radius %.2f\n", shape.radius)
@@ -334,36 +331,36 @@ case Triangle:
 }
 
 ////////////////////////////////////////////////////
-## 8. Maps
+## 8. 맵
 ////////////////////////////////////////////////////
 
-// Map declaration
+// 맵 선언
 scores: map[string]int
 
-// Initialize map
+// 맵 초기화
 scores = make(map[string]int)
-defer delete(scores)  // Clean up when done
+defer delete(scores)  // 완료 시 정리
 
-// Add key-value pairs
+// 키-값 쌍 추가
 scores["Alice"] = 95
 scores["Bob"] = 87
 scores["Charlie"] = 92
 
-// Access values
+// 값 접근
 alice_score := scores["Alice"]  // 95
 
-// Check if key exists
+// 키 존재 여부 확인
 bob_score, exists := scores["Bob"]
 if exists {
     fmt.printf("Bob's score: %d\n", bob_score)
 }
 
-// Iterate over map
+// 맵 반복
 for name, score in scores {
     fmt.printf("%s: %d\n", name, score)
 }
 
-// Map literal
+// 맵 리터럴
 ages := map[string]int{
     "Alice" = 30,
     "Bob" = 25,
@@ -372,40 +369,40 @@ ages := map[string]int{
 defer delete(ages)
 
 ////////////////////////////////////////////////////
-## 9. Pointers and Memory Management
+## 9. 포인터와 메모리 관리
 ////////////////////////////////////////////////////
 
-// Pointers
+// 포인터
 number := 42
-number_ptr := &number        // Get address of number
-value := number_ptr^         // Dereference pointer (get value)
+number_ptr := &number        // 숫자의 주소 가져오기
+value := number_ptr^         // 포인터 역참조 (값 가져오기)
 
 fmt.printf("Value: %d, Address: %p\n", value, number_ptr)
 
-// Dynamic memory allocation
-// new() allocates and returns a pointer
+// 동적 메모리 할당
+// new()는 포인터를 할당하고 반환합니다
 int_ptr := new(int)
 int_ptr^ = 100
-defer free(int_ptr)  // Clean up memory
+defer free(int_ptr)  // 메모리 정리
 
-// make() for complex types
-my_slice := make([]int, 5)    // Slice with length 5
+// 복잡한 타입을 위한 make()
+my_slice := make([]int, 5)    // 길이가 5인 슬라이스
 defer delete(my_slice)
 
 ////////////////////////////////////////////////////
-## 10. Error Handling
+## 10. 오류 처리
 ////////////////////////////////////////////////////
 
-// Odin uses multiple return values for error handling
+// Odin은 오류 처리를 위해 다중 반환 값을 사용합니다
 read_file :: proc(filename: string) -> (string, bool) {
-    // Simulate file reading
+    // 파일 읽기 시뮬레이션
     if filename == "" {
-        return "", false  // Error case
+        return "", false  // 오류 케이스
     }
-    return "file contents", true  // Success case
+    return "file contents", true  // 성공 케이스
 }
 
-// Using the error-returning procedure
+// 오류 반환 프로시저 사용
 content, success := read_file("myfile.txt")
 if !success {
     fmt.println("Failed to read file")
@@ -413,9 +410,9 @@ if !success {
     fmt.printf("File content: %s\n", content)
 }
 
-// Common pattern with or_return
+// or_return을 사용한 일반적인 패턴
 parse_number :: proc(s: string) -> (int, bool) {
-    // This is a simplified example
+    // 이것은 단순화된 예입니다
     if s == "42" {
         return 42, true
     }
@@ -423,59 +420,59 @@ parse_number :: proc(s: string) -> (int, bool) {
 }
 
 example_with_error_handling :: proc() -> bool {
-    // or_return automatically returns false if the second value is false
+    // or_return은 두 번째 값이 false이면 자동으로 false를 반환합니다
     num := parse_number("42") or_return
     fmt.printf("Parsed number: %d\n", num)
     return true
 }
 
 ////////////////////////////////////////////////////
-## 11. Packages and Imports
+## 11. 패키지와 임포트
 ////////////////////////////////////////////////////
 
-// Every .odin file starts with a package declaration
-// package main  // (Already declared at the top)
+// 모든 .odin 파일은 패키지 선언으로 시작합니다
+// package main  // (이미 맨 위에 선언됨)
 
-// Import from core library
+// 코어 라이브러리에서 임포트
 import "core:fmt"
 import "core:strings"
 import "core:os"
 
-// Import with alias
+// 별칭으로 임포트
 import str "core:strings"
 
-// Using imported procedures
+// 임포트된 프로시저 사용
 text := "Hello, World!"
 upper_text := strings.to_upper(text)
 fmt.println(upper_text)
 
-// Import from vendor packages (external libraries)
+// 벤더 패키지에서 임포트 (외부 라이브러리)
 // import "vendor:raylib"
 
 ////////////////////////////////////////////////////
-## 12. Compile-time Features
+## 12. 컴파일 타임 기능
 ////////////////////////////////////////////////////
 
-// Compile-time conditionals
+// 컴파일 타임 조건문
 when ODIN_OS == .Windows {
-    // Windows-specific code
+    // Windows 특정 코드
     fmt.println("Running on Windows")
 } else when ODIN_OS == .Linux {
-    // Linux-specific code
+    // Linux 특정 코드
     fmt.println("Running on Linux")
 } else {
-    // Other platforms
+    // 다른 플랫폼
     fmt.println("Running on other platform")
 }
 
-// Compile-time constants
+// 컴파일 타임 상수
 ODIN_DEBUG :: #config(DEBUG, false)
 
 when ODIN_DEBUG {
     fmt.println("Debug mode enabled")
 }
 
-// Generics (Parametric polymorphism)
+// 제네릭 (매개변수 다형성)
 Generic_Array :: struct($T: typeid) {
     data: []T,
 }
@@ -484,14 +481,14 @@ max :: proc(a: $T, b: T) -> T {
     return a if a > b else b
 }
 
-max_int := max(10, 20)      // T becomes int
-max_float := max(3.14, 2.71) // T becomes f64
+max_int := max(10, 20)      // T는 int가 됩니다
+max_float := max(3.14, 2.71) // T는 f64가 됩니다
 
 ////////////////////////////////////////////////////
-## 13. Built-in Data Structures
+## 13. 내장 데이터 구조
 ////////////////////////////////////////////////////
 
-// Bit sets for flags
+// 플래그를 위한 비트 세트
 File_Mode :: enum {
     READ,
     WRITE,
@@ -499,79 +496,75 @@ File_Mode :: enum {
 }
 
 permissions: bit_set[File_Mode]
-permissions |= {.READ, .WRITE}        // Set multiple flags
-permissions &~= {.WRITE}              // Remove flag
-has_read := .READ in permissions      // Check flag
-is_readonly := permissions == {.READ} // Compare sets
+permissions |= {.READ, .WRITE}        // 여러 플래그 설정
+permissions &~= {.WRITE}              // 플래그 제거
+has_read := .READ in permissions      // 플래그 확인
+is_readonly := permissions == {.READ} // 세트 비교
 
-// Complex numbers
+// 복소수
 z1 := complex64(3 + 4i)
 z2 := complex64(1 - 2i)
 sum := z1 + z2                        // (4 + 2i)
 magnitude := abs(z1)                  // 5.0
 
-// Matrices for linear algebra
+// 선형 대수를 위한 행렬
 transform := matrix[3, 3]f32{
-    1, 0, 5,  // Translation X = 5
-    0, 1, 3,  // Translation Y = 3
-    0, 0, 1,  // Homogeneous coordinate
+    1, 0, 5,  // X축으로 5만큼 이동
+    0, 1, 3,  // Y축으로 3만큼 이동
+    0, 0, 1,  // 동차 좌표
 }
 
 point := [3]f32{10, 20, 1}
-transformed := transform * point      // Matrix multiplication
+transformed := transform * point      // 행렬 곱셈
 
-// Quaternions for 3D rotations
-identity_rot := quaternion128{0, 0, 0, 1}  // No rotation
-rotation_90_z := quaternion128{0, 0, 0.707, 0.707}  // 90° around Z
+// 3D 회전을 위한 쿼터니언
+identity_rot := quaternion128{0, 0, 0, 1}  // 회전 없음
+rotation_90_z := quaternion128{0, 0, 0.707, 0.707}  // Z축 주위로 90°
 
 ////////////////////////////////////////////////////
-## 14. Context System and Defer
+## 14. 컨텍스트 시스템과 Defer
 ////////////////////////////////////////////////////
 
-// Odin has an implicit context system for threading allocators,
-// loggers, and other utilities through your program
+// Odin은 스레딩 할당자, 로거 및 기타 유틸리티를 프로그램을 통해 전달하기 위한 암시적 컨텍스트 시스템을 가지고 있습니다
 
 example_with_context :: proc() {
-    // Save current context
+    // 현재 컨텍스트 저장
     old_allocator := context.allocator
 
-    // Use a different allocator temporarily
+    // 일시적으로 다른 할당자 사용
     temp_allocator := context.temp_allocator
     context.allocator = temp_allocator
 
-    // All allocations in this scope use temp_allocator
+    // 이 범위의 모든 할당은 temp_allocator를 사용합니다
     temp_data := make([]int, 100)
-    // No need to delete temp_data - it's automatically cleaned up
+    // temp_data를 삭제할 필요가 없습니다 - 자동으로 정리됩니다
 
-    // Restore original allocator
+    // 원래 할당자 복원
     context.allocator = old_allocator
 }
 
-// defer ensures cleanup happens when scope exits
+// defer는 범위가 종료될 때 정리가 수행되도록 보장합니다
 resource_management_example :: proc() {
     file_handle := os.open("example.txt", os.O_RDONLY, 0) or_return
-    defer os.close(file_handle)  // Always closed when function exits
+    defer os.close(file_handle)  // 함수가 종료될 때 항상 닫힘
 
     buffer := make([]u8, 1024)
-    defer delete(buffer)  // Always freed when function exits
+    defer delete(buffer)  // 함수가 종료될 때 항상 해제됨
 
-    // Use file_handle and buffer...
-    // They're automatically cleaned up even if we return early
+    // file_handle과 버퍼 사용...
+    // 일찍 반환하더라도 자동으로 정리됩니다
 }
 ```
 
-## Further Reading
+## 더 읽을거리
 
-The [Odin Programming Language website](https://odin-lang.org/) provides
-excellent documentation and examples.
+[Odin 프로그래밍 언어 웹사이트](https://odin-lang.org/)는 훌륭한 문서와 예제를 제공합니다.
 
-The [overview](https://odin-lang.org/docs/overview/) covers much of the
-language in detail.
+[개요](https://odin-lang.org/docs/overview/)는 언어의 많은 부분을 자세히 다룹니다.
 
-The [GitHub examples repository](https://github.com/odin-lang/examples)
-contains idiomatic Odin code examples.
+[GitHub 예제 저장소](https://github.com/odin-lang/examples)에는 관용적인 Odin 코드 예제가 포함되어 있습니다.
 
-For learning resources:
-- ["Understanding the Odin Programming Language" by Karl Zylinski](https://odinbook.com)
-- [Odin Discord](https://discord.gg/sVBPHEv) for community support
-- [FAQ](https://odin-lang.org/docs/faq/) for common questions
+학습 자료:
+- [Karl Zylinski의 "Odin 프로그래밍 언어 이해하기"](https://odinbook.com)
+- 커뮤니티 지원을 위한 [Odin Discord](https://discord.gg/sVBPHEv)
+- 일반적인 질문에 대한 [FAQ](https://odin-lang.org/docs/faq/)

--- a/ko/paren.md
+++ b/ko/paren.md
@@ -9,33 +9,33 @@ contributors:
   - ["Claudson Martins", "https://github.com/claudsonm"]
 ---
 
-[Paren](https://bitbucket.org/ktg/paren) is a dialect of Lisp. It is designed to be an embedded language.
+[Paren](https://bitbucket.org/ktg/paren)은 Lisp의 방언입니다. 임베디드 언어로 설계되었습니다.
 
-Some examples are from [Racket](../racket/).
+일부 예제는 [Racket](../racket/)에서 가져왔습니다.
 
 ```scheme
-;;; Comments
-# comments
+;;; 주석
+# 주석
 
-;; Single line comments start with a semicolon or a sharp sign
+;; 한 줄 주석은 세미콜론 또는 샵 기호로 시작합니다.
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 1. Primitive Datatypes and Operators
+;; 1. 기본 데이터 타입 및 연산자
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;; Numbers
+;;; 숫자
 123 ; int
 3.14 ; double
 6.02e+23 ; double
 (int 3.14) ; => 3 : int
 (double 123) ; => 123 : double
 
-;; Function application is written (f x y z ...)
-;; where f is a function and x, y, z, ... are operands
-;; If you want to create a literal list of data, use (quote) to stop it from
-;; being evaluated
+;; 함수 적용은 (f x y z ...)로 작성됩니다.
+;; 여기서 f는 함수이고 x, y, z, ...는 피연산자입니다.
+;; 리터럴 데이터 목록을 만들고 싶다면 (quote)를 사용하여
+;; 평가되지 않도록 합니다.
 (quote (+ 1 2)) ; => (+ 1 2)
-;; Now, some arithmetic operations
+;; 이제 몇 가지 산술 연산
 (+ 1 1)  ; => 2
 (- 8 1)  ; => 7
 (* 10 2) ; => 20
@@ -44,132 +44,132 @@ Some examples are from [Racket](../racket/).
 (% 5 2) ; => 1
 (/ 5.0 2) ; => 2.5
 
-;;; Booleans
-true ; for true
-false ; for false
+;;; 불리언
+true ; 참
+false ; 거짓
 (! true) ; => false
-(&& true false (prn "doesn't get here")) ; => false
-(|| false true (prn "doesn't get here")) ; => true
+(&& true false (prn "여기에는 도달하지 않음")) ; => false
+(|| false true (prn "여기에는 도달하지 않음")) ; => true
 
-;;; Characters are ints.
+;;; 문자는 정수입니다.
 (char-at "A" 0) ; => 65
 (chr 65) ; => "A"
 
-;;; Strings are fixed-length array of characters.
+;;; 문자열은 고정 길이 문자 배열입니다.
 "Hello, world!"
-"Benjamin \"Bugsy\" Siegel"   ; backslash is an escaping character
-"Foo\tbar\r\n" ; includes C escapes: \t \r \n
+"Benjamin \"Bugsy\" Siegel"   ; 백슬래시는 이스케이프 문자입니다.
+"Foo\tbar\r\n" ; C 이스케이프 포함: \t \r \n
 
-;; Strings can be added too!
+;; 문자열도 추가할 수 있습니다!
 (strcat "Hello " "world!") ; => "Hello world!"
 
-;; A string can be treated like a list of characters
+;; 문자열은 문자 목록처럼 처리할 수 있습니다.
 (char-at "Apple" 0) ; => 65
 
-;; Printing is pretty easy
+;; 출력은 매우 쉽습니다.
 (pr "I'm" "Paren. ") (prn "Nice to meet you!")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 2. Variables
+;; 2. 변수
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; You can create or set a variable using (set)
-;; a variable name can use any character except: ();#"
+;; (set)을 사용하여 변수를 생성하거나 설정할 수 있습니다.
+;; 변수 이름에는 다음을 제외한 모든 문자를 사용할 수 있습니다: ();#"
 (set some-var 5) ; => 5
 some-var ; => 5
 
-;; Accessing a previously unassigned variable is an exception
-; x ; => Unknown variable: x : nil
+;; 이전에 할당되지 않은 변수에 액세스하면 예외가 발생합니다.
+; x ; => 알 수 없는 변수: x : nil
 
-;; Local binding: Use lambda calculus! 'a' and 'b' are bound to '1' and '2' only within the (fn ...)
+;; 지역 바인딩: 람다 계산법을 사용하십시오! 'a'와 'b'는 (fn ...) 내에서만 '1'과 '2'에 바인딩됩니다.
 ((fn (a b) (+ a b)) 1 2) ; => 3
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 3. Collections
+;; 3. 컬렉션
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;; Lists
+;;; 리스트
 
-;; Lists are vector-like data structures. (Random access is O(1).)
+;; 리스트는 벡터와 유사한 데이터 구조입니다. (임의 접근은 O(1)입니다.)
 (cons 1 (cons 2 (cons 3 (list)))) ; => (1 2 3)
-;; 'list' is a convenience variadic constructor for lists
+;; 'list'는 리스트에 대한 편리한 가변 인자 생성자입니다.
 (list 1 2 3) ; => (1 2 3)
-;; and a quote can also be used for a literal list value
+;; 그리고 따옴표는 리터럴 리스트 값에도 사용할 수 있습니다.
 (quote (+ 1 2)) ; => (+ 1 2)
 
-;; Can still use 'cons' to add an item to the beginning of a list
+;; 리스트 시작 부분에 항목을 추가하기 위해 여전히 'cons'를 사용할 수 있습니다.
 (cons 0 (list 1 2 3)) ; => (0 1 2 3)
 
-;; Lists are a very basic type, so there is a *lot* of functionality for
-;; them, a few examples:
+;; 리스트는 매우 기본적인 타입이므로
+;; 많은 기능이 있습니다. 몇 가지 예:
 (map inc (list 1 2 3))          ; => (2 3 4)
 (filter (fn (x) (== 0 (% x 2))) (list 1 2 3 4))    ; => (2 4)
 (length (list 1 2 3 4))     ; => 4
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 3. Functions
+;; 3. 함수
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Use 'fn' to create functions.
-;; A function always returns the value of its last expression
+;; 'fn'을 사용하여 함수를 만듭니다.
+;; 함수는 항상 마지막 표현식의 값을 반환합니다.
 (fn () "Hello World") ; => (fn () Hello World) : fn
 
-;; Use parentheses to call all functions, including a lambda expression
+;; 람다 식을 포함한 모든 함수를 호출하려면 괄호를 사용하십시오.
 ((fn () "Hello World")) ; => "Hello World"
 
-;; Assign a function to a var
+;; 변수에 함수 할당
 (set hello-world (fn () "Hello World"))
 (hello-world) ; => "Hello World"
 
-;; You can shorten this using the function definition syntactic sugar:
+;; 함수 정의 구문 설탕을 사용하여 이것을 단축할 수 있습니다:
 (defn hello-world2 () "Hello World")
 
-;; The () in the above is the list of arguments for the function
+;; 위의 ()는 함수의 인수 목록입니다.
 (set hello
   (fn (name)
     (strcat "Hello " name)))
 (hello "Steve") ; => "Hello Steve"
 
-;; ... or equivalently, using a sugared definition:
+;; ... 또는 동등하게, 설탕을 입힌 정의를 사용하여:
 (defn hello2 (name)
   (strcat "Hello " name))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 4. Equality
+;; 4. 동등성
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; for numbers use '=='
+;; 숫자의 경우 '=='를 사용합니다.
 (== 3 3.0) ; => true
 (== 2 1) ; => false
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 5. Control Flow
+;; 5. 제어 흐름
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;; Conditionals
+;;; 조건문
 
-(if true               ; test expression
-    "this is true"   ; then expression
-    "this is false") ; else expression
+(if true               ; 테스트 표현식
+    "this is true"   ; then 표현식
+    "this is false") ; else 표현식
 ; => "this is true"
 
-;;; Loops
+;;; 루프
 
-;; for loop is for number
+;; for 루프는 숫자를 위한 것입니다.
 ;; (for SYMBOL START END STEP EXPR ..)
-(for i 0 10 2 (pr i "")) ; => prints 0 2 4 6 8 10
-(for i 0.0 10 2.5 (pr i "")) ; => prints 0 2.5 5 7.5 10
+(for i 0 10 2 (pr i "")) ; => 0 2 4 6 8 10 출력
+(for i 0.0 10 2.5 (pr i "")) ; => 0 2.5 5 7.5 10 출력
 
-;; while loop
+;; while 루프
 ((fn (i)
   (while (< i 10)
     (pr i)
-    (++ i))) 0) ; => prints 0123456789
+    (++ i))) 0) ; => 0123456789 출력
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 6. Mutation
+;; 6. 변경
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Use 'set' to assign a new value to a variable or a place
+;; 'set'을 사용하여 변수 또는 위치에 새 값을 할당합니다.
 (set n 5) ; => 5
 (set n (inc n)) ; => 6
 n ; => 6
@@ -178,19 +178,19 @@ n ; => 6
 a ; => (3 2)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 7. Macros
+;; 7. 매크로
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Macros let you extend the syntax of the language.
-;; Paren macros are easy.
-;; In fact, (defn) is a macro.
+;; 매크로를 사용하면 언어의 구문을 확장할 수 있습니다.
+;; Paren 매크로는 쉽습니다.
+;; 사실, (defn)은 매크로입니다.
 (defmacro setfn (name ...) (set name (fn ...)))
 (defmacro defn (name ...) (def name (fn ...)))
 
-;; Let's add an infix notation
+;; 중위 표기법을 추가해 봅시다.
 (defmacro infix (a op ...) (op a ...))
 (infix 1 + 2 (infix 3 * 4)) ; => 15
 
-;; Macros are not hygienic, you can clobber existing variables!
-;; They are code transformations.
+;; 매크로는 위생적이지 않으므로 기존 변수를 덮어쓸 수 있습니다!
+;; 이것들은 코드 변환입니다.
 ```

--- a/ko/powershell.md
+++ b/ko/powershell.md
@@ -8,45 +8,41 @@ contributors:
 filename: LearnPowershell.ps1
 ---
 
-PowerShell is the Windows scripting language and configuration management
-framework from Microsoft built on the .NET Framework. Windows 7 and up ship
-with PowerShell.
-Nearly all examples below can be a part of a shell script or executed directly
-in the shell.
+PowerShell은 .NET Framework를 기반으로 구축된 Microsoft의 Windows 스크립팅 언어 및 구성 관리 프레임워크입니다. Windows 7 이상에는 PowerShell이 함께 제공됩니다.
+아래의 거의 모든 예제는 셸 스크립트의 일부가 되거나 셸에서 직접 실행될 수 있습니다.
 
-A key difference with Bash is that it is mostly objects that you manipulate
-rather than plain text. After years of evolving, it resembles Python a bit.
+Bash와의 주요 차이점은 일반 텍스트가 아닌 대부분 객체를 조작한다는 것입니다. 수년간의 발전을 거쳐 Python과 약간 유사해졌습니다.
 
-[Read more here.](https://docs.microsoft.com/powershell/scripting/overview)
+[여기에서 더 읽어보세요.](https://docs.microsoft.com/powershell/scripting/overview)
 
-Powershell as a Language:
+언어로서의 PowerShell:
 
 ```powershell
-# Single line comments start with a number symbol.
+# 한 줄 주석은 숫자 기호로 시작합니다.
 
 <#
-  Multi-line comments
-  like so
+  여러 줄 주석은
+  이와 같습니다
 #>
 
 
 ####################################################
-## 1. Primitive Datatypes and Operators
+## 1. 기본 데이터 타입 및 연산자
 ####################################################
 
-# Numbers
+# 숫자
 3 # => 3
 
-# Math
+# 수학
 1 + 1   # => 2
 8 - 1   # => 7
 10 * 2  # => 20
 35 / 5  # => 7.0
 
-# Powershell uses banker's rounding,
-# meaning [int]1.5 would round to 2 but so would [int]2.5
-# Division always returns a float.
-# You must cast result to [int] to round.
+# PowerShell은 뱅커스 라운딩을 사용합니다.
+# 즉, [int]1.5는 2로 반올림되지만 [int]2.5도 마찬가지입니다.
+# 나눗셈은 항상 부동 소수점을 반환합니다.
+# 반올림하려면 결과를 [int]로 캐스팅해야 합니다.
 [int]5 / [int]3       # => 1.66666666666667
 [int]-5 / [int]3      # => -1.66666666666667
 5.0 / 3.0   # => 1.66666666666667
@@ -54,98 +50,98 @@ Powershell as a Language:
 [int]$result = 5 / 3
 $result # => 2
 
-# Modulo operation
+# 나머지 연산
 7 % 3  # => 1
 
-# Exponentiation requires longform or the built-in [Math] class.
+# 거듭제곱은 긴 형식이나 내장 [Math] 클래스가 필요합니다.
 [Math]::Pow(2,3)  # => 8
 
-# Enforce order of operations with parentheses.
+# 괄호로 연산 순서를 강제합니다.
 1 + 3 * 2  # => 7
 (1 + 3) * 2  # => 8
 
-# Boolean values are primitives (Note: the $)
+# 불리언 값은 기본 타입입니다 (참고: $)
 $True  # => True
 $False  # => False
 
-# negate with !
+# !로 부정
 !$True   # => False
 !$False  # => True
 
-# Boolean Operators
-# Note "-and" and "-or" usage
+# 불리언 연산자
+# "-and" 및 "-or" 사용법 참고
 $True -and $False  # => False
 $False -or $True   # => True
 
-# True and False are actually 1 and 0 but only support limited arithmetic.
-# However, casting the bool to int resolves this.
+# True와 False는 실제로 1과 0이지만 제한된 산술만 지원합니다.
+# 그러나 bool을 int로 캐스팅하면 이 문제가 해결됩니다.
 $True + $True # => 2
-$True * 8    # => '[System.Boolean] * [System.Int32]' is undefined
+$True * 8    # => '[System.Boolean] * [System.Int32]'는 정의되지 않았습니다
 [int]$True * 8 # => 8
 $False - 5   # => -5
 
-# Comparison operators look at the numerical value of True and False.
+# 비교 연산자는 True와 False의 숫자 값을 봅니다.
 0 -eq $False  # => True
 1 -eq $True   # => True
 2 -eq $True   # => False
 -5 -ne $False # => True
 
-# Using boolean logical operators on ints casts to booleans for evaluation.
-# but their non-cast value is returned
-# Don't mix up with bool(ints) and bitwise -band/-bor
+# 불리언 논리 연산자를 int에 사용하면 평가를 위해 불리언으로 캐스팅됩니다.
+# 그러나 캐스팅되지 않은 값이 반환됩니다.
+# bool(ints)와 비트 -band/-bor를 혼동하지 마십시오.
 [bool](0)     # => False
 [bool](4)     # => True
 [bool](-6)    # => True
 0 -band 2     # => 0
 -5 -bor 0     # => -5
 
-# Equality is -eq (equals)
+# 같음은 -eq (equals)입니다.
 1 -eq 1  # => True
 2 -eq 1  # => False
 
-# Inequality is -ne (notequals)
+# 같지 않음은 -ne (notequals)입니다.
 1 -ne 1  # => False
 2 -ne 1  # => True
 
-# More comparisons
+# 더 많은 비교
 1 -lt 10  # => True
 1 -gt 10  # => False
 2 -le 2  # => True
 2 -ge 2  # => True
 
-# Seeing whether a value is in a range
+# 값이 범위에 있는지 확인
 1 -lt 2 -and 2 -lt 3  # => True
 2 -lt 3 -and 3 -lt 2  # => False
 
-# (-is vs. -eq) -is checks if two objects are the same type.
-# -eq checks if the objects have the same values, but sometimes doesn't work
-# as expected.
-# Note: we called '[Math]' from .NET previously without the preceeding
-# namespaces. We can do the same with [Collections.ArrayList] if preferred.
-[System.Collections.ArrayList]$a = @()  # Point a at a new list
+# (-is vs. -eq) -is는 두 객체가 동일한 타입인지 확인합니다.
+# -eq는 객체가 동일한 값을 갖는지 확인하지만 때로는
+# 예상대로 작동하지 않습니다.
+# 참고: 이전에 네임스페이스 없이 .NET에서 [Math]를 호출했습니다.
+# 원하는 경우 [Collections.ArrayList]에서도 동일하게 수행할 수 있습니다.
+[System.Collections.ArrayList]$a = @()  # a를 새 목록으로 지정
 $a = (1,2,3,4)
-$b = $a                                 # => Point b at what a is pointing to
-$b -is $a.GetType()                     # => True, a and b equal same type
-$b -eq $a                               # => None! See below
-[System.Collections.Hashtable]$b = @{}  # => Point b at a new hash table
+$b = $a                                 # => b를 a가 가리키는 것으로 지정
+$b -is $a.GetType()                     # => True, a와 b는 동일한 타입
+$b -eq $a                               # => 없음! 아래 참조
+[System.Collections.Hashtable]$b = @{}  # => b를 새 해시 테이블로 지정
 $b = @{'one' = 1
        'two' = 2}
-$b -is $a.GetType()                     # => False, a and b types not equal
+$b -is $a.GetType()                     # => False, a와 b 타입이 같지 않음
 
-# Strings are created with " or ' but " is required for string interpolation
+# 문자열은 " 또는 '로 생성되지만 문자열 보간에는 "가 필요합니다.
 "This is a string."
 'This is also a string.'
 
-# Strings can be added too! But try not to do this.
+# 문자열도 추가할 수 있습니다! 하지만 이렇게 하지 마십시오.
 "Hello " + "world!"  # => "Hello world!"
 
-# A string can be treated like a list of characters
+# 문자열은 문자 목록처럼 처리할 수 있습니다.
 "Hello world!"[0]  # => 'H'
 
-# You can find the length of a string
+# 문자열의 길이를 찾을 수 있습니다.
 ("This is a string").Length  # => 16
 
-# You can also format using f-strings or formatted string literals.
+# f-문자열 또는 서식화된 문자열 리터럴을 사용하여 서식을 지정할 수도 있습니다.
 $name = "Steve"
 $age = 22
 "He said his name is $name."
@@ -155,30 +151,30 @@ $age = 22
 "$name's name is $($name.Length) characters long."
 # => "Steve's name is 5 characters long."
 
-# Strings can be compared with -eq, but are case insensitive. We can
-# force with -ceq or -ieq.
+# 문자열은 -eq로 비교할 수 있지만 대소문자를 구분하지 않습니다. -ceq 또는 -ieq로
+# 강제할 수 있습니다.
 "ab" -eq "ab"  # => True
 "ab" -eq "AB"  # => True!
 "ab" -ceq "AB"  # => False
 "ab" -ieq "AB"  # => True
 
-# Escape Characters in Powershell
-# Many languages use the '\', but Windows uses this character for
-# file paths. Powershell thus uses '`' to escape characters
-# Take caution when working with files, as '`' is a
-# valid character in NTFS filenames.
-"Showing`nEscape Chars" # => new line between Showing and Escape
-"Making`tTables`tWith`tTabs" # => Format things with tabs
+# Powershell의 이스케이프 문자
+# 많은 언어에서 '\'를 사용하지만 Windows는 이 문자를
+# 파일 경로에 사용합니다. 따라서 Powershell은 '`'를 사용하여 문자를 이스케이프합니다.
+# 파일 작업 시 '`'는 NTFS 파일 이름에서 유효한 문자이므로
+# 주의하십시오.
+"Showing`nEscape Chars" # => Showing과 Escape 사이에 새 줄
+"Making`tTables`tWith`tTabs" # => 탭으로 서식 지정
 
-# Negate pound sign to prevent comment
-# Note that the function of '#' is removed, but '#' is still present
-`#Get-Process # => Fail: not a recognized cmdlet
+# 주석을 방지하기 위해 파운드 기호 부정
+# '#'의 기능은 제거되지만 '#'는 여전히 존재합니다.
+`#Get-Process # => 실패: 인식할 수 없는 cmdlet
 
-# $null is not an object
-$null  # => None
+# $null은 객체가 아닙니다.
+$null  # => 없음
 
-# $null, 0, and empty strings and arrays all evaluate to False.
-# All other values are True
+# $null, 0, 빈 문자열 및 배열은 모두 False로 평가됩니다.
+# 다른 모든 값은 True입니다.
 function Test-Value ($value) {
   if ($value) {
     Write-Output 'True'
@@ -192,179 +188,179 @@ Test-Value ($null) # => False
 Test-Value (0)     # => False
 Test-Value ("")    # => False
 Test-Value []      # => True
-# *[] calls .NET class; creates '[]' string when passed to function
+# *[]는 .NET 클래스를 호출합니다. 함수에 전달될 때 '[]' 문자열을 생성합니다.
 Test-Value ({})    # => True
 Test-Value @()     # => False
 
 
 ####################################################
-## 2. Variables and Collections
+## 2. 변수 및 컬렉션
 ####################################################
 
-# Powershell uses the "Write-Output" function to print
+# Powershell은 "Write-Output" 함수를 사용하여 출력합니다.
 Write-Output "I'm Posh. Nice to meet you!"  # => I'm Posh. Nice to meet you!
 
-# Simple way to get input data from console
-$userInput = Read-Host "Enter some data: " # Returns the data as a string
+# 콘솔에서 입력 데이터를 간단하게 가져오는 방법
+$userInput = Read-Host "Enter some data: " # 데이터를 문자열로 반환
 
-# There are no declarations, only assignments.
-# Convention is to use camelCase or PascalCase, whatever your team uses.
+# 선언은 없고 할당만 있습니다.
+# 관례는 팀에서 사용하는 camelCase 또는 PascalCase를 사용하는 것입니다.
 $someVariable = 5
 $someVariable  # => 5
 
-# Accessing a previously unassigned variable does not throw exception.
-# The value is $null by default
+# 이전에 할당되지 않은 변수에 액세스해도 예외가 발생하지 않습니다.
+# 기본값은 $null입니다.
 
-# Ternary Operators exist in Powershell 7 and up
+# 삼항 연산자는 Powershell 7 이상에 존재합니다.
 0 ? 'yes' : 'no'  # => no
 
 
-# The default array object in Powershell is an fixed length array.
+# Powershell의 기본 배열 객체는 고정 길이 배열입니다.
 $defaultArray = "thing","thing2","thing3"
-# you can add objects with '+=', but cannot remove objects.
-$defaultArray.Add("thing4") # => Exception "Collection was of a fixed size."
-# To have a more workable array, you'll want the .NET [ArrayList] class
-# It is also worth noting that ArrayLists are significantly faster
+# '+='로 객체를 추가할 수 있지만 객체를 제거할 수는 없습니다.
+$defaultArray.Add("thing4") # => 예외 "컬렉션의 크기가 고정되었습니다."
+# 더 작업하기 쉬운 배열을 원한다면 .NET [ArrayList] 클래스를 원할 것입니다.
+# ArrayList가 훨씬 빠르다는 점도 주목할 가치가 있습니다.
 
-# ArrayLists store sequences
+# ArrayList는 시퀀스를 저장합니다.
 [System.Collections.ArrayList]$array = @()
-# You can start with a prefilled ArrayList
+# 미리 채워진 ArrayList로 시작할 수 있습니다.
 [System.Collections.ArrayList]$otherArray = @(5, 6, 7, 8)
 
-# Add to the end of a list with 'Add' (Note: produces output, append to $null)
-$array.Add(1) > $null    # $array is now [1]
-$array.Add(2) > $null    # $array is now [1, 2]
-$array.Add(4) > $null    # $array is now [1, 2, 4]
-$array.Add(3) > $null    # $array is now [1, 2, 4, 3]
-# Remove from end with index of count of objects-1; array index starts at 0
-$array.RemoveAt($array.Count-1) # => 3 and array is now [1, 2, 4]
-# Let's put it back
-$array.Add(3) > $null   # array is now [1, 2, 4, 3] again.
+# 'Add'로 목록 끝에 추가 (참고: 출력을 생성하므로 $null에 추가)
+$array.Add(1) > $null    # $array는 이제 [1]입니다.
+$array.Add(2) > $null    # $array는 이제 [1, 2]입니다.
+$array.Add(4) > $null    # $array는 이제 [1, 2, 4]입니다.
+$array.Add(3) > $null    # $array는 이제 [1, 2, 4, 3]입니다.
+# 객체 수-1의 인덱스로 끝에서 제거; 배열 인덱스는 0부터 시작
+$array.RemoveAt($array.Count-1) # => 3이고 배열은 이제 [1, 2, 4]입니다.
+# 다시 넣자
+$array.Add(3) > $null   # 배열은 이제 다시 [1, 2, 4, 3]입니다.
 
-# Access a list like you would any array
+# 다른 배열처럼 목록에 액세스
 $array[0]   # => 1
-# Look at the last element
+# 마지막 요소 보기
 $array[-1]  # => 3
-# Looking out of bounds returns nothing
-$array[4]  # blank line returned
+# 경계를 벗어나면 아무것도 반환하지 않음
+$array[4]  # 빈 줄 반환
 
-# Remove elements from a array
-$array.Remove($array[3])  # $array is now [1, 2, 4]
+# 배열에서 요소 제거
+$array.Remove($array[3])  # $array는 이제 [1, 2, 4]입니다.
 
-# Insert at index an element
-$array.Insert(2, 3)  # $array is now [1, 2, 3, 4]
+# 인덱스에 요소 삽입
+$array.Insert(2, 3)  # $array는 이제 [1, 2, 3, 4]입니다.
 
-# Get the index of the first item found matching the argument
+# 인자와 일치하는 첫 번째 항목의 인덱스 가져오기
 $array.IndexOf(2)  # => 1
-$array.IndexOf(6)  # Returns -1 as "outside array"
+$array.IndexOf(6)  # "배열 외부"로 -1 반환
 
-# You can add arrays
-# Note: values for $array and for $otherArray are not modified.
+# 배열을 추가할 수 있습니다.
+# 참고: $array 및 $otherArray의 값은 수정되지 않습니다.
 $array + $otherArray  # => [1, 2, 3, 4, 5, 6, 7, 8]
 
-# Concatenate arrays with "AddRange()"
-$array.AddRange($otherArray)  # Now $array is [1, 2, 3, 4, 5, 6, 7, 8]
+# "AddRange()"로 배열 연결
+$array.AddRange($otherArray)  # 이제 $array는 [1, 2, 3, 4, 5, 6, 7, 8]입니다.
 
-# Check for existence in a array with "in"
+# "in"으로 배열에 존재 여부 확인
 1 -in $array  # => True
 
-# Examine length with "Count" (Note: "Length" on arrayList = each items length)
+# "Count"로 길이 검사 (참고: arrayList의 "Length" = 각 항목의 길이)
 $array.Count  # => 8
 
-# You can look at ranges with slice syntax.
-$array[1,3,5]     # Return selected index  => [2, 4, 6]
-$array[1..3]      # Return from index 1 to 3 => [2, 3, 4]
-$array[-3..-1]    # Return from last 3 to last 1 => [6, 7, 8]
-$array[-1..-3]    # Return from last 1 to last 3 => [8, 7, 6]
-$array[2..-1]     # Return from index 2 to last (NOT as most expect) => [3, 2, 1, 8]
-$array[0,2+4..6]  # Return multiple ranges with the + => [1, 3, 5, 6, 7]
+# 슬라이스 구문으로 범위를 볼 수 있습니다.
+$array[1,3,5]     # 선택한 인덱스 반환  => [2, 4, 6]
+$array[1..3]      # 인덱스 1에서 3까지 반환 => [2, 3, 4]
+$array[-3..-1]    # 마지막 3에서 마지막 1까지 반환 => [6, 7, 8]
+$array[-1..-3]    # 마지막 1에서 마지막 3까지 반환 => [8, 7, 6]
+$array[2..-1]     # 인덱스 2에서 마지막까지 반환 (대부분이 예상하는 것과 다름) => [3, 2, 1, 8]
+$array[0,2+4..6]  # +로 여러 범위 반환 => [1, 3, 5, 6, 7]
 
-# -eq doesn't compare array but extract the matching elements
+# -eq는 배열을 비교하지 않고 일치하는 요소를 추출합니다.
 $array = 1,2,3,1,1
 $array -eq 1          # => 1,1,1
 ($array -eq 1).Count  # => 3
 
-# Tuples are like arrays but are immutable.
-# To use Tuples in powershell, you must use the .NET tuple class.
+# 튜플은 배열과 같지만 불변입니다.
+# powershell에서 튜플을 사용하려면 .NET 튜플 클래스를 사용해야 합니다.
 $tuple = [System.Tuple]::Create(1, 2, 3)
 $tuple.Item(0)      # => 1
-$tuple.Item(0) = 3  # Raises a TypeError
+$tuple.Item(0) = 3  # TypeError 발생
 
-# You can do some of the array methods on tuples, but they are limited.
+# 튜플에서 일부 배열 메서드를 수행할 수 있지만 제한적입니다.
 $tuple.Length       # => 3
-$tuple + (4, 5, 6)  # => Exception
-$tuple[0..2]        # => $null (in powershell 5)    => [1, 2, 3] (in powershell 7)
+$tuple + (4, 5, 6)  # => 예외
+$tuple[0..2]        # => $null (powershell 5에서)    => [1, 2, 3] (powershell 7에서)
 2 -in $tuple        # => False
 
 
-# Hashtables store mappings from keys to values, similar to (but distinct from) Dictionaries.
-# Hashtables do not hold entry order as arrays do.
+# 해시 테이블은 키에서 값으로의 매핑을 저장하며, 딕셔너리와 유사하지만 다릅니다.
+# 해시 테이블은 배열처럼 항목 순서를 유지하지 않습니다.
 $emptyHash = @{}
-# Here is a prefilled hashtable
+# 미리 채워진 해시 테이블
 $filledHash = @{"one"= 1
                 "two"= 2
                 "three"= 3}
 
-# Look up values with []
+# []로 값 조회
 $filledHash["one"]  # => 1
 
-# Get all keys as an iterable with ".Keys".
+# ".Keys"로 모든 키를 반복 가능한 객체로 가져오기
 $filledHash.Keys  # => ["one", "two", "three"]
 
-# Get all values as an iterable with ".Values".
+# ".Values"로 모든 값을 반복 가능한 객체로 가져오기
 $filledHash.Values  # => [1, 2, 3]
 
-# Check for existence of keys or values in a hash with "-in"
+# "-in"으로 해시에 키 또는 값 존재 여부 확인
 "one" -in $filledHash.Keys  # => True
-1 -in $filledHash.Values    # => False (in powershell 5)    => True (in powershell 7)
+1 -in $filledHash.Values    # => False (powershell 5에서)    => True (powershell 7에서)
 
-# Looking up a non-existing key returns $null
+# 존재하지 않는 키를 조회하면 $null 반환
 $filledHash["four"]  # $null
 
-# Adding to a hashtable
-$filledHash.Add("five",5)  # $filledHash["five"] is set to 5
-$filledHash.Add("five",6)  # exception "Item with key "five" has already been added"
-$filledHash["four"] = 4    # $filledHash["four"] is set to 4, running again does nothing
+# 해시 테이블에 추가
+$filledHash.Add("five",5)  # $filledHash["five"]가 5로 설정됨
+$filledHash.Add("five",6)  # 예외 "키 "five"를 가진 항목이 이미 추가되었습니다."
+$filledHash["four"] = 4    # $filledHash["four"]가 4로 설정됨, 다시 실행해도 아무것도 안 함
 
-# Remove keys from a hashtable
-$filledHash.Remove("one") # Removes the key "one" from filled hashtable
+# 해시 테이블에서 키 제거
+$filledHash.Remove("one") # filled 해시 테이블에서 "one" 키 제거
 
 
 ####################################################
-## 3. Control Flow and Iterables
+## 3. 제어 흐름 및 반복 가능 객체
 ####################################################
 
-# Let's just make a variable
+# 변수를 만들어 봅시다
 $someVar = 5
 
-# Here is an if statement.
-# This prints "$someVar is smaller than 10"
+# if 문입니다.
+# "$someVar is smaller than 10"을 출력합니다.
 if ($someVar -gt 10) {
     Write-Output "$someVar is bigger than 10."
 }
-elseif ($someVar -lt 10) {    # This elseif clause is optional.
+elseif ($someVar -lt 10) {    # 이 elseif 절은 선택 사항입니다.
     Write-Output "$someVar is smaller than 10."
 }
-else {                        # This is optional too.
+else {                        # 이것도 선택 사항입니다.
     Write-Output "$someVar is indeed 10."
 }
 
 
 <#
-Foreach loops iterate over arrays
-prints:
+Foreach 루프는 배열을 반복합니다.
+출력:
     dog is a mammal
     cat is a mammal
     mouse is a mammal
 #>
 foreach ($animal in ("dog", "cat", "mouse")) {
-    # You can use -f to interpolate formatted strings
+    # -f를 사용하여 서식화된 문자열을 보간할 수 있습니다.
     "{0} is a mammal" -f $animal
 }
 
 <#
-For loops iterate over arrays and you can specify indices
-prints:
+For 루프는 배열을 반복하며 인덱스를 지정할 수 있습니다.
+출력:
    0 a
    1 b
    2 c
@@ -380,8 +376,8 @@ for($i=0; $i -le $letters.Count-1; $i++){
 }
 
 <#
-While loops go until a condition is no longer met.
-prints:
+While 루프는 조건이 더 이상 충족되지 않을 때까지 계속됩니다.
+출력:
     0
     1
     2
@@ -390,10 +386,10 @@ prints:
 $x = 0
 while ($x -lt 4) {
     Write-Output $x
-    $x += 1  # Shorthand for x = x + 1
+    $x += 1  # x = x + 1의 약어
 }
 
-# Switch statements are more powerful compared to most languages
+# Switch 문은 대부분의 언어에 비해 더 강력합니다.
 $val = "20"
 switch($val) {
   { $_ -eq 42 }           { "The answer equals 42"; break }
@@ -404,9 +400,9 @@ switch($val) {
   default                 { "Others" }
 }
 
-# Handle exceptions with a try/catch block
+# try/catch 블록으로 예외 처리
 try {
-    # Use "throw" to raise an error
+    # "throw"를 사용하여 오류 발생
     throw "This is an error"
 }
 catch {
@@ -417,31 +413,31 @@ finally {
 }
 
 
-# Writing to a file
+# 파일에 쓰기
 $contents = @{"aa"= 12
              "bb"= 21}
-$contents | Export-CSV "$env:HOMEDRIVE\file.csv" # writes to a file
+$contents | Export-CSV "$env:HOMEDRIVE\file.csv" # 파일에 쓰기
 
 $contents = "test string here"
-$contents | Out-File "$env:HOMEDRIVE\file.txt" # writes to another file
+$contents | Out-File "$env:HOMEDRIVE\file.txt" # 다른 파일에 쓰기
 
-# Read file contents and convert to json
+# 파일 내용 읽고 json으로 변환
 Get-Content "$env:HOMEDRIVE\file.csv" | ConvertTo-Json
 
 
 ####################################################
-## 4. Functions
+## 4. 함수
 ####################################################
 
-# Use "function" to create new functions
-# Keep the Verb-Noun naming convention for functions
+# "function"을 사용하여 새 함수 생성
+# 함수에 대한 동사-명사 명명 규칙 유지
 function Add-Numbers {
  $args[0] + $args[1]
 }
 
 Add-Numbers 1 2 # => 3
 
-# Calling functions with parameters
+# 매개변수로 함수 호출
 function Add-ParamNumbers {
  param( [int]$firstNumber, [int]$secondNumber )
  $firstNumber + $secondNumber
@@ -449,18 +445,18 @@ function Add-ParamNumbers {
 
 Add-ParamNumbers -FirstNumber 1 -SecondNumber 2 # => 3
 
-# Functions with named parameters, parameter attributes, parsable documentation
+# 명명된 매개변수, 매개변수 속성, 구문 분석 가능한 문서가 있는 함수
 <#
 .SYNOPSIS
-Setup a new website
+새 웹사이트 설정
 .DESCRIPTION
-Creates everything your new website needs for much win
+새 웹사이트에 필요한 모든 것을 만들어 많은 승리를 거둡니다.
 .PARAMETER siteName
-The name for the new website
+새 웹사이트의 이름
 .EXAMPLE
 New-Website -Name FancySite -Po 5000
 New-Website SiteWithDefaultPort
-New-Website siteName 2000 # ERROR! Port argument could not be validated
+New-Website siteName 2000 # 오류! 포트 인수를 확인할 수 없습니다.
 ('name1','name2') | New-Website -Verbose
 #>
 function New-Website() {
@@ -479,11 +475,11 @@ function New-Website() {
 
 
 ####################################################
-## 5. Modules
+## 5. 모듈
 ####################################################
 
-# You can import modules and install modules
-# The Install-Module is similar to pip or npm, pulls from Powershell Gallery
+# 모듈을 가져오고 모듈을 설치할 수 있습니다.
+# Install-Module은 pip 또는 npm과 유사하며 Powershell Gallery에서 가져옵니다.
 Install-Module dbaTools
 Import-Module dbaTools
 
@@ -495,25 +491,25 @@ $queryParams = @{
 }
 Invoke-DbaQuery @queryParams
 
-# You can get specific functions from a module
+# 모듈에서 특정 함수를 가져올 수 있습니다.
 Import-Module -Function Invoke-DbaQuery
 
 
-# Powershell modules are just ordinary Posh files. You
-# can write your own, and import them. The name of the
-# module is the same as the name of the file.
+# Powershell 모듈은 일반 Posh 파일일 뿐입니다.
+# 직접 작성하고 가져올 수 있습니다. 모듈의 이름은
+# 파일 이름과 동일합니다.
 
-# You can find out which functions and attributes
-# are defined in a module.
+# 모듈에 정의된 함수와 속성을
+# 찾을 수 있습니다.
 Get-Command -module dbaTools
 Get-Help dbaTools -Full
 
 
 ####################################################
-## 6. Classes
+## 6. 클래스
 ####################################################
 
-# We use the "class" statement to create a class
+# "class" 문을 사용하여 클래스를 만듭니다.
 class Instrument {
     [string]$Type
     [string]$Family
@@ -525,7 +521,7 @@ $instrument.Family = "Plucked String"
 
 $instrument
 
-<# Output:
+<# 출력:
 Type              Family
 ----              ------
 String Instrument Plucked String
@@ -533,11 +529,11 @@ String Instrument Plucked String
 
 
 ####################################################
-## 6.1 Inheritance
+## 6.1 상속
 ####################################################
 
-# Inheritance allows new child classes to be defined that inherit
-# methods and variables from their parent class.
+# 상속을 통해 부모 클래스에서 메서드와 변수를
+# 상속하는 새로운 자식 클래스를 정의할 수 있습니다.
 
 class Guitar : Instrument
 {
@@ -563,68 +559,68 @@ True     False    Guitar                                   Instrument
 
 
 ####################################################
-## 7. Advanced
+## 7. 고급
 ####################################################
 
-# The powershell pipeline allows things like High-Order Functions.
+# powershell 파이프라인은 고차 함수와 같은 것을 허용합니다.
 
-# Group-Object is a handy cmdlet that does incredible things.
-# It works much like a GROUP BY in SQL.
+# Group-Object는 놀라운 일을 하는 편리한 cmdlet입니다.
+# SQL의 GROUP BY와 매우 유사하게 작동합니다.
 
 <#
- The following will get all the running processes,
- group them by Name,
- and tell us how many instances of each process we have running.
- Tip: Chrome and svcHost are usually big numbers in this regard.
+ 다음은 실행 중인 모든 프로세스를 가져와서
+ 이름으로 그룹화하고,
+ 각 프로세스의 실행 중인 인스턴스 수를 알려줍니다.
+ 팁: Chrome과 svcHost는 일반적으로 이 점에서 큰 숫자입니다.
 #>
 Get-Process | Foreach-Object ProcessName | Group-Object
 
-# Useful pipeline examples are iteration and filtering.
+# 유용한 파이프라인 예제는 반복 및 필터링입니다.
 1..10 | ForEach-Object { "Loop number $PSITEM" }
 1..10 | Where-Object { $PSITEM -gt 5 } | ConvertTo-Json
 
-# A notable pitfall of the pipeline is its performance when
-# compared with other options.
-# Additionally, raw bytes are not passed through the pipeline,
-# so passing an image causes some issues.
-# See more on that in the link at the bottom.
+# 파이프라인의 주목할 만한 단점은 다른 옵션에 비해
+# 성능이 떨어진다는 것입니다.
+# 또한 원시 바이트는 파이프라인을 통과하지 않으므로
+# 이미지를 전달하면 몇 가지 문제가 발생합니다.
+# 자세한 내용은 하단 링크를 참조하십시오.
 
 <#
- Asynchronous functions exist in the form of jobs.
- Typically a procedural language,
- Powershell can operate non-blocking functions when invoked as Jobs.
+ 비동기 함수는 작업의 형태로 존재합니다.
+ 일반적으로 절차적 언어인
+ Powershell은 작업으로 호출될 때 비차단 함수를 작동할 수 있습니다.
 #>
 
-# This function is known to be non-optimized, and therefore slow.
+# 이 함수는 최적화되지 않아 느린 것으로 알려져 있습니다.
 $installedApps = Get-CimInstance -ClassName Win32_Product
 
-# If we had a script, it would hang at this func for a period of time.
+# 스크립트가 있다면 이 함수에서 일정 시간 동안 멈출 것입니다.
 $scriptBlock = {Get-CimInstance -ClassName Win32_Product}
 Start-Job -ScriptBlock $scriptBlock
 
-# This will start a background job that runs the command.
-# You can then obtain the status of jobs and their returned results.
+# 이것은 명령을 실행하는 백그라운드 작업을 시작합니다.
+# 그런 다음 작업의 상태와 반환된 결과를 얻을 수 있습니다.
 $allJobs = Get-Job
 $jobResponse = Get-Job | Receive-Job
 
 
-# Math is built in to powershell and has many functions.
+# 수학은 powershell에 내장되어 있으며 많은 함수가 있습니다.
 $r=2
 $pi=[math]::pi
 $r2=[math]::pow( $r, 2 )
 $area = $pi*$r2
 $area
 
-# To see all possibilities, check the members.
+# 모든 가능성을 보려면 멤버를 확인하십시오.
 [System.Math] | Get-Member -Static -MemberType All
 
 
 <#
- This is a silly one:
- You may one day be asked to create a func that could take $start and $end
- and reverse anything in an array within the given range
- based on an arbitrary array without mutating the original array.
- Let's see one way to do that and introduce another data structure.
+ 이것은 어리석은 것입니다:
+ 언젠가 $start와 $end를 받아
+ 원래 배열을 변경하지 않고 임의의 배열을 기반으로 주어진 범위 내의
+ 모든 것을 뒤집을 수 있는 함수를 만들라는 요청을 받을 수 있습니다.
+ 그것을 하는 한 가지 방법을 보고 다른 데이터 구조를 소개합시다.
 #>
 
 $targetArray = 'a','b','c','d','e','f','g','h','i','j','k','l','m'
@@ -651,10 +647,10 @@ function Format-Range ($start, $end, $array) {
 Format-Range 2 6 $targetArray
 # => 'a','b','g','f','e','d','c','h','i','j','k','l','m'
 
-# The previous method works, but uses extra memory by allocating new arrays.
-# It's also kind of lengthy.
-# Let's see how we can do this without allocating a new array.
-# This is slightly faster as well.
+# 이전 방법은 작동하지만 새 배열을 할당하여 추가 메모리를 사용합니다.
+# 또한 다소 깁니다.
+# 새 배열을 할당하지 않고 이 작업을 수행하는 방법을 봅시다.
+# 이것은 또한 약간 더 빠릅니다.
 
 function Format-Range ($start, $end) {
   while ($start -lt $end)
@@ -671,63 +667,63 @@ function Format-Range ($start, $end) {
 Format-Range 2 6 # => 'a','b','g','f','e','d','c','h','i','j','k','l','m'
 ```
 
-Powershell as a Tool:
+도구로서의 Powershell:
 
-Getting Help:
+도움말 얻기:
 
 ```powershell
-# Find commands
-Get-Command about_* # alias: gcm
+# 명령어 찾기
+Get-Command about_* # 별칭: gcm
 Get-Command -Verb Add
 Get-Alias ps
 Get-Alias -Definition Get-Process
 
-Get-Help ps | less # alias: help
-ps | Get-Member # alias: gm
+Get-Help ps | less # 별칭: help
+ps | Get-Member # 별칭: gm
 
-Show-Command Get-WinEvent # Display GUI to fill in the parameters
+Show-Command Get-WinEvent # 매개변수를 채우기 위한 GUI 표시
 
-Update-Help # Run as admin
+Update-Help # 관리자로 실행
 ```
 
-If you are uncertain about your environment:
+환경이 확실하지 않은 경우:
 
 ```powershell
 Get-ExecutionPolicy -List
 Set-ExecutionPolicy AllSigned
-# Execution policies include:
-# - Restricted: Scripts won't run.
-# - RemoteSigned: Downloaded scripts run only if signed by a trusted publisher.
-# - AllSigned: Scripts need to be signed by a trusted publisher.
-# - Unrestricted: Run all scripts.
-help about_Execution_Policies # for more info
+# 실행 정책에는 다음이 포함됩니다:
+# - Restricted: 스크립트가 실행되지 않습니다.
+# - RemoteSigned: 신뢰할 수 있는 게시자가 서명한 경우에만 다운로드한 스크립트 실행
+# - AllSigned: 스크립트는 신뢰할 수 있는 게시자가 서명해야 합니다.
+# - Unrestricted: 모든 스크립트 실행
+help about_Execution_Policies # 자세한 정보
 
-# Current PowerShell version:
+# 현재 PowerShell 버전:
 $PSVersionTable
 ```
 
 ```powershell
-# Calling external commands, executables,
-# and functions with the call operator.
-# Exe paths with arguments passed or containing spaces can create issues.
+# 외부 명령어, 실행 파일,
+# 및 호출 연산자가 있는 함수 호출.
+# 인수가 전달되거나 공백이 포함된 Exe 경로는 문제를 일으킬 수 있습니다.
 C:\Program Files\dotnet\dotnet.exe
-# The term 'C:\Program' is not recognized as a name of a cmdlet,
-# function, script file, or executable program.
-# Check the spelling of the name, or if a path was included,
-# verify that the path is correct and try again
+# 'C:\Program'이라는 용어는 cmdlet,
+# 함수, 스크립트 파일 또는 실행 프로그램의 이름으로 인식되지 않습니다.
+# 이름의 철자를 확인하거나 경로가 포함된 경우
+# 경로가 올바른지 확인하고 다시 시도하십시오.
 
 "C:\Program Files\dotnet\dotnet.exe"
-C:\Program Files\dotnet\dotnet.exe    # returns string rather than execute
+C:\Program Files\dotnet\dotnet.exe    # 실행 대신 문자열 반환
 
-&"C:\Program Files\dotnet\dotnet.exe --help"   # fail
-&"C:\Program Files\dotnet\dotnet.exe" --help   # success
-# Alternatively, you can use dot-sourcing here
-."C:\Program Files\dotnet\dotnet.exe" --help   # success
+&"C:\Program Files\dotnet\dotnet.exe --help"   # 실패
+&"C:\Program Files\dotnet\dotnet.exe" --help   # 성공
+# 또는 여기서 점 소싱을 사용할 수 있습니다.
+."C:\Program Files\dotnet\dotnet.exe" --help   # 성공
 
-# the call operator (&) is similar to Invoke-Expression,
-# but IEX runs in current scope.
-# One usage of '&' would be to invoke a scriptblock inside of your script.
-# Notice the variables are scoped
+# 호출 연산자(&)는 Invoke-Expression과 유사하지만,
+# IEX는 현재 범위에서 실행됩니다.
+# '&'의 한 가지 용도는 스크립트 블록을 스크립트 내에서 호출하는 것입니다.
+# 변수가 범위 지정되었는지 확인하십시오.
 $i = 2
 $scriptBlock = { $i=5; Write-Output $i }
 & $scriptBlock # => 5
@@ -736,18 +732,18 @@ $i # => 2
 invoke-expression ' $i=5; Write-Output $i ' # => 5
 $i # => 5
 
-# Alternatively, to preserve changes to public variables
-# you can use "Dot-Sourcing". This will run in the current scope.
+# 또는 공용 변수에 대한 변경 사항을 유지하려면
+# "점 소싱"을 사용할 수 있습니다. 이것은 현재 범위에서 실행됩니다.
 $x=1
 &{$x=2};$x # => 1
 
 .{$x=2};$x # => 2
 
 
-# Remoting into computers is easy.
+# 컴퓨터에 원격으로 접속하는 것은 쉽습니다.
 Enter-PSSession -ComputerName RemoteComputer
 
-# Once remoted in, you can run commands as if you're local.
+# 원격으로 접속하면 로컬인 것처럼 명령을 실행할 수 있습니다.
 RemoteComputer\PS> Get-Process powershell
 
 <#
@@ -759,12 +755,12 @@ Handles  NPM(K)    PM(K)      WS(K)     CPU(s)     Id  SI ProcessName
 RemoteComputer\PS> Exit-PSSession
 
 <#
- Powershell is an incredible tool for Windows management and Automation.
- Let's take the following scenario:
- You have 10 servers.
- You need to check whether a service is running on all of them.
- You can RDP and log in, or PSSession to all of them, but why?
- Check out the following
+ PowerShell은 Windows 관리 및 자동화를 위한 놀라운 도구입니다.
+ 다음 시나리오를 살펴보겠습니다.
+ 10개의 서버가 있습니다.
+ 모든 서버에서 서비스가 실행 중인지 확인해야 합니다.
+ RDP로 로그인하거나 모든 서버에 PSSession으로 접속할 수 있지만 왜 그래야 할까요?
+ 다음을 확인하십시오.
 #>
 
 $serverList = @(
@@ -796,22 +792,22 @@ foreach ($server in $serverList) {
 }
 
 <#
- Here we've invoked jobs across many servers.
- We can now Receive-Job and see if they're all running.
- Now scale this up 100x as many servers :)
+ 여기서는 여러 서버에서 작업을 호출했습니다.
+ 이제 Receive-Job을 사용하여 모두 실행 중인지 확인할 수 있습니다.
+ 이제 서버 수를 100배로 확장해 봅시다 :)
 #>
 ```
 
-Interesting Projects
+흥미로운 프로젝트
 
-* [Channel9](https://channel9.msdn.com/Search?term=powershell%20pipeline#ch9Search&lang-en=en) PowerShell tutorials
-* [KevinMarquette's Powershell Blog](https://powershellexplained.com/) Excellent blog that goes into great detail on Powershell
-* [PSGet](https://github.com/psget/psget) NuGet for PowerShell
-* [PSReadLine](https://github.com/lzybkr/PSReadLine/) A bash inspired readline implementation for PowerShell (So good that it now ships with Windows10 by default!)
-* [Posh-Git](https://github.com/dahlbyk/posh-git/) Fancy Git Prompt (Recommended!)
-* [Oh-My-Posh](https://github.com/JanDeDobbeleer/oh-my-posh) Shell customization similar to the popular Oh-My-Zsh on Mac
-* [PSake](https://github.com/psake/psake) Build automation tool
-* [Pester](https://github.com/pester/Pester) BDD Testing Framework
-* [ZLocation](https://github.com/vors/ZLocation) Powershell `cd` that reads your mind
-* [PowerShell Community Extensions](https://github.com/Pscx/Pscx)
-* [More on the Powershell Pipeline Issue](https://github.com/PowerShell/PowerShell/issues/1908)
+* [Channel9](https://channel9.msdn.com/Search?term=powershell%20pipeline#ch9Search&lang-en=en) PowerShell 튜토리얼
+* [KevinMarquette의 Powershell 블로그](https://powershellexplained.com/) PowerShell에 대해 자세히 설명하는 훌륭한 블로그
+* [PSGet](https://github.com/psget/psget) PowerShell용 NuGet
+* [PSReadLine](https://github.com/lzybkr/PSReadLine/) PowerShell용 bash에서 영감을 받은 readline 구현 (Windows10에 기본적으로 제공될 정도로 좋음!)
+* [Posh-Git](https://github.com/dahlbyk/posh-git/) 멋진 Git 프롬프트 (권장!)
+* [Oh-My-Posh](https://github.com/JanDeDobbeleer/oh-my-posh) Mac의 인기 있는 Oh-My-Zsh와 유사한 셸 사용자 지정
+* [PSake](https://github.com/psake/psake) 빌드 자동화 도구
+* [Pester](https://github.com/pester/Pester) BDD 테스트 프레임워크
+* [ZLocation](https://github.com/vors/ZLocation) 마음을 읽는 Powershell `cd`
+* [PowerShell 커뮤니티 확장](https://github.com/Pscx/Pscx)
+* [Powershell 파이프라인 문제에 대한 추가 정보](https://github.com/PowerShell/PowerShell/issues/1908)

--- a/ko/prolog.md
+++ b/ko/prolog.md
@@ -7,274 +7,267 @@ contributors:
     - ["hyphz", "http://github.com/hyphz/"]
 ---
 
-Prolog is a logic programming language first specified in 1972, and refined into multiple modern implementations.
+Prolog는 1972년에 처음 명시되었고, 여러 현대적인 구현으로 개선된 논리 프로그래밍 언어입니다.
 
 ```
-% This is a comment.
+% 이것은 주석입니다.
 
-% Prolog treats code entered in interactive mode differently
-% to code entered in a file and loaded ("consulted").
-% This code must be loaded from a file to work as intended.
-% Lines that begin with ?- can be typed in interactive mode.
-% A bunch of errors and warnings will trigger when you load this file
-% due to the examples which are supposed to fail - they can be safely
-% ignored.
+% Prolog는 대화형 모드에서 입력된 코드와
+% 파일에 입력되어 로드("컨설팅")된 코드를 다르게 처리합니다.
+% 이 코드는 의도대로 작동하려면 파일에서 로드해야 합니다.
+% ?-로 시작하는 줄은 대화형 모드에서 입력할 수 있습니다.
+% 실패해야 하는 예제 때문에 이 파일을 로드할 때
+% 여러 오류와 경고가 발생하지만 안전하게 무시할 수 있습니다.
 
-% Output is based on SWI-prolog 7.2.3. Different Prologs may behave
-% differently.
+% 출력은 SWI-prolog 7.2.3을 기반으로 합니다. 다른 Prolog는 다르게
+% 동작할 수 있습니다.
 
-% Prolog is based on the ideal of logic programming.
-% A subprogram (called a predicate) represents a state of the world.
-% A command (called a goal) tells Prolog to make that state of the world
-%   come true, if possible.
+% Prolog는 논리 프로그래밍의 이상에 기반을 두고 있습니다.
+% 서브프로그램(술어라고 함)은 세계의 상태를 나타냅니다.
+% 명령어(목표라고 함)는 Prolog에게 가능한 경우 해당 세계의 상태를
+% 실현하도록 지시합니다.
 
-% As an example, here is a definition of the simplest kind of predicate:
-% a fact.
+% 예로서, 가장 간단한 종류의 술어인 사실의
+% 정의는 다음과 같습니다.
 
 magicNumber(7).
 magicNumber(9).
 magicNumber(42).
 
-% This introduces magicNumber as a predicate and says that it is true
-% with parameter 7, 9, or 42, but no other parameter. Note that
-% predicate names must start with lower case letters. We can now use
-% interactive mode to ask if it is true for different values:
+% 이것은 magicNumber를 술어로 도입하고 매개변수 7, 9 또는 42에 대해
+% 참이지만 다른 매개변수에는 해당하지 않음을 나타냅니다.
+% 술어 이름은 소문자로 시작해야 합니다. 이제 대화형 모드를 사용하여
+% 다른 값에 대해 참인지 물어볼 수 있습니다.
 
-?- magicNumber(7).                   % True
-?- magicNumber(8).                   % False
-?- magicNumber(9).                   % True
+?- magicNumber(7).                   % 참
+?- magicNumber(8).                   % 거짓
+?- magicNumber(9).                   % 참
 
-% Some older Prologs may display "Yes" and "No" instead of True and
-% False.
+% 일부 오래된 Prolog는 참과 거짓 대신 "예"와 "아니오"를
+% 표시할 수 있습니다.
 
-% What makes Prolog unusual is that we can also tell Prolog to _make_
-% magicNumber true, by passing it an undefined variable. Any name
-% starting with a capital letter is a variable in Prolog.
+% Prolog를 특이하게 만드는 것은 Prolog에게 정의되지 않은 변수를 전달하여
+% magicNumber를 참으로 만들도록 지시할 수도 있다는 것입니다.
+% 대문자로 시작하는 모든 이름은 Prolog에서 변수입니다.
 
 ?- magicNumber(Presto).              % Presto = 7 ;
                                      % Presto = 9 ;
                                      % Presto = 42.
 
-% Prolog makes magicNumber true by assigning one of the valid numbers to
-% the undefined variable Presto. By default it assigns the first one, 7.
-% By pressing ; in interactive mode you can reject that solution and
-% force it to assign the next one, 9. Pressing ; again forces it to try
-% the last one, 42, after which it no longer accepts input because this
-% is the last solution. You can accept an earlier solution by pressing .
-% instead of ;.
+% Prolog는 정의되지 않은 변수 Presto에 유효한 숫자 중 하나를
+% 할당하여 magicNumber를 참으로 만듭니다. 기본적으로 첫 번째인 7을
+% 할당합니다. 대화형 모드에서 ;를 눌러 해당 솔루션을 거부하고
+% 다음 솔루션인 9를 할당하도록 강제할 수 있습니다. ;를 다시 누르면
+% 마지막 솔루션인 42를 시도하도록 강제하며, 이것이 마지막 솔루션이므로
+% 더 이상 입력을 받지 않습니다. ; 대신 .을 눌러 이전 솔루션을
+% 수락할 수 있습니다.
 
-% This is Prolog's central operation: unification. Unification is
-% essentially a combination of assignment and equality! It works as
-% follows:
-%  If both sides are bound (ie, defined), check equality.
-%  If one side is free (ie, undefined), assign to match the other side.
-%  If both sides are free, the assignment is remembered. With some luck,
-%    one of the two sides will eventually be bound, but this isn't
-%    necessary.
+% 이것이 Prolog의 핵심 연산인 통일입니다. 통일은
+% 본질적으로 할당과 동등성의 조합입니다! 다음과 같이 작동합니다.
+%  양쪽이 모두 바인딩된 경우(즉, 정의된 경우) 동등성을 확인합니다.
+%  한쪽이 자유로운 경우(즉, 정의되지 않은 경우) 다른 쪽과 일치하도록 할당합니다.
+%  양쪽이 모두 자유로운 경우 할당이 기억됩니다. 운이 좋으면
+%    두 쪽 중 하나가 결국 바인딩되지만, 이것이
+%    필수적인 것은 아닙니다.
 %
-% The = sign in Prolog represents unification, so:
+% Prolog의 = 기호는 통일을 나타내므로 다음과 같습니다.
 
-?- 2 = 3.                            % False - equality test
-?- X = 3.                            % X = 3 - assignment
-?- X = 2, X = Y.                     % X = Y = 2 - two assignments
-                                     % Note Y is assigned too, even though it is
-                                     % on the right hand side, because it is free
-?- X = 3, X = 2.                     % False
-                                     % First acts as assignment and binds X=3
-                                     % Second acts as equality because X is bound
-                                     % Since 3 does not equal 2, gives False
-                                     % Thus in Prolog variables are immutable
-?- X = 3+2.                          % X = 3+2 - unification can't do arithmetic
-?- X is 3+2.                         % X = 5 - "is" does arithmetic.
-?- 5 = X+2.                          % This is why = can't do arithmetic -
-                                     % because Prolog can't solve equations
-?- 5 is X+2.                         % Error. Unlike =, the right hand side of IS
-                                     % must always be bound, thus guaranteeing
-                                     % no attempt to solve an equation.
+?- 2 = 3.                            % 거짓 - 동등성 테스트
+?- X = 3.                            % X = 3 - 할당
+?- X = 2, X = Y.                     % X = Y = 2 - 두 개의 할당
+                                     % 참고로 Y도 할당됩니다. 비록
+                                     % 오른쪽에 있지만 자유롭기 때문입니다.
+?- X = 3, X = 2.                     % 거짓
+                                     % 첫 번째는 할당으로 작동하여 X=3을 바인딩합니다.
+                                     % 두 번째는 X가 바인딩되었기 때문에 동등성으로 작동합니다.
+                                     % 3은 2와 같지 않으므로 거짓을 반환합니다.
+                                     % 따라서 Prolog에서 변수는 불변입니다.
+?- X = 3+2.                          % X = 3+2 - 통일은 산술을 할 수 없습니다.
+?- X is 3+2.                         % X = 5 - "is"는 산술을 수행합니다.
+?- 5 = X+2.                          % 이것이 =가 산술을 할 수 없는 이유입니다.
+                                     % Prolog는 방정식을 풀 수 없기 때문입니다.
+?- 5 is X+2.                         % 오류. =와 달리 IS의 오른쪽은
+                                     % 항상 바인딩되어야 하므로
+                                     % 방정식을 풀려는 시도가 없음을 보장합니다.
 ?- X = Y, X = 2, Z is Y + 3.         % X = Y, Y = 2, Z = 5.
-                                     % X = Y are both free, so Prolog remembers
-                                     % it. Therefore assigning X will also
-                                     % assign Y.
+                                     % X = Y는 모두 자유로우므로 Prolog는
+                                     % 이를 기억합니다. 따라서 X를 할당하면
+                                     % Y도 할당됩니다.
 
-% Any unification, and thus any predicate in Prolog, can either:
-% Succeed (return True) without changing anything,
-%   because an equality-style unification was true
-% Succeed (return True) and bind one or more variables in the process,
-%   because an assignment-style unification was made true
-% or Fail (return False)
-%   because an equality-style unification was false
-% (Failure can never bind variables)
+% 모든 통일, 따라서 Prolog의 모든 술어는 다음 중 하나를 수행할 수 있습니다.
+% 아무것도 변경하지 않고 성공(참 반환),
+%   동등성 스타일 통일이 참이었기 때문에
+% 하나 이상의 변수를 바인딩하면서 성공(참 반환),
+%   할당 스타일 통일이 참으로 만들어졌기 때문에
+% 또는 실패(거짓 반환)
+%   동등성 스타일 통일이 거짓이었기 때문에
+% (실패는 변수를 바인딩할 수 없음)
 
-% The ideal of being able to give any predicate as a goal and have it
-% made true is not always possible, but can be worked toward. For
-% example, Prolog has a built in predicate plus which represents
-% arithmetic addition but can reverse simple additions.
+% 어떤 술어든 목표로 주어지고 그것을 참으로 만들 수 있다는 이상은
+% 항상 가능한 것은 아니지만, 노력할 수 있습니다. 예를 들어,
+% Prolog에는 산술 덧셈을 나타내지만 간단한 덧셈을 되돌릴 수 있는
+% 내장 술어 plus가 있습니다.
 
-?- plus(1, 2, 3).                    % True
-?- plus(1, 2, X).                    % X = 3 because 1+2 = X.
-?- plus(1, X, 3).                    % X = 2 because 1+X = 3.
-?- plus(X, 2, 3).                    % X = 1 because X+2 = 3.
-?- plus(X, 5, Y).                    % Error - although this could be solved,
-                                     % the number of solutions is infinite,
-                                     % which most predicates try to avoid.
+?- plus(1, 2, 3).                    % 참
+?- plus(1, 2, X).                    % 1+2 = X이므로 X = 3.
+?- plus(1, X, 3).                    % 1+X = 3이므로 X = 2.
+?- plus(X, 2, 3).                    % X+2 = 3이므로 X = 1.
+?- plus(X, 5, Y).                    % 오류 - 이것은 해결될 수 있지만,
+                                     % 해의 수가 무한하므로
+                                     % 대부분의 술어는 이를 피하려고 합니다.
 
-% When a predicate such as magicNumber can give several solutions, the
-% overall compound goal including it may have several solutions too.
+% magicNumber와 같은 술어가 여러 해를 줄 수 있을 때,
+% 그것을 포함하는 전체 복합 목표도 여러 해를 가질 수 있습니다.
 
 ?- magicNumber(X), plus(X,Y,100).    % X = 7, Y = 93 ;
                                      % X = 9, Y = 91 ;
                                      % X = 42, Y = 58 .
-% Note: on this occasion it works to pass two variables to plus because
-% only Y is free (X is bound by magicNumber).
+% 참고: 이 경우 Y만 자유롭기 때문에(X는 magicNumber에 의해 바인딩됨)
+% plus에 두 변수를 전달하는 것이 작동합니다.
 
-% However, if one of the goals is fully bound and thus acts as a test,
-% then solutions which fail the test are rejected.
+% 그러나 목표 중 하나가 완전히 바인딩되어 테스트 역할을 하는 경우,
+% 테스트에 실패하는 해는 거부됩니다.
 ?- magicNumber(X), X > 40.           % X = 42
-?- magicNumber(X), X > 100.          % False
+?- magicNumber(X), X > 100.          % 거짓
 
-% To see how Prolog actually handles this, let's introduce the print
-% predicate. Print always succeeds, never binds any variables, and
-% prints out its parameter as a side effect.
+% Prolog가 실제로 이것을 어떻게 처리하는지 보려면, print
+% 술어를 소개합시다. Print는 항상 성공하고, 변수를 바인딩하지 않으며,
+% 부작용으로 매개변수를 출력합니다.
 
-?- print("Hello").                   % "Hello" true.
-?- X = 2, print(X).                  % 2 true.
-?- X = 2, print(X), X = 3.           % 2 false - print happens immediately when
-                                     % it is encountered, even though the overall
-                                     % compound goal fails (because 2 != 3,
-                                     % see the example above).
+?- print("Hello").                   % "Hello" 참.
+?- X = 2, print(X).                  % 2 참.
+?- X = 2, print(X), X = 3.           % 2 거짓 - 전체 복합 목표가
+                                     % 실패하더라도(2 != 3이므로,
+                                     % 위 예제 참조) print는
+                                     % 마주치면 즉시 발생합니다.
 
-% By using Print we can see what actually happens when we give a
-% compound goal including a test that sometimes fails.
+% Print를 사용하여 때때로 실패하는 테스트를 포함하는
+% 복합 목표를 줄 때 실제로 무슨 일이 일어나는지 볼 수 있습니다.
 ?- magicNumber(X), print(X), X > 40. % 7 9 42 X = 42 .
 
-% MagicNumber(X) unifies X with its first possibility, 7.
-% Print(X) prints out 7.
-% X > 40 tests if 7 > 40. It is not, so it fails.
-% However, Prolog remembers that magicNumber(X) offered multiple
-% solutions. So it _backtracks_ to that point in the code to try
-% the next solution, X = 9.
-% Having backtracked it must work through the compound goal
-% again from that point including the Print(X). So Print(X) prints out
-% 9.
-% X > 40 tests if 9 > 40 and fails again.
-% Prolog remembers that magicNumber(X) still has solutions and
-% backtracks. Now X = 42.
-% It works through the Print(X) again and prints 42.
-% X > 40 tests if 42 > 40 and succeeds so the result bound to X
-% The same backtracking process is used when you reject a result at
-% the interactive prompt by pressing ;, for example:
+% MagicNumber(X)는 X를 첫 번째 가능성인 7과 통일합니다.
+% Print(X)는 7을 출력합니다.
+% X > 40은 7 > 40인지 테스트합니다. 그렇지 않으므로 실패합니다.
+% 그러나 Prolog는 magicNumber(X)가 여러 해를 제공했다는 것을
+% 기억합니다. 그래서 다음 해인 X = 9를 시도하기 위해 코드의 해당 지점으로
+% _백트래킹_합니다.
+% 백트래킹한 후에는 Print(X)를 포함하여 해당 지점에서
+% 복합 목표를 다시 작업해야 합니다. 그래서 Print(X)는 9를 출력합니다.
+% X > 40은 9 > 40인지 테스트하고 다시 실패합니다.
+% Prolog는 magicNumber(X)가 여전히 해를 가지고 있음을 기억하고
+% 백트래킹합니다. 이제 X = 42입니다.
+% Print(X)를 다시 작업하고 42를 출력합니다.
+% X > 40은 42 > 40인지 테스트하고 성공하므로 X에 바인딩된 결과
+% 대화형 프롬프트에서 ;를 눌러 결과를 거부할 때도 동일한
+% 백트래킹 프로세스가 사용됩니다. 예를 들면 다음과 같습니다.
 
 ?- magicNumber(X), print(X), X > 8.  % 7 9 X = 9 ;
                                      % 42 X = 42.
 
-% As you saw above we can define our own simple predicates as facts.
-% More complex predicates are defined as rules, like this:
+% 위에서 보았듯이 우리는 사실로서 간단한 술어를 정의할 수 있습니다.
+% 더 복잡한 술어는 다음과 같이 규칙으로 정의됩니다.
 
 nearby(X,Y) :- X = Y.
 nearby(X,Y) :- Y is X+1.
 nearby(X,Y) :- Y is X-1.
 
-% nearby(X,Y) is true if Y is X plus or minus 1.
-% However this predicate could be improved. Here's why:
+% nearby(X,Y)는 Y가 X에 1을 더하거나 뺀 경우 참입니다.
+% 그러나 이 술어는 개선될 수 있습니다. 이유는 다음과 같습니다.
 
-?- nearby(2,3).                      % True ; False.
-% Because we have three possible definitions, Prolog sees this as 3
-% possibilities. X = Y fails, so Y is X+1 is then tried and succeeds,
-% giving the True answer. But Prolog still remembers there are more
-% possibilities for nearby() (in Prolog terminology, "it has a
-% choice point") even though "Y is X-1" is doomed to fail, and gives us
-% the option of rejecting the True answer, which doesn't make a whole
-% lot of sense.
+?- nearby(2,3).                      % 참 ; 거짓.
+% 세 가지 가능한 정의가 있으므로 Prolog는 이것을 3가지
+% 가능성으로 봅니다. X = Y는 실패하므로 Y is X+1이 시도되고 성공하여
+% 참 답변을 제공합니다. 그러나 Prolog는 "Y is X-1"이 실패할 운명임에도 불구하고
+% nearby()에 대한 더 많은 가능성이 있다는 것을 여전히 기억하고(Prolog 용어로는
+% "선택 지점이 있음"), 우리에게 참 답변을 거부할 수 있는 옵션을 제공하는데,
+% 이는 별로 의미가 없습니다.
 
 ?- nearby(4, X).                     % X = 4 ;
                                      % X = 5 ;
-                                     % X = 3. Great, this works
+                                     % X = 3. 좋습니다, 이것은 작동합니다.
 ?- nearby(X, 4).                     % X = 4 ;
-                                     % error
-% After rejecting X = 4 prolog backtracks and tries "Y is X+1" which is
-% "4 is X+1" after substitution of parameters. But as we know from above
-% "is" requires its argument to be fully instantiated and it is not, so
-% an error occurs.
+                                     % 오류
+% X = 4를 거부한 후 Prolog는 백트래킹하여 "Y is X+1"을 시도하는데,
+% 이는 매개변수 치환 후 "4 is X+1"입니다. 그러나 위에서 알 수 있듯이
+% "is"는 인수가 완전히 인스턴스화되어야 하지만 그렇지 않으므로
+% 오류가 발생합니다.
 
-% One way to solve the first problem is to use a construct called the
-% cut, !, which does nothing but which cannot be backtracked past.
+% 첫 번째 문제를 해결하는 한 가지 방법은 컷이라는 구문을 사용하는 것입니다.
+% !, 아무것도 하지 않지만 백트래킹할 수 없습니다.
 
 nearbychk(X,Y) :- X = Y, !.
 nearbychk(X,Y) :- Y is X+1, !.
 nearbychk(X,Y) :- Y is X-1.
 
-% This solves the first problem:
-?- nearbychk(2,3).                   % True.
+% 이것은 첫 번째 문제를 해결합니다.
+?- nearbychk(2,3).                   % 참.
 
-% But unfortunately it has consequences:
+% 하지만 불행히도 다음과 같은 결과가 있습니다.
 ?- nearbychk(2,X).                   % X = 2.
-% Because Prolog cannot backtrack past the cut after X = Y, it cannot
-% try the possibilities "Y is X+1" and "Y is X-1", so it only generates
-% one solution when there should be 3.
-% However if our only interest is in checking if numbers are nearby,
-% this may be all we need, thus the name nearbychk.
-% This structure is used in Prolog itself from time to time (for example
-% in list membership).
+% Prolog는 X = Y 이후의 컷을 백트래킹할 수 없으므로
+% "Y is X+1" 및 "Y is X-1" 가능성을 시도할 수 없으므로 3개의 해가 있어야 할 때
+% 하나의 해만 생성합니다.
+% 그러나 우리의 유일한 관심사가 숫자가 근처에 있는지 확인하는 것이라면
+% 이것만으로도 충분할 수 있으므로 이름이 nearbychk입니다.
+% 이 구조는 Prolog 자체에서도 때때로 사용됩니다(예: 목록 멤버십).
 
-% To solve the second problem we can use built-in predicates in Prolog
-% to verify if a parameter is bound or free and adjust our calculations
-% appropriately.
+% 두 번째 문제를 해결하기 위해 Prolog의 내장 술어를 사용하여
+% 매개변수가 바인딩되었는지 또는 자유로운지 확인하고 계산을
+% 적절하게 조정할 수 있습니다.
 nearby2(X,Y) :- nonvar(X), X = Y.
 nearby2(X,Y) :- nonvar(X), Y is X+1.
 nearby2(X,Y) :- nonvar(X), Y is X-1.
 nearby2(X,Y) :- var(X), nonvar(Y), nearby2(Y,X).
 
-% We can combine this with a cut in the case where both variables are
-% bound, to solve both problems.
+% 두 변수가 모두 바인딩된 경우 컷과 결합하여 두 문제를 모두 해결할 수 있습니다.
 nearby3(X,Y) :- nonvar(X), nonvar(Y), nearby2(X,Y), !.
 nearby3(X,Y) :- nearby2(X,Y).
 
-% However when writing a predicate it is not normally necessary to go to
-% these lengths to perfectly support every possible parameter
-% combination. It suffices to support parameter combinations we need to
-% use in the program. It is a good idea to document which combinations
-% are supported. In regular Prolog this is informally in structured
-% comments, but in some Prolog variants like Visual Prolog and Mercury
-% this is mandatory and checked by the compiler.
+% 그러나 술어를 작성할 때 모든 가능한 매개변수 조합을 완벽하게 지원하기 위해
+% 이러한 길이를 갈 필요는 없습니다. 프로그램에서 사용해야 하는
+% 매개변수 조합을 지원하는 것으로 충분합니다. 어떤 조합이 지원되는지
+% 문서화하는 것이 좋습니다. 일반 Prolog에서는 구조화된 주석에서 비공식적으로
+% 수행되지만 Visual Prolog 및 Mercury와 같은 일부 Prolog 변형에서는
+% 이것이 필수이며 컴파일러에서 확인됩니다.
 
-% Here is the structured comment declaration for nearby3:
+% 다음은 nearby3에 대한 구조화된 주석 선언입니다.
 
 %!    nearby3(+X:Int, +Y:Int) is semideterministic.
 %!    nearby3(+X:Int, -Y:Int) is multi.
 %!    nearby3(-X:Int, +Y:Int) is multi.
 
-% For each variable we list a type. The + or - before the variable name
-% indicates if the parameter is bound (+) or free (-). The word after
-% "is" describes the behaviour of the predicate:
-%   semideterministic - can succeed once or fail
-%     ( Two specific numbers are either nearby or not )
-%   multi - can succeed multiple times but cannot fail
-%     ( One number surely has at least 3 nearby numbers )
-%  Other possibilities are:
-%    det - always succeeds exactly once (eg, print)
-%    nondet - can succeed multiple times or fail.
-% In Prolog these are just structured comments and strictly informal but
-% extremely useful.
+% 각 변수에 대해 타입을 나열합니다. 변수 이름 앞의 + 또는 -는
+% 매개변수가 바인딩되었는지(+) 또는 자유로운지(-)를 나타냅니다.
+% "is" 뒤의 단어는 술어의 동작을 설명합니다.
+%   semideterministic - 한 번 성공하거나 실패할 수 있습니다.
+%     ( 두 특정 숫자는 근처에 있거나 그렇지 않습니다 )
+%   multi - 여러 번 성공할 수 있지만 실패할 수는 없습니다.
+%     ( 한 숫자는 확실히 적어도 3개의 근처 숫자를 가집니다 )
+%  다른 가능성은 다음과 같습니다.
+%    det - 항상 정확히 한 번 성공합니다 (예: print)
+%    nondet - 여러 번 성공하거나 실패할 수 있습니다.
+% Prolog에서는 이것들이 단지 구조화된 주석이며 엄격하게 비공식적이지만
+% 매우 유용합니다.
 
-% An unusual feature of Prolog is its support for atoms. Atoms are
-% essentially members of an enumerated type that are created on demand
-% whenever an unquoted non variable value is used. For example:
-character(batman).            % Creates atom value batman
-character(robin).             % Creates atom value robin
-character(joker).             % Creates atom value joker
-character(darthVader).        % Creates atom value darthVader
-?- batman = batman.           % True - Once created value is reused
-?- batman = batMan.           % False - atoms are case sensitive
-?- batman = darthVader.       % False - atoms are distinct
+% Prolog의 특이한 특징은 원자를 지원한다는 것입니다. 원자는
+% 본질적으로 따옴표 없는 비변수 값이 사용될 때마다
+% 필요에 따라 생성되는 열거형 타입의 멤버입니다. 예를 들면 다음과 같습니다.
+character(batman).            % 원자 값 batman 생성
+character(robin).             % 원자 값 robin 생성
+character(joker).             % 원자 값 joker 생성
+character(darthVader).        % 원자 값 darthVader 생성
+?- batman = batman.           % 참 - 생성되면 값이 재사용됩니다.
+?- batman = batMan.           % 거짓 - 원자는 대소문자를 구분합니다.
+?- batman = darthVader.       % 거짓 - 원자는 구별됩니다.
 
-% Atoms are popular in examples but were created on the assumption that
-% Prolog would be used interactively by end users - they are less
-% useful for modern applications and some Prolog variants abolish them
-% completely. However they can be very useful internally.
+% 원자는 예제에서 인기가 있지만 Prolog가 최종 사용자에 의해
+% 대화식으로 사용될 것이라는 가정 하에 만들어졌습니다. 현대적인 응용 프로그램에는
+% 덜 유용하며 일부 Prolog 변형에서는 완전히 폐지되었습니다.
+% 그러나 내부적으로는 매우 유용할 수 있습니다.
 
-% Loops in Prolog are classically written using recursion.
-% Note that below, writeln is used instead of print because print is
-% intended for debugging.
+% Prolog의 루프는 고전적으로 재귀를 사용하여 작성됩니다.
+% 아래에서는 print가 디버깅용이므로 print 대신 writeln이
+% 사용되었습니다.
 
 %!    countTo(+X:Int) is deterministic.
 %!    countUpTo(+Value:Int, +Limit:Int) is deterministic.
@@ -284,11 +277,11 @@ countUpTo(Value, Limit) :- Value \= Limit, writeln(Value),
     NextValue is Value+1,
     countUpTo(NextValue, Limit).
 
-?- countTo(10).                      % Outputs 1 to 10
+?- countTo(10).                      % 1에서 10까지 출력
 
-% Note the use of multiple declarations in countUpTo to create an
-% IF test. If Value = Limit fails the second declaration is run.
-% There is also a more elegant syntax.
+% countUpTo에서 IF 테스트를 만들기 위해 여러 선언을 사용하는 것에
+% 유의하십시오. Value = Limit가 실패하면 두 번째 선언이 실행됩니다.
+% 더 우아한 구문도 있습니다.
 
 %!    countUpTo2(+Value:Int, +Limit:Int) is deterministic.
 countUpTo2(Value, Limit) :- writeln(Value),
@@ -296,46 +289,43 @@ countUpTo2(Value, Limit) :- writeln(Value),
         NextValue is Value+1,
         countUpTo2(NextValue, Limit)).
 
-?- countUpTo2(1,10).                 % Outputs 1 to 10
+?- countUpTo2(1,10).                 % 1에서 10까지 출력
 
-% If a predicate returns multiple times it is often useful to loop
-% through all the values it returns. Older Prologs used a hideous syntax
-% called a "failure-driven loop" to do this, but newer ones use a higher
-% order function.
+% 술어가 여러 번 반환하는 경우 반환하는 모든 값을 반복하는 것이
+% 종종 유용합니다. 오래된 Prolog는 "실패 기반 루프"라는 끔찍한 구문을
+% 사용하여 이를 수행했지만, 최신 Prolog는 고차 함수를 사용합니다.
 
 %!    countTo2(+X:Int) is deterministic.
 countTo2(X) :- forall(between(1,X,Y),writeln(Y)).
 
-?- countTo2(10).                     % Outputs 1 to 10
+?- countTo2(10).                     % 1에서 10까지 출력
 
-% Lists are given in square brackets. Use memberchk to check membership.
-% A group is safe if it doesn't include Joker or does include Batman.
+% 리스트는 대괄호로 주어집니다. 멤버십을 확인하려면 memberchk를 사용하십시오.
+% 그룹은 Joker를 포함하지 않거나 Batman을 포함하는 경우 안전합니다.
 
 %!     safe(Group:list(atom)) is deterministic.
 safe(Group) :- memberchk(joker, Group) -> memberchk(batman, Group) ; true.
 
-?- safe([robin]).                    % True
-?- safe([joker]).                    % False
-?- safe([joker, batman]).            % True
+?- safe([robin]).                    % 참
+?- safe([joker]).                    % 거짓
+?- safe([joker, batman]).            % 참
 
-% The member predicate works like memberchk if both arguments are bound,
-% but can accept free variables and thus can be used to loop through
-% lists.
+% member 술어는 두 인수가 모두 바인딩된 경우 memberchk처럼 작동하지만,
+% 자유 변수를 받아들일 수 있으므로 리스트를 반복하는 데 사용할 수 있습니다.
 
 ?- member(X, [1,2,3]).               % X = 1 ; X = 2 ; X = 3 .
 ?- forall(member(X,[1,2,3]),
        (Y is X+1, writeln(Y))).      % 2 3 4
 
-% The maplist function can be used to generate lists based on other
-% lists. Note that the output list is a free variable, causing an
-% undefined value to be passed to plus, which is then bound by
-% unification. Also notice the use of currying on the plus predicate -
-% it's a 3 argument predicate, but we specify only the first, because
-% the second and third are filled in by maplist.
+% maplist 함수를 사용하여 다른 리스트를 기반으로 리스트를 생성할 수 있습니다.
+% 출력 리스트는 자유 변수이므로 정의되지 않은 값이 plus에 전달되고,
+% 그런 다음 통일에 의해 바인딩됩니다. 또한 plus 술어에 대한 커링 사용에
+% 유의하십시오. 3개의 인수를 가진 술어이지만, 두 번째와 세 번째는
+% maplist에 의해 채워지므로 첫 번째만 지정합니다.
 
 ?- maplist(plus(1), [2,3,4], Output).   % Output = [3, 4, 5].
 ```
 
-## Further reading
+## 더 읽을거리
 
 * [SWI-Prolog](http://www.swi-prolog.org/)

--- a/ko/pyqt.md
+++ b/ko/pyqt.md
@@ -8,42 +8,40 @@ contributors:
     - ["Nathan Hughes", "https://github.com/sirsharpest"]
 ---
 
-**Qt** is a widely-known framework for developing cross-platform software that can be run on various software and hardware platforms with little or no change in the code, while having the power and speed of native applications. Though **Qt** was originally written in *C++*.
+**Qt**는 코드 변경이 거의 또는 전혀 없이 다양한 소프트웨어 및 하드웨어 플랫폼에서 실행할 수 있는 크로스 플랫폼 소프트웨어를 개발하기 위한 널리 알려진 프레임워크이며, 네이티브 애플리케이션의 성능과 속도를 가지고 있습니다. **Qt**는 원래 *C++*로 작성되었습니다.
 
 
-This is an adaption on the C++ intro to QT by [Aleksey Kholovchuk](https://github.com/vortexxx192
-), some of the code examples should result in the same functionality
-this version just having been done using pyqt!
+이것은 [Aleksey Kholovchuk](https://github.com/vortexxx192)의 C++ QT 소개를 각색한 것으로, 일부 코드 예제는 동일한 기능을 가져야 하며 이 버전은 pyqt를 사용하여 작성되었습니다!
 
 ```python
 import sys
 from PyQt4 import QtGui
 
 def window():
-	# Create an application object
+	# 애플리케이션 객체 생성
     app = QtGui.QApplication(sys.argv)
-	# Create a widget where our label will be placed in
+	# 레이블이 배치될 위젯 생성
     w = QtGui.QWidget()
-	# Add a label to the widget
+	# 위젯에 레이블 추가
     b = QtGui.QLabel(w)
-	# Set some text for the label
+	# 레이블에 텍스트 설정
     b.setText("Hello World!")
-	# Give some size and placement information
+	# 크기 및 배치 정보 제공
     w.setGeometry(100, 100, 200, 50)
     b.move(50, 20)
-	# Give our window a nice title
+	# 창에 멋진 제목 부여
     w.setWindowTitle("PyQt")
-	# Have everything display
+	# 모든 것을 표시
     w.show()
-	# Execute what we have asked for, once all setup
+	# 모든 설정이 완료되면 요청한 내용 실행
     sys.exit(app.exec_())
 
 if __name__ == '__main__':
     window()
 ```
 
-In order to get some of the more advanced features in **pyqt** we need to start looking at building additional elements.
-Here we show how to introduce a dialog popup box, useful for asking the user to confirm a decision or to provide information.
+**pyqt**에서 더 고급 기능을 사용하려면 추가 요소를 구축하는 것을 고려해야 합니다.
+여기서는 사용자에게 결정 확인을 요청하거나 정보를 제공하는 데 유용한 대화 상자 팝업 상자를 도입하는 방법을 보여줍니다.
 
 ```python
 import sys
@@ -54,27 +52,27 @@ from PyQt4.QtCore import *
 def window():
     app = QApplication(sys.argv)
     w = QWidget()
-    # Create a button and attach to widget w
+    # 버튼을 생성하고 위젯 w에 연결
     b = QPushButton(w)
     b.setText("Press me")
     b.move(50, 50)
-    # Tell b to call this function when clicked
-    # notice the lack of "()" on the function call
+    # b를 클릭했을 때 이 함수를 호출하도록 지시
+    # 함수 호출에 "()"가 없는 점에 유의
     b.clicked.connect(showdialog)
     w.setWindowTitle("PyQt Dialog")
     w.show()
     sys.exit(app.exec_())
 
-# This function should create a dialog window with a button
-# that waits to be clicked and then exits the program
+# 이 함수는 버튼이 있는 대화 상자 창을 생성해야 하며,
+# 버튼을 클릭하면 프로그램이 종료됩니다
 def showdialog():
     d = QDialog()
     b1 = QPushButton("ok", d)
     b1.move(50, 50)
     d.setWindowTitle("Dialog")
-    # This modality tells the popup to block the parent whilst it's active
+    # 이 양식은 팝업이 활성화되어 있는 동안 부모를 차단하도록 지시합니다
     d.setWindowModality(Qt.ApplicationModal)
-    # On click I'd like the entire process to end
+    # 클릭 시 전체 프로세스가 종료되기를 원합니다
     b1.clicked.connect(sys.exit)
     d.exec_()
 

--- a/ko/python.md
+++ b/ko/python.md
@@ -16,78 +16,76 @@ contributors:
 filename: learnpython.py
 ---
 
-Python was created by Guido van Rossum in the early 90s. It is now one of the
-most popular languages in existence. I fell in love with Python for its
-syntactic clarity. It's basically executable pseudocode.
+Python은 90년대 초에 Guido van Rossum에 의해 만들어졌습니다. 지금은 가장 인기 있는 언어 중 하나입니다. 저는 Python의 구문적 명확성에 반했습니다. 기본적으로 실행 가능한 의사 코드입니다.
 
 ```python
-# Single line comments start with a number symbol.
+# 한 줄 주석은 숫자 기호로 시작합니다.
 
-""" Multiline strings can be written
-    using three "s, and are often used
-    as documentation.
+""" 여러 줄 문자열은
+    세 개의 "를 사용하여 작성할 수 있으며, 종종
+    문서로 사용됩니다.
 """
 
 ####################################################
-## 1. Primitive Datatypes and Operators
+## 1. 기본 데이터 타입 및 연산자
 ####################################################
 
-# You have numbers
+# 숫자가 있습니다.
 3  # => 3
 
-# Math is what you would expect
+# 수학은 예상대로입니다.
 1 + 1   # => 2
 8 - 1   # => 7
 10 * 2  # => 20
 35 / 5  # => 7.0
 
-# Floor division rounds towards negative infinity
+# 내림 나눗셈은 음의 무한대 방향으로 반올림합니다.
 5 // 3       # => 1
 -5 // 3      # => -2
-5.0 // 3.0   # => 1.0  # works on floats too
+5.0 // 3.0   # => 1.0  # 부동 소수점에서도 작동합니다.
 -5.0 // 3.0  # => -2.0
 
-# The result of division is always a float
+# 나눗셈의 결과는 항상 부동 소수점입니다.
 10.0 / 3  # => 3.3333333333333335
 
-# Modulo operation
+# 나머지 연산
 7 % 3   # => 1
-# i % j have the same sign as j, unlike C
+# i % j는 C와 달리 j와 같은 부호를 가집니다.
 -7 % 3  # => 2
 
-# Exponentiation (x**y, x to the yth power)
+# 거듭제곱 (x**y, x의 y 제곱)
 2**3  # => 8
 
-# Enforce precedence with parentheses
+# 괄호로 우선순위 강제
 1 + 3 * 2    # => 7
 (1 + 3) * 2  # => 8
 
-# Boolean values are primitives (Note: the capitalization)
+# 불리언 값은 기본 타입입니다 (참고: 대소문자 구분)
 True   # => True
 False  # => False
 
-# negate with not
+# not으로 부정
 not True   # => False
 not False  # => True
 
-# Boolean Operators
-# Note "and" and "or" are case-sensitive
+# 불리언 연산자
+# "and"와 "or"은 대소문자를 구분합니다.
 True and False  # => False
 False or True   # => True
 
-# True and False are actually 1 and 0 but with different keywords
+# True와 False는 실제로 1과 0이지만 다른 키워드를 사용합니다.
 True + True  # => 2
 True * 8     # => 8
 False - 5    # => -5
 
-# Comparison operators look at the numerical value of True and False
+# 비교 연산자는 True와 False의 숫자 값을 봅니다.
 0 == False   # => True
 2 > True     # => True
 2 == True    # => False
 -5 != False  # => True
 
-# None, 0, and empty strings/lists/dicts/tuples/sets all evaluate to False.
-# All other values are True
+# None, 0, 빈 문자열/리스트/딕셔너리/튜플/세트는 모두 False로 평가됩니다.
+# 다른 모든 값은 True입니다.
 bool(0)      # => False
 bool("")     # => False
 bool([])     # => False
@@ -97,9 +95,9 @@ bool(set())  # => False
 bool(4)      # => True
 bool(-6)     # => True
 
-# Using boolean logical operators on ints casts them to booleans for evaluation,
-# but their non-cast value is returned. Don't mix up with bool(ints) and bitwise
-# and/or (&,|)
+# int에 불리언 논리 연산자를 사용하면 평가를 위해 불리언으로 캐스팅되지만,
+# 캐스팅되지 않은 값이 반환됩니다. bool(ints)와 비트
+# and/or (&,|)를 혼동하지 마십시오.
 bool(0)   # => False
 bool(2)   # => True
 0 and 2   # => 0
@@ -107,337 +105,336 @@ bool(-5)  # => True
 bool(2)   # => True
 -5 or 0   # => -5
 
-# Equality is ==
+# 같음은 == 입니다.
 1 == 1  # => True
 2 == 1  # => False
 
-# Inequality is !=
+# 같지 않음은 != 입니다.
 1 != 1  # => False
 2 != 1  # => True
 
-# More comparisons
+# 더 많은 비교
 1 < 10  # => True
 1 > 10  # => False
 2 <= 2  # => True
 2 >= 2  # => True
 
-# Seeing whether a value is in a range
+# 값이 범위에 있는지 확인
 1 < 2 and 2 < 3  # => True
 2 < 3 and 3 < 2  # => False
-# Chaining makes this look nicer
+# 연쇄를 사용하면 더 보기 좋습니다.
 1 < 2 < 3  # => True
 2 < 3 < 2  # => False
 
-# (is vs. ==) is checks if two variables refer to the same object, but == checks
-# if the objects pointed to have the same values.
-a = [1, 2, 3, 4]  # Point a at a new list, [1, 2, 3, 4]
-b = a             # Point b at what a is pointing to
-b is a            # => True, a and b refer to the same object
-b == a            # => True, a's and b's objects are equal
-b = [1, 2, 3, 4]  # Point b at a new list, [1, 2, 3, 4]
-b is a            # => False, a and b do not refer to the same object
-b == a            # => True, a's and b's objects are equal
+# (is vs. ==) is는 두 변수가 동일한 객체를 참조하는지 확인하지만, ==는
+# 가리키는 객체가 동일한 값을 갖는지 확인합니다.
+a = [1, 2, 3, 4]  # a를 새 목록 [1, 2, 3, 4]로 지정
+b = a             # b를 a가 가리키는 것으로 지정
+b is a            # => True, a와 b는 동일한 객체를 참조
+b == a            # => True, a와 b의 객체는 동일
+b = [1, 2, 3, 4]  # b를 새 목록 [1, 2, 3, 4]로 지정
+b is a            # => False, a와 b는 동일한 객체를 참조하지 않음
+b == a            # => True, a와 b의 객체는 동일
 
-# Strings are created with " or '
+# 문자열은 " 또는 '로 생성됩니다.
 "This is a string."
 'This is also a string.'
 
-# Strings can be added too
+# 문자열도 추가할 수 있습니다.
 "Hello " + "world!"  # => "Hello world!"
-# String literals (but not variables) can be concatenated without using '+'
+# 문자열 리터럴(변수는 아님)은 '+'를 사용하지 않고 연결할 수 있습니다.
 "Hello " "world!"    # => "Hello world!"
 
-# A string can be treated like a list of characters
+# 문자열은 문자 목록처럼 처리할 수 있습니다.
 "Hello world!"[0]  # => 'H'
 
-# You can find the length of a string
+# 문자열의 길이를 찾을 수 있습니다.
 len("This is a string")  # => 16
 
-# Since Python 3.6, you can use f-strings or formatted string literals.
+# Python 3.6부터 f-문자열 또는 서식화된 문자열 리터럴을 사용할 수 있습니다.
 name = "Reiko"
 f"She said her name is {name}."  # => "She said her name is Reiko"
-# Any valid Python expression inside these braces is returned to the string.
+# 이 중괄호 안의 모든 유효한 Python 표현식은 문자열로 반환됩니다.
 f"{name} is {len(name)} characters long."  # => "Reiko is 5 characters long."
 
-# None is an object
+# None은 객체입니다.
 None  # => None
 
-# Don't use the equality "==" symbol to compare objects to None
-# Use "is" instead. This checks for equality of object identity.
+# 객체를 None과 비교하기 위해 등호 "==" 기호를 사용하지 마십시오.
+# 대신 "is"를 사용하십시오. 이것은 객체 ID의 동등성을 확인합니다.
 "etc" is None  # => False
 None is None   # => True
 
 ####################################################
-## 2. Variables and Collections
+## 2. 변수 및 컬렉션
 ####################################################
 
-# Python has a print function
+# Python에는 print 함수가 있습니다.
 print("I'm Python. Nice to meet you!")  # => I'm Python. Nice to meet you!
 
-# By default the print function also prints out a newline at the end.
-# Use the optional argument end to change the end string.
+# 기본적으로 print 함수는 끝에 줄 바꿈도 출력합니다.
+# 끝 문자열을 변경하려면 선택적 인수 end를 사용하십시오.
 print("Hello, World", end="!")  # => Hello, World!
 
-# Simple way to get input data from console
-input_string_var = input("Enter some data: ")  # Returns the data as a string
+# 콘솔에서 입력 데이터를 간단하게 가져오는 방법
+input_string_var = input("Enter some data: ")  # 데이터를 문자열로 반환
 
-# There are no declarations, only assignments.
-# Convention in naming variables is snake_case style
+# 선언은 없고 할당만 있습니다.
+# 변수 명명 규칙은 snake_case 스타일입니다.
 some_var = 5
 some_var  # => 5
 
-# Accessing a previously unassigned variable is an exception.
-# See Control Flow to learn more about exception handling.
-some_unknown_var  # Raises a NameError
+# 이전에 할당되지 않은 변수에 액세스하면 예외가 발생합니다.
+# 예외 처리에 대해 자세히 알아보려면 제어 흐름을 참조하십시오.
+some_unknown_var  # NameError 발생
 
-# if can be used as an expression
-# Equivalent of C's '?:' ternary operator
+# if는 표현식으로 사용할 수 있습니다.
+# C의 '?:' 삼항 연산자와 동일합니다.
 "yay!" if 0 > 1 else "nay!"  # => "nay!"
 
-# Lists store sequences
+# 리스트는 시퀀스를 저장합니다.
 li = []
-# You can start with a prefilled list
+# 미리 채워진 리스트로 시작할 수 있습니다.
 other_li = [4, 5, 6]
 
-# Add stuff to the end of a list with append
-li.append(1)    # li is now [1]
-li.append(2)    # li is now [1, 2]
-li.append(4)    # li is now [1, 2, 4]
-li.append(3)    # li is now [1, 2, 4, 3]
-# Remove from the end with pop
-li.pop()        # => 3 and li is now [1, 2, 4]
-# Let's put it back
-li.append(3)    # li is now [1, 2, 4, 3] again.
+# append로 리스트 끝에 항목 추가
+li.append(1)    # li는 이제 [1]입니다.
+li.append(2)    # li는 이제 [1, 2]입니다.
+li.append(4)    # li는 이제 [1, 2, 4]입니다.
+li.append(3)    # li는 이제 [1, 2, 4, 3]입니다.
+# pop으로 끝에서 제거
+li.pop()        # => 3이고 li는 이제 [1, 2, 4]입니다.
+# 다시 넣자
+li.append(3)    # li는 이제 다시 [1, 2, 4, 3]입니다.
 
-# Access a list like you would any array
+# 다른 배열처럼 리스트에 액세스
 li[0]   # => 1
-# Look at the last element
+# 마지막 요소 보기
 li[-1]  # => 3
 
-# Looking out of bounds is an IndexError
-li[4]  # Raises an IndexError
+# 범위를 벗어나면 IndexError입니다.
+li[4]  # IndexError 발생
 
-# You can look at ranges with slice syntax.
-# The start index is included, the end index is not
-# (It's a closed/open range for you mathy types.)
-li[1:3]   # Return list from index 1 to 3 => [2, 4]
-li[2:]    # Return list starting from index 2 => [4, 3]
-li[:3]    # Return list from beginning until index 3  => [1, 2, 4]
-li[::2]   # Return list selecting elements with a step size of 2 => [1, 4]
-li[::-1]  # Return list in reverse order => [3, 4, 2, 1]
-# Use any combination of these to make advanced slices
+# 슬라이스 구문으로 범위를 볼 수 있습니다.
+# 시작 인덱스는 포함되고 끝 인덱스는 포함되지 않습니다.
+# (수학적인 분들을 위해 닫힌/열린 범위입니다.)
+li[1:3]   # 인덱스 1에서 3까지의 목록 반환 => [2, 4]
+li[2:]    # 인덱스 2부터 시작하는 목록 반환 => [4, 3]
+li[:3]    # 처음부터 인덱스 3까지의 목록 반환  => [1, 2, 4]
+li[::2]   # 2의 단계 크기로 요소를 선택하는 목록 반환 => [1, 4]
+li[::-1]  # 역순으로 목록 반환 => [3, 4, 2, 1]
+# 고급 슬라이스를 만들기 위해 이들의 조합을 사용하십시오.
 # li[start:end:step]
 
-# Make a one layer deep copy using slices
-li2 = li[:]  # => li2 = [1, 2, 4, 3] but (li2 is li) will result in false.
+# 슬라이스를 사용하여 한 단계 깊은 복사본 만들기
+li2 = li[:]  # => li2 = [1, 2, 4, 3]이지만 (li2 is li)는 false가 됩니다.
 
-# Remove arbitrary elements from a list with "del"
-del li[2]  # li is now [1, 2, 3]
+# "del"로 리스트에서 임의의 요소 제거
+del li[2]  # li는 이제 [1, 2, 3]입니다.
 
-# Remove first occurrence of a value
-li.remove(2)  # li is now [1, 3]
-li.remove(2)  # Raises a ValueError as 2 is not in the list
+# 값의 첫 번째 발생 제거
+li.remove(2)  # li는 이제 [1, 3]입니다.
+li.remove(2)  # 2가 목록에 없으므로 ValueError 발생
 
-# Insert an element at a specific index
-li.insert(1, 2)  # li is now [1, 2, 3] again
+# 특정 인덱스에 요소 삽입
+li.insert(1, 2)  # li는 이제 다시 [1, 2, 3]입니다.
 
-# Get the index of the first item found matching the argument
+# 인자와 일치하는 첫 번째 항목의 인덱스 가져오기
 li.index(2)  # => 1
-li.index(4)  # Raises a ValueError as 4 is not in the list
+li.index(4)  # 4가 목록에 없으므로 ValueError 발생
 
-# You can add lists
-# Note: values for li and for other_li are not modified.
+# 리스트를 추가할 수 있습니다.
+# 참고: li와 other_li의 값은 수정되지 않습니다.
 li + other_li  # => [1, 2, 3, 4, 5, 6]
 
-# Concatenate lists with "extend()"
-li.extend(other_li)  # Now li is [1, 2, 3, 4, 5, 6]
+# "extend()"로 리스트 연결
+li.extend(other_li)  # 이제 li는 [1, 2, 3, 4, 5, 6]입니다.
 
-# Check for existence in a list with "in"
+# "in"으로 리스트에 존재 여부 확인
 1 in li  # => True
 
-# Examine the length with "len()"
+# "len()"으로 길이 검사
 len(li)  # => 6
 
 
-# Tuples are like lists but are immutable.
+# 튜플은 리스트와 같지만 불변입니다.
 tup = (1, 2, 3)
 tup[0]      # => 1
-tup[0] = 3  # Raises a TypeError
+tup[0] = 3  # TypeError 발생
 
-# Note that a tuple of length one has to have a comma after the last element but
-# tuples of other lengths, even zero, do not.
+# 길이가 1인 튜플은 마지막 요소 뒤에 쉼표가 있어야 하지만
+# 0을 포함한 다른 길이의 튜플은 그렇지 않습니다.
 type((1))   # => <class 'int'>
 type((1,))  # => <class 'tuple'>
 type(())    # => <class 'tuple'>
 
-# You can do most of the list operations on tuples too
+# 튜플에서도 대부분의 리스트 작업을 수행할 수 있습니다.
 len(tup)         # => 3
 tup + (4, 5, 6)  # => (1, 2, 3, 4, 5, 6)
 tup[:2]          # => (1, 2)
 2 in tup         # => True
 
-# You can unpack tuples (or lists) into variables
-a, b, c = (1, 2, 3)  # a is now 1, b is now 2 and c is now 3
-# You can also do extended unpacking
-a, *b, c = (1, 2, 3, 4)  # a is now 1, b is now [2, 3] and c is now 4
-# Tuples are created by default if you leave out the parentheses
-d, e, f = 4, 5, 6  # tuple 4, 5, 6 is unpacked into variables d, e and f
-# respectively such that d = 4, e = 5 and f = 6
-# Now look how easy it is to swap two values
-e, d = d, e  # d is now 5 and e is now 4
+# 튜플(또는 리스트)을 변수로 언패킹할 수 있습니다.
+a, b, c = (1, 2, 3)  # a는 이제 1, b는 이제 2, c는 이제 3입니다.
+# 확장 언패킹도 할 수 있습니다.
+a, *b, c = (1, 2, 3, 4)  # a는 이제 1, b는 이제 [2, 3], c는 이제 4입니다.
+# 괄호를 생략하면 기본적으로 튜플이 생성됩니다.
+d, e, f = 4, 5, 6  # 튜플 4, 5, 6이 변수 d, e, f로 언패킹됩니다.
+# 각각 d = 4, e = 5, f = 6이 되도록
+# 이제 두 값을 바꾸는 것이 얼마나 쉬운지 보십시오.
+e, d = d, e  # d는 이제 5, e는 이제 4입니다.
 
 
-# Dictionaries store mappings from keys to values
+# 딕셔너리는 키에서 값으로의 매핑을 저장합니다.
 empty_dict = {}
-# Here is a prefilled dictionary
+# 미리 채워진 딕셔너리
 filled_dict = {"one": 1, "two": 2, "three": 3}
 
-# Note keys for dictionaries have to be immutable types. This is to ensure that
-# the key can be converted to a constant hash value for quick look-ups.
-# Immutable types include ints, floats, strings, tuples.
-invalid_dict = {[1,2,3]: "123"}  # => Yield a TypeError: unhashable type: 'list'
-valid_dict = {(1,2,3):[1,2,3]}   # Values can be of any type, however.
+# 딕셔너리의 키는 불변 타입이어야 합니다. 이는 키가
+# 빠른 조회를 위해 상수 해시 값으로 변환될 수 있도록 하기 위함입니다.
+# 불변 타입에는 int, float, string, tuple이 포함됩니다.
+invalid_dict = {[1,2,3]: "123"}  # => TypeError: unhashable type: 'list' 발생
+valid_dict = {(1,2,3):[1,2,3]}   # 값은 모든 타입이 될 수 있습니다.
 
-# Look up values with []
+# []로 값 조회
 filled_dict["one"]  # => 1
 
-# Get all keys as an iterable with "keys()". We need to wrap the call in list()
-# to turn it into a list. We'll talk about those later.  Note - for Python
-# versions <3.7, dictionary key ordering is not guaranteed. Your results might
-# not match the example below exactly. However, as of Python 3.7, dictionary
-# items maintain the order at which they are inserted into the dictionary.
+# "keys()"로 모든 키를 반복 가능한 객체로 가져오기. list()로 호출을 래핑해야
+# 목록으로 변환됩니다. 나중에 이에 대해 이야기하겠습니다. 참고 - Python
+# 3.7 미만 버전의 경우 딕셔너리 키 순서가 보장되지 않습니다. 결과가
+# 아래 예제와 정확히 일치하지 않을 수 있습니다. 그러나 Python 3.7부터는 딕셔너리
+# 항목이 딕셔너리에 삽입된 순서를 유지합니다.
 list(filled_dict.keys())  # => ["three", "two", "one"] in Python <3.7
 list(filled_dict.keys())  # => ["one", "two", "three"] in Python 3.7+
 
 
-# Get all values as an iterable with "values()". Once again we need to wrap it
-# in list() to get it out of the iterable. Note - Same as above regarding key
-# ordering.
+# "values()"로 모든 값을 반복 가능한 객체로 가져오기. 다시 한 번 list()로 래핑해야
+# 반복 가능한 객체에서 벗어날 수 있습니다. 참고 - 키 순서에 대한 위와 동일합니다.
 list(filled_dict.values())  # => [3, 2, 1]  in Python <3.7
 list(filled_dict.values())  # => [1, 2, 3] in Python 3.7+
 
-# Check for existence of keys in a dictionary with "in"
+# "in"으로 딕셔너리에 키 존재 여부 확인
 "one" in filled_dict  # => True
 1 in filled_dict      # => False
 
-# Looking up a non-existing key is a KeyError
+# 존재하지 않는 키를 조회하면 KeyError입니다.
 filled_dict["four"]  # KeyError
 
-# Use "get()" method to avoid the KeyError
+# KeyError를 피하기 위해 "get()" 메서드 사용
 filled_dict.get("one")      # => 1
 filled_dict.get("four")     # => None
-# The get method supports a default argument when the value is missing
+# get 메서드는 값이 없을 때 기본 인수를 지원합니다.
 filled_dict.get("one", 4)   # => 1
 filled_dict.get("four", 4)  # => 4
 
-# "setdefault()" inserts into a dictionary only if the given key isn't present
-filled_dict.setdefault("five", 5)  # filled_dict["five"] is set to 5
-filled_dict.setdefault("five", 6)  # filled_dict["five"] is still 5
+# "setdefault()"는 주어진 키가 없는 경우에만 딕셔너리에 삽입합니다.
+filled_dict.setdefault("five", 5)  # filled_dict["five"]가 5로 설정됨
+filled_dict.setdefault("five", 6)  # filled_dict["five"]는 여전히 5입니다.
 
-# Adding to a dictionary
+# 딕셔너리에 추가
 filled_dict.update({"four":4})  # => {"one": 1, "two": 2, "three": 3, "four": 4}
-filled_dict["four"] = 4         # another way to add to dict
+filled_dict["four"] = 4         # 딕셔너리에 추가하는 다른 방법
 
-# Remove keys from a dictionary with del
-del filled_dict["one"]  # Removes the key "one" from filled dict
+# del로 딕셔너리에서 키 제거
+del filled_dict["one"]  # filled dict에서 "one" 키 제거
 
-# From Python 3.5 you can also use the additional unpacking options
+# Python 3.5부터 추가 언패킹 옵션을 사용할 수도 있습니다.
 {"a": 1, **{"b": 2}}  # => {'a': 1, 'b': 2}
 {"a": 1, **{"a": 2}}  # => {'a': 2}
 
 
-# Sets store ... well sets
+# 세트는... 음, 세트를 저장합니다.
 empty_set = set()
-# Initialize a set with a bunch of values.
-some_set = {1, 1, 2, 2, 3, 4}  # some_set is now {1, 2, 3, 4}
+# 여러 값으로 세트 초기화
+some_set = {1, 1, 2, 2, 3, 4}  # some_set은 이제 {1, 2, 3, 4}입니다.
 
-# Similar to keys of a dictionary, elements of a set have to be immutable.
-invalid_set = {[1], 1}  # => Raises a TypeError: unhashable type: 'list'
+# 딕셔너리의 키와 마찬가지로 세트의 요소는 불변이어야 합니다.
+invalid_set = {[1], 1}  # => TypeError: unhashable type: 'list' 발생
 valid_set = {(1,), 1}
 
-# Add one more item to the set
+# 세트에 항목 하나 더 추가
 filled_set = some_set
-filled_set.add(5)  # filled_set is now {1, 2, 3, 4, 5}
-# Sets do not have duplicate elements
-filled_set.add(5)  # it remains as before {1, 2, 3, 4, 5}
+filled_set.add(5)  # filled_set은 이제 {1, 2, 3, 4, 5}입니다.
+# 세트에는 중복 요소가 없습니다.
+filled_set.add(5)  # 이전과 같이 {1, 2, 3, 4, 5}로 유지됩니다.
 
-# Do set intersection with &
+# &로 세트 교집합
 other_set = {3, 4, 5, 6}
 filled_set & other_set  # => {3, 4, 5}
 
-# Do set union with |
+# |로 세트 합집합
 filled_set | other_set  # => {1, 2, 3, 4, 5, 6}
 
-# Do set difference with -
+# -로 세트 차집합
 {1, 2, 3, 4} - {2, 3, 5}  # => {1, 4}
 
-# Do set symmetric difference with ^
+# ^로 세트 대칭 차집합
 {1, 2, 3, 4} ^ {2, 3, 5}  # => {1, 4, 5}
 
-# Check if set on the left is a superset of set on the right
+# 왼쪽 세트가 오른쪽 세트의 상위 집합인지 확인
 {1, 2} >= {1, 2, 3}  # => False
 
-# Check if set on the left is a subset of set on the right
+# 왼쪽 세트가 오른쪽 세트의 하위 집합인지 확인
 {1, 2} <= {1, 2, 3}  # => True
 
-# Check for existence in a set with in
+# in으로 세트에 존재 여부 확인
 2 in filled_set   # => True
 10 in filled_set  # => False
 
-# Make a one layer deep copy
-filled_set = some_set.copy()  # filled_set is {1, 2, 3, 4, 5}
+# 한 단계 깊은 복사본 만들기
+filled_set = some_set.copy()  # filled_set은 {1, 2, 3, 4, 5}입니다.
 filled_set is some_set        # => False
 
 
 ####################################################
-## 3. Control Flow and Iterables
+## 3. 제어 흐름 및 반복 가능 객체
 ####################################################
 
-# Let's just make a variable
+# 변수를 만들어 봅시다.
 some_var = 5
 
-# Here is an if statement. Indentation is significant in Python!
-# Convention is to use four spaces, not tabs.
-# This prints "some_var is smaller than 10"
+# if 문입니다. Python에서는 들여쓰기가 중요합니다!
+# 관례는 탭이 아닌 4개의 공백을 사용하는 것입니다.
+# "some_var is smaller than 10"을 출력합니다.
 if some_var > 10:
     print("some_var is totally bigger than 10.")
-elif some_var < 10:    # This elif clause is optional.
+elif some_var < 10:    # 이 elif 절은 선택 사항입니다.
     print("some_var is smaller than 10.")
-else:                  # This is optional too.
+else:                  # 이것도 선택 사항입니다.
     print("some_var is indeed 10.")
 
-# Match/Case — Introduced in Python 3.10
-# It compares a value against multiple patterns and executes the matching case block.
+# Match/Case — Python 3.10에 도입됨
+# 여러 패턴에 대해 값을 비교하고 일치하는 케이스 블록을 실행합니다.
 
 command = "run"
 
 match command:
     case "run":
         print("The robot started to run 🏃‍♂️")
-    case "speak" | "say_hi":  # multiple options (OR pattern)
+    case "speak" | "say_hi":  # 여러 옵션 (OR 패턴)
         print("The robot said hi 🗣️")
-    case code if command.isdigit():  # conditional
+    case code if command.isdigit():  # 조건부
         print(f"The robot execute code: {code}")
-    case _:  # _ is a wildcard that never fails (like default/else)
+    case _:  # _는 절대 실패하지 않는 와일드카드입니다 (default/else와 같음)
         print("Invalid command ❌")
 
-# Output: "the robot started to run 🏃‍♂️"
+# 출력: "the robot started to run 🏃‍♂️"
 
 """
-For loops iterate over lists
-prints:
+For 루프는 리스트를 반복합니다.
+출력:
     dog is a mammal
     cat is a mammal
     mouse is a mammal
 """
 for animal in ["dog", "cat", "mouse"]:
-    # You can use format() to interpolate formatted strings
+    # format()을 사용하여 서식화된 문자열을 보간할 수 있습니다.
     print("{} is a mammal".format(animal))
 
 """
-"range(number)" returns an iterable of numbers
-from zero up to (but excluding) the given number
-prints:
+"range(number)"는 0부터 주어진 숫자
+(제외)까지의 숫자 반복 가능 객체를 반환합니다.
+출력:
     0
     1
     2
@@ -447,9 +444,9 @@ for i in range(4):
     print(i)
 
 """
-"range(lower, upper)" returns an iterable of numbers
-from the lower number to the upper number
-prints:
+"range(lower, upper)"는 아래 숫자에서 위 숫자까지의
+숫자 반복 가능 객체를 반환합니다.
+출력:
     4
     5
     6
@@ -459,10 +456,10 @@ for i in range(4, 8):
     print(i)
 
 """
-"range(lower, upper, step)" returns an iterable of numbers
-from the lower number to the upper number, while incrementing
-by step. If step is not indicated, the default value is 1.
-prints:
+"range(lower, upper, step)"는 아래 숫자에서 위 숫자까지
+step만큼 증가하면서 숫자 반복 가능 객체를 반환합니다.
+step이 표시되지 않으면 기본값은 1입니다.
+출력:
     4
     6
 """
@@ -470,7 +467,7 @@ for i in range(4, 8, 2):
     print(i)
 
 """
-Loop over a list to retrieve both the index and the value of each list item:
+리스트를 반복하여 각 리스트 항목의 인덱스와 값을 모두 검색합니다.
     0 dog
     1 cat
     2 mouse
@@ -480,8 +477,8 @@ for i, value in enumerate(animals):
     print(i, value)
 
 """
-While loops go until a condition is no longer met.
-prints:
+While 루프는 조건이 더 이상 충족되지 않을 때까지 계속됩니다.
+출력:
     0
     1
     2
@@ -490,175 +487,175 @@ prints:
 x = 0
 while x < 4:
     print(x)
-    x += 1  # Shorthand for x = x + 1
+    x += 1  # x = x + 1의 약어
 
-# Handle exceptions with a try/except block
+# try/except 블록으로 예외 처리
 try:
-    # Use "raise" to raise an error
+    # "raise"를 사용하여 오류 발생
     raise IndexError("This is an index error")
 except IndexError as e:
-    pass                 # Refrain from this, provide a recovery (next example).
+    pass                 # 이것은 삼가십시오. 복구를 제공하십시오 (다음 예제).
 except (TypeError, NameError):
-    pass                 # Multiple exceptions can be processed jointly.
-else:                    # Optional clause to the try/except block. Must follow
-                         # all except blocks.
-    print("All good!")   # Runs only if the code in try raises no exceptions
-finally:                 # Execute under all circumstances
+    pass                 # 여러 예외를 공동으로 처리할 수 있습니다.
+else:                    # try/except 블록의 선택적 절. 모든
+                         # except 블록을 따라야 합니다.
+    print("All good!")   # try의 코드가 예외를 발생시키지 않을 때만 실행됩니다.
+finally:                 # 모든 상황에서 실행
     print("We can clean up resources here")
 
-# Instead of try/finally to cleanup resources you can use a with statement
+# 리소스 정리를 위해 try/finally 대신 with 문을 사용할 수 있습니다.
 with open("myfile.txt") as f:
     for line in f:
         print(line)
 
-# Writing to a file
+# 파일에 쓰기
 contents = {"aa": 12, "bb": 21}
 with open("myfile1.txt", "w") as file:
-    file.write(str(contents))        # writes a string to a file
+    file.write(str(contents))        # 파일에 문자열 쓰기
 
 import json
 with open("myfile2.txt", "w") as file:
-    file.write(json.dumps(contents))  # writes an object to a file
+    file.write(json.dumps(contents))  # 파일에 객체 쓰기
 
-# Reading from a file
+# 파일에서 읽기
 with open("myfile1.txt") as file:
-    contents = file.read()           # reads a string from a file
+    contents = file.read()           # 파일에서 문자열 읽기
 print(contents)
-# print: {"aa": 12, "bb": 21}
+# 출력: {"aa": 12, "bb": 21}
 
 with open("myfile2.txt", "r") as file:
-    contents = json.load(file)       # reads a json object from a file
+    contents = json.load(file)       # 파일에서 json 객체 읽기
 print(contents)
-# print: {"aa": 12, "bb": 21}
+# 출력: {"aa": 12, "bb": 21}
 
 
-# Python offers a fundamental abstraction called the Iterable.
-# An iterable is an object that can be treated as a sequence.
-# The object returned by the range function, is an iterable.
+# Python은 반복 가능이라는 기본 추상화를 제공합니다.
+# 반복 가능 객체는 시퀀스로 처리할 수 있는 객체입니다.
+# range 함수에서 반환된 객체는 반복 가능 객체입니다.
 
 filled_dict = {"one": 1, "two": 2, "three": 3}
 our_iterable = filled_dict.keys()
-print(our_iterable)  # => dict_keys(['one', 'two', 'three']). This is an object
-                     # that implements our Iterable interface.
+print(our_iterable)  # => dict_keys(['one', 'two', 'three']). 이것은
+                     # Iterable 인터페이스를 구현하는 객체입니다.
 
-# We can loop over it.
+# 반복할 수 있습니다.
 for i in our_iterable:
-    print(i)  # Prints one, two, three
+    print(i)  # one, two, three 출력
 
-# However we cannot address elements by index.
-our_iterable[1]  # Raises a TypeError
+# 그러나 인덱스로 요소에 주소를 지정할 수는 없습니다.
+our_iterable[1]  # TypeError 발생
 
-# An iterable is an object that knows how to create an iterator.
+# 반복 가능 객체는 반복자를 만드는 방법을 아는 객체입니다.
 our_iterator = iter(our_iterable)
 
-# Our iterator is an object that can remember the state as we traverse through
-# it. We get the next object with "next()".
+# 반복자는 반복하면서 상태를 기억할 수 있는 객체입니다.
+# "next()"로 다음 객체를 가져옵니다.
 next(our_iterator)  # => "one"
 
-# It maintains state as we iterate.
+# 반복하면서 상태를 유지합니다.
 next(our_iterator)  # => "two"
 next(our_iterator)  # => "three"
 
-# After the iterator has returned all of its data, it raises a
-# StopIteration exception
-next(our_iterator)  # Raises StopIteration
+# 반복자가 모든 데이터를 반환한 후에는
+# StopIteration 예외를 발생시킵니다.
+next(our_iterator)  # StopIteration 발생
 
-# We can also loop over it, in fact, "for" does this implicitly!
+# 반복할 수도 있습니다. 사실 "for"는 암시적으로 이 작업을 수행합니다!
 our_iterator = iter(our_iterable)
 for i in our_iterator:
-    print(i)  # Prints one, two, three
+    print(i)  # one, two, three 출력
 
-# You can grab all the elements of an iterable or iterator by call of list().
-list(our_iterable)  # => Returns ["one", "two", "three"]
-list(our_iterator)  # => Returns [] because state is saved
+# list() 호출로 반복 가능 객체 또는 반복자의 모든 요소를 가져올 수 있습니다.
+list(our_iterable)  # => ["one", "two", "three"] 반환
+list(our_iterator)  # => [] 반환, 상태가 저장되었기 때문
 
 
 ####################################################
-## 4. Functions
+## 4. 함수
 ####################################################
 
-# Use "def" to create new functions
+# "def"를 사용하여 새 함수 생성
 def add(x, y):
     print("x is {} and y is {}".format(x, y))
-    return x + y  # Return values with a return statement
+    return x + y  # return 문으로 값 반환
 
-# Calling functions with parameters
-add(5, 6)  # => prints out "x is 5 and y is 6" and returns 11
+# 매개변수로 함수 호출
+add(5, 6)  # => "x is 5 and y is 6"을 출력하고 11을 반환
 
-# Another way to call functions is with keyword arguments
-add(y=6, x=5)  # Keyword arguments can arrive in any order.
+# 함수를 호출하는 다른 방법은 키워드 인수입니다.
+add(y=6, x=5)  # 키워드 인수는 순서에 상관없이 도착할 수 있습니다.
 
-# You can define functions that take a variable number of
-# positional arguments
+# 가변 개수의 위치 인수를 받는 함수를
+# 정의할 수 있습니다.
 def varargs(*args):
     return args
 
 varargs(1, 2, 3)  # => (1, 2, 3)
 
-# You can define functions that take a variable number of
-# keyword arguments, as well
+# 가변 개수의 키워드 인수를 받는 함수를
+# 정의할 수도 있습니다.
 def keyword_args(**kwargs):
     return kwargs
 
-# Let's call it to see what happens
+# 어떻게 되는지 보기 위해 호출해 봅시다.
 keyword_args(big="foot", loch="ness")  # => {"big": "foot", "loch": "ness"}
 
 
-# You can do both at once, if you like
+# 원한다면 한 번에 둘 다 할 수 있습니다.
 def all_the_args(*args, **kwargs):
     print(args)
     print(kwargs)
 """
-all_the_args(1, 2, a=3, b=4) prints:
+all_the_args(1, 2, a=3, b=4) 출력:
     (1, 2)
     {"a": 3, "b": 4}
 """
 
-# When calling functions, you can do the opposite of args/kwargs!
-# Use * to expand args (tuples) and use ** to expand kwargs (dictionaries).
+# 함수를 호출할 때 args/kwargs의 반대 작업을 수행할 수 있습니다!
+# *를 사용하여 args(튜플)를 확장하고 **를 사용하여 kwargs(딕셔너리)를 확장합니다.
 args = (1, 2, 3, 4)
 kwargs = {"a": 3, "b": 4}
-all_the_args(*args)            # equivalent: all_the_args(1, 2, 3, 4)
-all_the_args(**kwargs)         # equivalent: all_the_args(a=3, b=4)
-all_the_args(*args, **kwargs)  # equivalent: all_the_args(1, 2, 3, 4, a=3, b=4)
+all_the_args(*args)            # 동등: all_the_args(1, 2, 3, 4)
+all_the_args(**kwargs)         # 동등: all_the_args(a=3, b=4)
+all_the_args(*args, **kwargs)  # 동등: all_the_args(1, 2, 3, 4, a=3, b=4)
 
-# Returning multiple values (with tuple assignments)
+# 여러 값 반환 (튜플 할당 사용)
 def swap(x, y):
-    return y, x  # Return multiple values as a tuple without the parenthesis.
-                 # (Note: parenthesis have been excluded but can be included)
+    return y, x  # 괄호 없이 튜플로 여러 값 반환
+                 # (참고: 괄호는 제외되었지만 포함될 수 있음)
 
 x = 1
 y = 2
 x, y = swap(x, y)     # => x = 2, y = 1
-# (x, y) = swap(x,y)  # Again the use of parenthesis is optional.
+# (x, y) = swap(x,y)  # 다시 괄호 사용은 선택 사항입니다.
 
-# global scope
+# 전역 범위
 x = 5
 
 def set_x(num):
-    # local scope begins here
-    # local var x not the same as global var x
+    # 지역 범위 시작
+    # 지역 변수 x는 전역 변수 x와 다릅니다.
     x = num    # => 43
     print(x)   # => 43
 
 def set_global_x(num):
-    # global indicates that particular var lives in the global scope
+    # global은 특정 변수가 전역 범위에 있음을 나타냅니다.
     global x
     print(x)   # => 5
-    x = num    # global var x is now set to 6
+    x = num    # 전역 변수 x가 이제 6으로 설정됨
     print(x)   # => 6
 
 set_x(43)
 set_global_x(6)
 """
-prints:
+출력:
     43
     5
     6
 """
 
 
-# Python has first class functions
+# Python에는 일급 함수가 있습니다.
 def create_adder(x):
     def adder(y):
         return x + y
@@ -667,8 +664,8 @@ def create_adder(x):
 add_10 = create_adder(10)
 add_10(3)   # => 13
 
-# Closures in nested functions:
-# We can use the nonlocal keyword to work with variables in nested scope which shouldn't be declared in the inner functions.
+# 중첩된 함수의 클로저:
+# nonlocal 키워드를 사용하여 내부 함수에서 선언되어서는 안 되는 중첩된 범위의 변수로 작업할 수 있습니다.
 def create_avg():
     total = 0
     count = 0
@@ -683,215 +680,215 @@ avg(3)  # => 3.0
 avg(5)  # (3+5)/2 => 4.0
 avg(7)  # (8+7)/3 => 5.0
 
-# There are also anonymous functions
+# 익명 함수도 있습니다.
 (lambda x: x > 2)(3)                  # => True
 (lambda x, y: x ** 2 + y ** 2)(2, 1)  # => 5
 
-# There are built-in higher order functions
+# 내장 고차 함수가 있습니다.
 list(map(add_10, [1, 2, 3]))          # => [11, 12, 13]
 list(map(max, [1, 2, 3], [4, 2, 1]))  # => [4, 2, 3]
 
 list(filter(lambda x: x > 5, [3, 4, 5, 6, 7]))  # => [6, 7]
 
-# We can use list comprehensions for nice maps and filters
-# List comprehension stores the output as a list (which itself may be nested).
+# 멋진 맵과 필터를 위해 리스트 내포를 사용할 수 있습니다.
+# 리스트 내포는 출력을 리스트로 저장합니다(자체적으로 중첩될 수 있음).
 [add_10(i) for i in [1, 2, 3]]         # => [11, 12, 13]
 [x for x in [3, 4, 5, 6, 7] if x > 5]  # => [6, 7]
 
-# You can construct set and dict comprehensions as well.
+# 세트 및 딕셔너리 내포도 구성할 수 있습니다.
 {x for x in "abcddeef" if x not in "abc"}  # => {'d', 'e', 'f'}
 {x: x**2 for x in range(5)}  # => {0: 0, 1: 1, 2: 4, 3: 9, 4: 16}
 
 
 ####################################################
-## 5. Modules
+## 5. 모듈
 ####################################################
 
-# You can import modules
+# 모듈을 가져올 수 있습니다.
 import math
 print(math.sqrt(16))  # => 4.0
 
-# You can get specific functions from a module
+# 모듈에서 특정 함수를 가져올 수 있습니다.
 from math import ceil, floor
 print(ceil(3.7))   # => 4
 print(floor(3.7))  # => 3
 
-# You can import all functions from a module.
-# Warning: this is not recommended
+# 모듈에서 모든 함수를 가져올 수 있습니다.
+# 경고: 권장하지 않습니다.
 from math import *
 
-# You can shorten module names
+# 모듈 이름을 단축할 수 있습니다.
 import math as m
 math.sqrt(16) == m.sqrt(16)  # => True
 
-# Python modules are just ordinary Python files. You
-# can write your own, and import them. The name of the
-# module is the same as the name of the file.
+# Python 모듈은 일반 Python 파일일 뿐입니다.
+# 직접 작성하고 가져올 수 있습니다. 모듈의 이름은
+# 파일 이름과 동일합니다.
 
-# You can find out which functions and attributes
-# are defined in a module.
+# 모듈에 정의된 함수와 속성을
+# 찾을 수 있습니다.
 import math
 dir(math)
 
-# If you have a Python script named math.py in the same
-# folder as your current script, the file math.py will
-# be loaded instead of the built-in Python module.
-# This happens because the local folder has priority
-# over Python's built-in libraries.
+# 현재 스크립트와 동일한 폴더에 math.py라는
+# Python 스크립트가 있는 경우, 내장 Python 모듈 대신
+# math.py 파일이 로드됩니다.
+# 이것은 로컬 폴더가 Python의 내장 라이브러리보다
+# 우선순위가 높기 때문에 발생합니다.
 
 
 ####################################################
-## 6. Classes
+## 6. 클래스
 ####################################################
 
-# We use the "class" statement to create a class
+# "class" 문을 사용하여 클래스를 만듭니다.
 class Human:
 
-    # A class attribute. It is shared by all instances of this class
+    # 클래스 속성입니다. 이 클래스의 모든 인스턴스에서 공유됩니다.
     species = "H. sapiens"
 
-    # Basic initializer, this is called when this class is instantiated.
-    # Note that the double leading and trailing underscores denote objects
-    # or attributes that are used by Python but that live in user-controlled
-    # namespaces. Methods(or objects or attributes) like: __init__, __str__,
-    # __repr__ etc. are called special methods (or sometimes called dunder
-    # methods). You should not invent such names on your own.
+    # 기본 초기화자, 이 클래스가 인스턴스화될 때 호출됩니다.
+    # 이중 선행 및 후행 밑줄은 Python에서 사용되지만
+    # 사용자 제어 네임스페이스에 있는 객체 또는 속성을 나타냅니다.
+    # __init__, __str__, __repr__ 등과 같은 메서드(또는 객체 또는 속성)는
+    # 특수 메서드(때로는 dunder 메서드라고도 함)라고 합니다.
+    # 이러한 이름을 직접 만들어서는 안 됩니다.
     def __init__(self, name):
-        # Assign the argument to the instance's name attribute
+        # 인수를 인스턴스의 이름 속성에 할당
         self.name = name
 
-        # Initialize property
-        self._age = 0   # the leading underscore indicates the "age" property is
-                        # intended to be used internally
-                        # do not rely on this to be enforced: it's a hint to other devs
+        # 속성 초기화
+        self._age = 0   # 선행 밑줄은 "age" 속성이
+                        # 내부적으로 사용되도록 의도되었음을 나타냅니다.
+                        # 이것이 강제될 것이라고 의존하지 마십시오. 다른 개발자에게 힌트입니다.
 
-    # An instance method. All methods take "self" as the first argument
+    # 인스턴스 메서드입니다. 모든 메서드는 "self"를 첫 번째 인수로 받습니다.
     def say(self, msg):
         print("{name}: {message}".format(name=self.name, message=msg))
 
-    # Another instance method
+    # 다른 인스턴스 메서드
     def sing(self):
         return "yo... yo... microphone check... one two... one two..."
 
-    # A class method is shared among all instances
-    # They are called with the calling class as the first argument
+    # 클래스 메서드는 모든 인스턴스에서 공유됩니다.
+    # 호출하는 클래스를 첫 번째 인수로 사용하여 호출됩니다.
     @classmethod
     def get_species(cls):
         return cls.species
 
-    # A static method is called without a class or instance reference
+    # 정적 메서드는 클래스 또는 인스턴스 참조 없이 호출됩니다.
     @staticmethod
     def grunt():
         return "*grunt*"
 
-    # A property is just like a getter.
-    # It turns the method age() into a read-only attribute of the same name.
-    # There's no need to write trivial getters and setters in Python, though.
+    # 속성은 getter와 같습니다.
+    # age() 메서드를 동일한 이름의 읽기 전용 속성으로 바꿉니다.
+    # 하지만 Python에서는 사소한 getter와 setter를 작성할 필요가 없습니다.
     @property
     def age(self):
         return self._age
 
-    # This allows the property to be set
+    # 이렇게 하면 속성을 설정할 수 있습니다.
     @age.setter
     def age(self, age):
         self._age = age
 
-    # This allows the property to be deleted
+    # 이렇게 하면 속성을 삭제할 수 있습니다.
     @age.deleter
     def age(self):
         del self._age
 
 
-# When a Python interpreter reads a source file it executes all its code.
-# This __name__ check makes sure this code block is only executed when this
-# module is the main program.
+# Python 인터프리터가 소스 파일을 읽을 때 모든 코드를 실행합니다.
+# 이 __name__ 검사는 이 코드 블록이 이 모듈이
+# 주 프로그램일 때만 실행되도록 합니다.
 if __name__ == "__main__":
-    # Instantiate a class
+    # 클래스 인스턴스화
     i = Human(name="Ian")
     i.say("hi")                     # "Ian: hi"
     j = Human("Joel")
     j.say("hello")                  # "Joel: hello"
-    # i and j are instances of type Human; i.e., they are Human objects.
+    # i와 j는 Human 타입의 인스턴스입니다. 즉, Human 객체입니다.
 
-    # Call our class method
+    # 클래스 메서드 호출
     i.say(i.get_species())          # "Ian: H. sapiens"
-    # Change the shared attribute
+    # 공유 속성 변경
     Human.species = "H. neanderthalensis"
     i.say(i.get_species())          # => "Ian: H. neanderthalensis"
     j.say(j.get_species())          # => "Joel: H. neanderthalensis"
 
-    # Call the static method
+    # 정적 메서드 호출
     print(Human.grunt())            # => "*grunt*"
 
-    # Static methods can be called by instances too
+    # 정적 메서드는 인스턴스에서도 호출할 수 있습니다.
     print(i.grunt())                # => "*grunt*"
 
-    # Update the property for this instance
+    # 이 인스턴스의 속성 업데이트
     i.age = 42
-    # Get the property
+    # 속성 가져오기
     i.say(i.age)                    # => "Ian: 42"
     j.say(j.age)                    # => "Joel: 0"
-    # Delete the property
+    # 속성 삭제
     del i.age
-    # i.age                         # => this would raise an AttributeError
+    # i.age                         # => AttributeError 발생
 
 
 ####################################################
-## 6.1 Inheritance
+## 6.1 상속
 ####################################################
 
-# Inheritance allows new child classes to be defined that inherit methods and
-# variables from their parent class.
+# 상속을 통해 부모 클래스에서 메서드와
+# 변수를 상속하는 새로운 자식 클래스를 정의할 수 있습니다.
 
-# Using the Human class defined above as the base or parent class, we can
-# define a child class, Superhero, which inherits variables like "species",
-# "name", and "age", as well as methods, like "sing" and "grunt"
-# from the Human class, but can also have its own unique properties.
+# 위에서 정의한 Human 클래스를 기본 또는 부모 클래스로 사용하여
+# 자식 클래스인 Superhero를 정의할 수 있습니다. Superhero는 "species",
+# "name", "age"와 같은 변수와 "sing", "grunt"와 같은 메서드를
+# Human 클래스에서 상속하지만, 자신만의 고유한 속성을 가질 수도 있습니다.
 
-# To take advantage of modularization by file you could place the classes above
-# in their own files, say, human.py
+# 파일별 모듈화를 활용하려면 위 클래스를
+# human.py와 같은 자체 파일에 배치할 수 있습니다.
 
-# To import functions from other files use the following format
-# from "filename-without-extension" import "function-or-class"
+# 다른 파일에서 함수를 가져오려면 다음 형식을 사용하십시오.
+# from "파일이름-확장자없음" import "함수-또는-클래스"
 
 from human import Human
 
 
-# Specify the parent class(es) as parameters to the class definition
+# 부모 클래스를 클래스 정의의 매개변수로 지정
 class Superhero(Human):
 
-    # If the child class should inherit all of the parent's definitions without
-    # any modifications, you can just use the "pass" keyword (and nothing else)
-    # but in this case it is commented out to allow for a unique child class:
+    # 자식 클래스가 부모의 모든 정의를 수정 없이
+    # 상속해야 하는 경우 "pass" 키워드를 사용할 수 있습니다(다른 것은 없음).
+    # 하지만 이 경우 고유한 자식 클래스를 허용하기 위해 주석 처리되었습니다.
     # pass
 
-    # Child classes can override their parents' attributes
+    # 자식 클래스는 부모의 속성을 재정의할 수 있습니다.
     species = "Superhuman"
 
-    # Children automatically inherit their parent class's constructor including
-    # its arguments, but can also define additional arguments or definitions
-    # and override its methods such as the class constructor.
-    # This constructor inherits the "name" argument from the "Human" class and
-    # adds the "superpower" and "movie" arguments:
+    # 자식은 부모 클래스의 생성자를 자동으로 상속하며
+    # 인수도 포함하지만, 추가 인수를 정의하거나 정의하고
+    # 클래스 생성자와 같은 메서드를 재정의할 수도 있습니다.
+    # 이 생성자는 "Human" 클래스에서 "name" 인수를 상속하고
+    # "superpower" 및 "movie" 인수를 추가합니다.
     def __init__(self, name, movie=False,
                  superpowers=["super strength", "bulletproofing"]):
 
-        # add additional class attributes:
+        # 추가 클래스 속성 추가:
         self.fictional = True
         self.movie = movie
-        # be aware of mutable default values, since defaults are shared
+        # 기본값이 공유되므로 가변 기본값에 유의하십시오.
         self.superpowers = superpowers
 
-        # The "super" function lets you access the parent class's methods
-        # that are overridden by the child, in this case, the __init__ method.
-        # This calls the parent class constructor:
+        # "super" 함수를 사용하면 자식에 의해 재정의된
+        # 부모 클래스의 메서드에 액세스할 수 있습니다. 이 경우 __init__ 메서드입니다.
+        # 이것은 부모 클래스 생성자를 호출합니다.
         super().__init__(name)
 
-    # override the sing method
+    # sing 메서드 재정의
     def sing(self):
         return "Dun, dun, DUN!"
 
-    # add an additional instance method
+    # 추가 인스턴스 메서드 추가
     def boast(self):
         for power in self.superpowers:
             print("I wield the power of {pow}!".format(pow=power))
@@ -900,44 +897,44 @@ class Superhero(Human):
 if __name__ == "__main__":
     sup = Superhero(name="Tick")
 
-    # Instance type checks
+    # 인스턴스 타입 확인
     if isinstance(sup, Human):
         print("I am human")
     if type(sup) is Superhero:
         print("I am a superhero")
 
-    # Get the "Method Resolution Order" used by both getattr() and super()
-    # (the order in which classes are searched for an attribute or method)
-    # This attribute is dynamic and can be updated
+    # getattr() 및 super()에서 사용하는 "메서드 확인 순서" 가져오기
+    # (속성 또는 메서드를 검색하는 클래스 순서)
+    # 이 속성은 동적이며 업데이트할 수 있습니다.
     print(Superhero.__mro__)    # => (<class '__main__.Superhero'>,
                                 # => <class 'human.Human'>, <class 'object'>)
 
-    # Calls parent method but uses its own class attribute
+    # 부모 메서드를 호출하지만 자체 클래스 속성을 사용
     print(sup.get_species())    # => Superhuman
 
-    # Calls overridden method
+    # 재정의된 메서드 호출
     print(sup.sing())           # => Dun, dun, DUN!
 
-    # Calls method from Human
+    # Human에서 메서드 호출
     sup.say("Spoon")            # => Tick: Spoon
 
-    # Call method that exists only in Superhero
+    # Superhero에만 존재하는 메서드 호출
     sup.boast()                 # => I wield the power of super strength!
                                 # => I wield the power of bulletproofing!
 
-    # Inherited class attribute
+    # 상속된 클래스 속성
     sup.age = 31
     print(sup.age)              # => 31
 
-    # Attribute that only exists within Superhero
+    # Superhero 내에만 존재하는 속성
     print("Am I Oscar eligible? " + str(sup.movie))
 
 ####################################################
-## 6.2 Multiple Inheritance
+## 6.2 다중 상속
 ####################################################
 
 
-# Another class definition
+# 다른 클래스 정의
 # bat.py
 class Bat:
 
@@ -946,12 +943,12 @@ class Bat:
     def __init__(self, can_fly=True):
         self.fly = can_fly
 
-    # This class also has a say method
+    # 이 클래스에도 say 메서드가 있습니다.
     def say(self, msg):
         msg = "... ... ..."
         return msg
 
-    # And its own method as well
+    # 그리고 자신만의 메서드도 있습니다.
     def sonar(self):
         return "))) ... ((("
 
@@ -962,26 +959,26 @@ if __name__ == "__main__":
     print(b.fly)
 
 
-# And yet another class definition that inherits from Superhero and Bat
+# 그리고 Superhero와 Bat에서 상속하는 또 다른 클래스 정의
 # superhero.py
 from superhero import Superhero
 from bat import Bat
 
-# Define Batman as a child that inherits from both Superhero and Bat
+# Batman을 Superhero와 Bat 모두에서 상속하는 자식으로 정의
 class Batman(Superhero, Bat):
 
     def __init__(self, *args, **kwargs):
-        # Typically to inherit attributes you have to call super:
+        # 일반적으로 속성을 상속하려면 super를 호출해야 합니다.
         # super(Batman, self).__init__(*args, **kwargs)
-        # However we are dealing with multiple inheritance here, and super()
-        # only works with the next base class in the MRO list.
-        # So instead we explicitly call __init__ for all ancestors.
-        # The use of *args and **kwargs allows for a clean way to pass
-        # arguments, with each parent "peeling a layer of the onion".
+        # 하지만 여기서는 다중 상속을 다루고 있으며, super()는
+        # MRO 목록의 다음 기본 클래스에서만 작동합니다.
+        # 따라서 대신 모든 조상에 대해 명시적으로 __init__을 호출합니다.
+        # *args와 **kwargs를 사용하면 각 부모가 "양파 껍질을 벗기는"
+        # 방식으로 인수를 깔끔하게 전달할 수 있습니다.
         Superhero.__init__(self, "anonymous", movie=True,
                            superpowers=["Wealthy"], *args, **kwargs)
         Bat.__init__(self, *args, can_fly=False, **kwargs)
-        # override the value for the name attribute
+        # name 속성 값 재정의
         self.name = "Sad Affleck"
 
     def sing(self):
@@ -991,67 +988,67 @@ class Batman(Superhero, Bat):
 if __name__ == "__main__":
     sup = Batman()
 
-    # The Method Resolution Order
+    # 메서드 확인 순서
     print(Batman.__mro__)     # => (<class '__main__.Batman'>,
                               # => <class 'superhero.Superhero'>,
                               # => <class 'human.Human'>,
                               # => <class 'bat.Bat'>, <class 'object'>)
 
-    # Calls parent method but uses its own class attribute
+    # 부모 메서드를 호출하지만 자체 클래스 속성을 사용
     print(sup.get_species())  # => Superhuman
 
-    # Calls overridden method
+    # 재정의된 메서드 호출
     print(sup.sing())         # => nan nan nan nan nan batman!
 
-    # Calls method from Human, because inheritance order matters
+    # 상속 순서가 중요하므로 Human에서 메서드 호출
     sup.say("I agree")        # => Sad Affleck: I agree
 
-    # Call method that exists only in 2nd ancestor
+    # 두 번째 조상에만 존재하는 메서드 호출
     print(sup.sonar())        # => ))) ... (((
 
-    # Inherited class attribute
+    # 상속된 클래스 속성
     sup.age = 100
     print(sup.age)            # => 100
 
-    # Inherited attribute from 2nd ancestor whose default value was overridden.
+    # 기본값이 재정의된 두 번째 조상에서 상속된 속성
     print("Can I fly? " + str(sup.fly))  # => Can I fly? False
 
 
 ####################################################
-## 7. Advanced
+## 7. 고급
 ####################################################
 
-# Generators help you make lazy code.
+# 제너레이터는 게으른 코드를 만드는 데 도움이 됩니다.
 def double_numbers(iterable):
     for i in iterable:
         yield i + i
 
-# Generators are memory-efficient because they only load the data needed to
-# process the next value in the iterable. This allows them to perform
-# operations on otherwise prohibitively large value ranges.
-# NOTE: `range` replaces `xrange` in Python 3.
-for i in double_numbers(range(1, 900000000)):  # `range` is a generator.
+# 제너레이터는 반복 가능한 객체에서 다음 값을 처리하는 데 필요한
+# 데이터만 로드하기 때문에 메모리 효율적입니다.
+# 이를 통해 금지적으로 큰 값 범위에 대한 작업을 수행할 수 있습니다.
+# 참고: `range`는 Python 3에서 `xrange`를 대체합니다.
+for i in double_numbers(range(1, 900000000)):  # `range`는 제너레이터입니다.
     print(i)
     if i >= 30:
         break
 
-# Just as you can create a list comprehension, you can create generator
-# comprehensions as well.
+# 리스트 내포를 만들 수 있는 것처럼 제너레이터
+# 내포도 만들 수 있습니다.
 values = (-x for x in [1,2,3,4,5])
 for x in values:
-    print(x)  # prints -1 -2 -3 -4 -5 to console/terminal
+    print(x)  # 콘솔/터미널에 -1 -2 -3 -4 -5 출력
 
-# You can also cast a generator comprehension directly to a list.
+# 제너레이터 내포를 리스트로 직접 캐스팅할 수도 있습니다.
 values = (-x for x in [1,2,3,4,5])
 gen_to_list = list(values)
 print(gen_to_list)  # => [-1, -2, -3, -4, -5]
 
 
-# Decorators are a form of syntactic sugar.
-# They make code easier to read while accomplishing clunky syntax.
+# 데코레이터는 구문 설탕의 한 형태입니다.
+# 투박한 구문을 달성하면서 코드를 더 쉽게 읽을 수 있도록 합니다.
 
-# Wrappers are one type of decorator.
-# They're really useful for adding logging to existing functions without needing to modify them.
+# 래퍼는 데코레이터의 한 유형입니다.
+# 기존 함수를 수정할 필요 없이 로깅을 추가하는 데 정말 유용합니다.
 
 def log_function(func):
     def wrapper(*args, **kwargs):
@@ -1061,36 +1058,36 @@ def log_function(func):
         return result
     return wrapper
 
-@log_function               # equivalent:
+@log_function               # 동등:
 def my_function(x,y):       # def my_function(x,y):
     """Adds two numbers together."""
     return x+y              #   return x+y
                             # my_function = log_function(my_function)
-# The decorator @log_function tells us as we begin reading the function definition
-# for my_function that this function will be wrapped with log_function.
-# When function definitions are long, it can be hard to parse the non-decorated
-# assignment at the end of the definition.
+# 데코레이터 @log_function은 my_function에 대한 함수 정의를 읽기 시작할 때
+# 이 함수가 log_function으로 래핑될 것임을 알려줍니다.
+# 함수 정의가 길면 정의 끝에 있는 데코레이션되지 않은
+# 할당을 구문 분석하기 어려울 수 있습니다.
 
 my_function(1,2)  # => "Entering function my_function"
                   # => "3"
                   # => "Exiting function my_function"
 
-# But there's a problem.
-# What happens if we try to get some information about my_function?
+# 하지만 문제가 있습니다.
+# my_function에 대한 정보를 얻으려고 하면 어떻게 될까요?
 
 print(my_function.__name__)  # => 'wrapper'
-print(my_function.__doc__)  # => None (wrapper function has no docstring)
+print(my_function.__doc__)  # => None (래퍼 함수에는 docstring이 없음)
 
-# Because our decorator is equivalent to my_function = log_function(my_function)
-# we've replaced information about my_function with information from wrapper
+# 데코레이터가 my_function = log_function(my_function)과 동일하기 때문에
+# my_function에 대한 정보를 래퍼 정보로 대체했습니다.
 
-# Fix this using functools
+# functools를 사용하여 이 문제를 해결하십시오.
 
 from functools import wraps
 
 def log_function(func):
-    @wraps(func)  # this ensures docstring, function name, arguments list, etc. are all copied
-                  # to the wrapped function - instead of being replaced with wrapper's info
+    @wraps(func)  # 이것은 docstring, 함수 이름, 인수 목록 등이 모두
+                  # 래핑된 함수에 복사되도록 보장합니다 - 래퍼 정보로 대체되는 대신
     def wrapper(*args, **kwargs):
         print("Entering function", func.__name__)
         result = func(*args, **kwargs)
@@ -1111,16 +1108,16 @@ print(my_function.__name__)  # => 'my_function'
 print(my_function.__doc__)  # => 'Adds two numbers together.'
 ```
 
-### Free Online
+### 무료 온라인
 
-* [Automate the Boring Stuff with Python](https://automatetheboringstuff.com)
-* [The Official Docs](https://docs.python.org/3/)
-* [Hitchhiker's Guide to Python](https://docs.python-guide.org/)
-* [Python Course](https://www.python-course.eu)
-* [First Steps With Python](https://realpython.com/learn/python-first-steps/)
-* [A curated list of awesome Python frameworks, libraries and software](https://github.com/vinta/awesome-python)
-* [Official Style Guide for Python](https://peps.python.org/pep-0008/)
-* [Python 3 Computer Science Circles](https://cscircles.cemc.uwaterloo.ca/)
-* [Dive Into Python 3](https://www.diveintopython3.net/)
-* [Python Tutorial for Intermediates](https://pythonbasics.org/)
-* [Build a Desktop App with Python](https://pythonpyqt.com/)
+* [파이썬으로 지루한 작업 자동화하기](https://automatetheboringstuff.com)
+* [공식 문서](https://docs.python.org/3/)
+* [파이썬을 위한 히치하이커 안내서](https://docs.python-guide.org/)
+* [파이썬 코스](https://www.python-course.eu)
+* [파이썬 첫걸음](https://realpython.com/learn/python-first-steps/)
+* [엄선된 멋진 파이썬 프레임워크, 라이브러리 및 소프트웨어 목록](https://github.com/vinta/awesome-python)
+* [파이썬 공식 스타일 가이드](https://peps.python.org/pep-0008/)
+* [파이썬 3 컴퓨터 과학 서클](https://cscircles.cemc.uwaterloo.ca/)
+* [파이썬 3으로 뛰어들기](https://www.diveintopython3.net/)
+* [중급자를 위한 파이썬 튜토리얼](https://pythonbasics.org/)
+* [파이썬으로 데스크톱 앱 만들기](https://pythonpyqt.com/)

--- a/ko/pythonstatcomp.md
+++ b/ko/pythonstatcomp.md
@@ -8,40 +8,41 @@ contributors:
 filename: pythonstatcomp.py
 ---
 
-This is a tutorial on how to do some typical statistical programming tasks using Python. It's intended for people basically familiar with Python and experienced at statistical programming in a language like R, Stata, SAS, SPSS, or MATLAB.
+이것은 파이썬을 사용하여 몇 가지 일반적인 통계 프로그래밍 작업을 수행하는 방법에 대한 튜토리얼입니다. 기본적으로 파이썬에 익숙하고 R, Stata, SAS, SPSS 또는 MATLAB과 같은 언어로 통계 프로그래밍 경험이 있는 사람들을 대상으로 합니다.
 
 ```python
-# 0. Getting set up ====
+# 0. 설정하기 ====
 
-""" To get started, pip install the following: jupyter, numpy, scipy, pandas,
+""" 시작하려면 다음을 pip 설치하십시오: jupyter, numpy, scipy, pandas,
     matplotlib, seaborn, requests.
-        Make sure to do this tutorial in a Jupyter notebook so that you get
-    the inline plots and easy documentation lookup. The shell command to open
-    one is simply `jupyter notebook`, then click New -> Python.
+        인라인 플롯과 쉬운 문서 조회를 위해 이 튜토리얼을
+    Jupyter 노트북에서 수행해야 합니다. 셸 명령어는
+    `jupyter notebook`이며, New -> Python을 클릭하십시오.
 """
 
-# 1. Data acquisition ====
+# 1. 데이터 수집 ====
 
-""" One reason people choose Python over R is that they intend to interact a lot
-    with the web, either by scraping pages directly or requesting data through
-    an API. You can do those things in R, but in the context of a project
-    already using Python, there's a benefit to sticking with one language.
+""" 사람들이 R보다 파이썬을 선택하는 한 가지 이유는 웹과
+    많이 상호 작용하려는 의도 때문입니다. 직접 페이지를 스크래핑하거나
+    API를 통해 데이터를 요청하는 등. R에서도 이러한 작업을 할 수 있지만,
+    이미 파이썬을 사용하는 프로젝트의 맥락에서는 한 가지 언어를
+    고수하는 것이 이점이 있습니다.
 """
 
-import requests  # for HTTP requests (web scraping, APIs)
+import requests  # HTTP 요청용 (웹 스크래핑, API)
 import os
 
-# web scraping
+# 웹 스크래핑
 r = requests.get("https://github.com/adambard/learnxinyminutes-docs")
-r.status_code  # if 200, request was successful
-r.text  # raw page source
-print(r.text)  # prettily formatted
-# save the page source in a file:
-os.getcwd()  # check what's the working directory
+r.status_code  # 200이면 요청이 성공한 것입니다.
+r.text  # 원시 페이지 소스
+print(r.text)  # 예쁘게 서식 지정됨
+# 페이지 소스를 파일에 저장:
+os.getcwd()  # 작업 디렉토리 확인
 with open("learnxinyminutes.html", "wb") as f:
     f.write(r.text.encode("UTF-8"))
 
-# downloading a csv
+# csv 다운로드
 fp = "https://raw.githubusercontent.com/adambard/learnxinyminutes-docs/master/"
 fn = "pets.csv"
 r = requests.get(fp + fn)
@@ -49,14 +50,14 @@ print(r.text)
 with open(fn, "wb") as f:
     f.write(r.text.encode("UTF-8"))
 
-""" for more on the requests module, including APIs, see
-    http://docs.python-requests.org/en/latest/user/quickstart/
+""" requests 모듈에 대한 자세한 내용, API 포함,
+    http://docs.python-requests.org/en/latest/user/quickstart/ 참조
 """
 
-# 2. Reading a CSV file ====
+# 2. CSV 파일 읽기 ====
 
-""" Wes McKinney's pandas package gives you 'DataFrame' objects in Python. If
-    you've used R, you will be familiar with the idea of the "data.frame" already.
+""" Wes McKinney의 pandas 패키지는 파이썬에서 'DataFrame' 객체를 제공합니다.
+    R을 사용해 본 적이 있다면 이미 "data.frame"의 개념에 익숙할 것입니다.
 """
 
 import pandas as pd
@@ -69,22 +70,23 @@ pets
 # 1  vesuvius    6      23    fish
 # 2       rex    5      34     dog
 
-""" R users: note that Python, like most C-influenced programming languages, starts
-    indexing from 0. R starts indexing at 1 due to Fortran influence.
+""" R 사용자는 C의 영향을 받은 대부분의 프로그래밍 언어와 마찬가지로 파이썬은
+    0부터 인덱싱을 시작한다는 점에 유의해야 합니다. R은 Fortran의 영향으로 1부터
+    인덱싱을 시작합니다.
 """
 
-# two different ways to print out a column
+# 열을 출력하는 두 가지 다른 방법
 pets.age
 pets["age"]
 
-pets.head(2)  # prints first 2 rows
-pets.tail(1)  # prints last row
+pets.head(2)  # 처음 2개 행 출력
+pets.tail(1)  # 마지막 행 출력
 
 pets.name[1]  # 'vesuvius'
 pets.species[0]  # 'cat'
 pets["weight"][2]  # 34
 
-# in R, you would expect to get 3 rows doing this, but here you get 2:
+# R에서는 이렇게 하면 3개의 행을 얻을 것으로 예상하지만, 여기서는 2개를 얻습니다.
 pets.age[0:2]
 # 0    3
 # 1    6
@@ -92,18 +94,18 @@ pets.age[0:2]
 sum(pets.age) * 2  # 28
 max(pets.weight) - min(pets.weight)  # 20
 
-""" If you are doing some serious linear algebra and number-crunching, you may
-    just want arrays, not DataFrames. DataFrames are ideal for combining columns
-    of different types.
+""" 심각한 선형 대수 및 숫자 계산을 수행하는 경우
+    DataFrame이 아닌 배열을 원할 수 있습니다. DataFrame은
+    다른 유형의 열을 결합하는 데 이상적입니다.
 """
 
-# 3. Charts ====
+# 3. 차트 ====
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 %matplotlib inline
 
-# To do data visualization in Python, use matplotlib
+# 파이썬에서 데이터 시각화를 하려면 matplotlib를 사용하십시오.
 
 plt.hist(pets.age);
 
@@ -113,7 +115,7 @@ plt.scatter(pets.age, pets.weight)
 plt.xlabel("age")
 plt.ylabel("weight");
 
-# seaborn sits atop matplotlib and makes plots prettier
+# seaborn은 matplotlib 위에 있으며 플롯을 더 예쁘게 만듭니다.
 
 import seaborn as sns
 
@@ -121,31 +123,30 @@ plt.scatter(pets.age, pets.weight)
 plt.xlabel("age")
 plt.ylabel("weight");
 
-# there are also some seaborn-specific plotting functions
-# notice how seaborn automatically labels the x-axis on this barplot
+# seaborn 전용 플로팅 함수도 있습니다.
+# 이 막대 그래프에서 seaborn이 x축에 자동으로 레이블을 지정하는 방법을 확인하십시오.
 sns.barplot(pets["age"])
 
-# R veterans can still use ggplot
+# R 베테랑은 여전히 ggplot을 사용할 수 있습니다.
 from ggplot import *
 ggplot(aes(x="age",y="weight"), data=pets) + geom_point() + labs(title="pets")
-# source: https://pypi.python.org/pypi/ggplot
+# 출처: https://pypi.python.org/pypi/ggplot
 
-# there's even a d3.js port: https://github.com/mikedewar/d3py
+# d3.js 포트도 있습니다: https://github.com/mikedewar/d3py
 
-# 4. Simple data cleaning and exploratory analysis ====
+# 4. 간단한 데이터 정리 및 탐색적 분석 ====
 
-""" Here's a more complicated example that demonstrates a basic data
-    cleaning workflow leading to the creation of some exploratory plots
-    and the running of a linear regression.
-        The data set was transcribed from Wikipedia by hand. It contains
-    all the Holy Roman Emperors and the important milestones in their lives
-    (birth, death, coronation, etc.).
-        The goal of the analysis will be to explore whether a relationship
-    exists between emperor birth year and emperor lifespan.
-    data source: https://en.wikipedia.org/wiki/Holy_Roman_Emperor
+""" 다음은 일부 탐색적 플롯 생성 및 선형 회귀 실행으로
+    이어지는 기본 데이터 정리 워크플로를 보여주는 더 복잡한 예입니다.
+        데이터 세트는 위키백과에서 직접 필사되었습니다. 여기에는
+    모든 신성 로마 황제와 그들의 삶의 중요한 이정표(출생, 사망,
+    대관식 등)가 포함되어 있습니다.
+        분석의 목표는 황제 출생 연도와 황제 수명 사이에
+    관계가 있는지 탐색하는 것입니다.
+    데이터 출처: https://en.wikipedia.org/wiki/Holy_Roman_Emperor
 """
 
-# load some data on Holy Roman Emperors
+# 신성 로마 황제에 대한 일부 데이터 로드
 url = "https://raw.githubusercontent.com/adambard/learnxinyminutes-docs/master/hre.csv"
 r = requests.get(url)
 fp = "hre.csv"
@@ -171,16 +172,16 @@ hre.head()
 4   29 December 875            NaN        6 October 877
 """
 
-# clean the Birth and Death columns
+# 출생 및 사망 열 정리
 
-import re  # module for regular expressions
+import re  # 정규식 모듈
 
-rx = re.compile(r'\d+$')  # match trailing digits
+rx = re.compile(r'\d+$')  # 후행 숫자 일치
 
-""" This function applies the regular expression to an input column (here Birth,
-    Death), flattens the resulting list, converts it to a Series object, and
-    finally converts the type of the Series object from string to integer. For
-    more information into what different parts of the code do, see:
+""" 이 함수는 정규식을 입력 열(여기서는 출생, 사망)에 적용하고,
+    결과 목록을 평탄화하고, Series 객체로 변환하고,
+    마지막으로 Series 객체의 유형을 문자열에서 정수로 변환합니다.
+    코드의 다른 부분이 무엇을 하는지에 대한 자세한 내용은 다음을 참조하십시오.
       - https://docs.python.org/2/howto/regex.html
       - http://stackoverflow.com/questions/11860476/how-to-unlist-a-python-list
       - http://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.html
@@ -194,45 +195,45 @@ def extractYear(v):
 hre["BirthY"] = extractYear(hre.Birth)
 hre["DeathY"] = extractYear(hre.Death)
 
-# make a column telling estimated age
+# 예상 수명을 알려주는 열 만들기
 hre["EstAge"] = hre.DeathY.astype(int) - hre.BirthY.astype(int)
 
-# simple scatterplot, no trend line, color represents dynasty
+# 간단한 산점도, 추세선 없음, 색상은 왕조를 나타냄
 sns.lmplot("BirthY", "EstAge", data=hre, hue="Dynasty", fit_reg=False)
 
-# use scipy to run a linear regression
+# scipy를 사용하여 선형 회귀 실행
 from scipy import stats
 (slope, intercept, rval, pval, stderr) = stats.linregress(hre.BirthY, hre.EstAge)
-# code source: http://wiki.scipy.org/Cookbook/LinearRegression
+# 코드 출처: http://wiki.scipy.org/Cookbook/LinearRegression
 
-# check the slope
+# 기울기 확인
 slope  # 0.0057672618839073328
 
-# check the R^2 value:
+# R^2 값 확인:
 rval**2  # 0.020363950027333586
 
-# check the p-value
+# p-값 확인
 pval  # 0.34971812581498452
 
-# use seaborn to make a scatterplot and plot the linear regression trend line
+# seaborn을 사용하여 산점도를 만들고 선형 회귀 추세선 플롯
 sns.lmplot("BirthY", "EstAge", data=hre)
 
-""" For more information on seaborn, see
+""" seaborn에 대한 자세한 내용은 다음을 참조하십시오.
       - http://web.stanford.edu/~mwaskom/software/seaborn/
       - https://github.com/mwaskom/seaborn
-    For more information on SciPy, see
+    SciPy에 대한 자세한 내용은 다음을 참조하십시오.
       - http://wiki.scipy.org/SciPy
       - http://wiki.scipy.org/Cookbook/
-    To see a version of the Holy Roman Emperors analysis using R, see
+    R을 사용한 신성 로마 황제 분석 버전을 보려면 다음을 참조하십시오.
       - http://github.com/e99n09/R-notes/blob/master/holy_roman_emperors_dates.R
 """
 ```
 
-If you want to learn more, get _Python for Data Analysis_ by Wes McKinney. It's a superb resource and I used it as a reference when writing this tutorial.
+더 배우고 싶다면 Wes McKinney의 _Python for Data Analysis_를 구하십시오. 이 튜토리얼을 작성할 때 참고 자료로 사용한 훌륭한 자료입니다.
 
-You can also find plenty of interactive IPython tutorials on subjects specific to your interests, like Cam Davidson-Pilon's [Probabilistic Programming and Bayesian Methods for Hackers](http://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/).
+Cam Davidson-Pilon의 [해커를 위한 확률론적 프로그래밍 및 베이지안 방법](http://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/)과 같이 관심 분야에 특정한 주제에 대한 대화형 IPython 튜토리얼도 많이 찾을 수 있습니다.
 
-Some more modules to research:
+연구할 추가 모듈:
 
-   - text analysis and natural language processing: [nltk](http://www.nltk.org)
-   - social network analysis: [igraph](http://igraph.org/python/)
+   - 텍스트 분석 및 자연어 처리: [nltk](http://www.nltk.org)
+   - 소셜 네트워크 분석: [igraph](http://igraph.org/python/)

--- a/ko/rst.md
+++ b/ko/rst.md
@@ -8,109 +8,109 @@ contributors:
 filename: restructuredtext.rst
 ---
 
-RST, Restructured Text, is a file format created by the Python community to write documentation. It is part of [Docutils](https://docutils.sourceforge.io/rst.html).
+RST, 재구조화된 텍스트는 파이썬 커뮤니티에서 문서를 작성하기 위해 만든 파일 형식입니다. [Docutils](https://docutils.sourceforge.io/rst.html)의 일부입니다.
 
-RST is a markup language like HTML but is much more lightweight and easier to read.
+RST는 HTML과 같은 마크업 언어이지만 훨씬 가볍고 읽기 쉽습니다.
 
 
-## Installation
+## 설치
 
-To use Restructured Text, you will have to install [Python](http://www.python.org) and the `docutils` package.
+재구조화된 텍스트를 사용하려면 [Python](http://www.python.org)과 `docutils` 패키지를 설치해야 합니다.
 
-`docutils` can be installed using the commandline:
+`docutils`는 명령줄을 사용하여 설치할 수 있습니다.
 
 ```bash
 $ easy_install docutils
 ```
 
-If your system has `pip`, you can use it too:
+시스템에 `pip`가 있는 경우에도 사용할 수 있습니다.
 
 ```bash
 $ pip install docutils
 ```
 
 
-## File syntax
+## 파일 구문
 
-A simple example of the file syntax:
+파일 구문의 간단한 예:
 
 ```rst
-.. Lines starting with two dots are special commands. But if no command can be found, the line is considered as a comment.
+.. 두 개의 점으로 시작하는 줄은 특수 명령어입니다. 하지만 명령어를 찾을 수 없으면 해당 줄은 주석으로 간주됩니다.
 
 =========================================================
-Main titles are written using equals signs over and under
+주요 제목은 위아래에 등호 기호를 사용하여 작성됩니다.
 =========================================================
 
-Note that each character, including spaces, needs an equals sign above and below.
+공백을 포함한 각 문자 위아래에 등호 기호가 필요하다는 점에 유의하십시오.
 
-Titles also use equals signs but are only underneath
+제목도 등호 기호를 사용하지만 아래에만 있습니다.
 ====================================================
 
-Subtitles with dashes
+대시가 있는 부제목
 ---------------------
 
-You can put text in *italic* or in **bold**, you can "mark" text as code with double backquote ``print()``.
+텍스트를 *기울임꼴* 또는 **굵게** 표시할 수 있으며, 이중 백쿼트 ``print()``로 텍스트를 코드로 "표시"할 수 있습니다.
 
-Special characters can be escaped using a backslash, e.g. \\ or \*.
+특수 문자는 백슬래시를 사용하여 이스케이프할 수 있습니다(예: \\ 또는 \*).
 
-Lists are similar to Markdown, but a little more involved.
+목록은 마크다운과 유사하지만 조금 더 복잡합니다.
 
-Remember to line up list symbols (like - or \*) with the left edge of the previous text block, and remember to use blank lines to separate new lists from parent lists:
+목록 기호(- 또는 \*)를 이전 텍스트 블록의 왼쪽 가장자리에 맞추고, 새 목록을 부모 목록과 분리하기 위해 빈 줄을 사용하는 것을 잊지 마십시오.
 
-- First item
-- Second item
+- 첫 번째 항목
+- 두 번째 항목
 
-  - Sub item
+  - 하위 항목
 
-- Third item
+- 세 번째 항목
 
-or
+또는
 
-* First item
-* Second item
+* 첫 번째 항목
+* 두 번째 항목
 
-  * Sub item
+  * 하위 항목
 
-* Third item
+* 세 번째 항목
 
-Tables are really easy to write:
+표는 정말 쉽게 작성할 수 있습니다.
 
 =========== ========
-Country     Capital
+국가        수도
 =========== ========
-France      Paris
-Japan       Tokyo
+프랑스      파리
+일본        도쿄
 =========== ========
 
-More complex tables can be done easily (merged columns and/or rows) but I suggest you to read the complete doc for this. :)
+더 복잡한 표(병합된 열 및/또는 행)도 쉽게 만들 수 있지만, 이를 위해서는 전체 문서를 읽는 것이 좋습니다. :)
 
-There are multiple ways to make links:
+링크를 만드는 방법에는 여러 가지가 있습니다.
 
-- By adding an underscore after a word : GitHub_ and by adding the target URL after the text (this way has the advantage of not inserting unnecessary URLs in the visible text).
-- By typing a full comprehensible URL : https://github.com/ (will be automatically converted to a link).
-- By making a more Markdown-like link: `GitHub <https://github.com/>`_ .
+- 단어 뒤에 밑줄을 추가하여: GitHub_ 그리고 텍스트 뒤에 대상 URL을 추가하여 (이 방법은 보이는 텍스트에 불필요한 URL을 삽입하지 않는 장점이 있습니다).
+- 전체 이해 가능한 URL을 입력하여: https://github.com/ (자동으로 링크로 변환됩니다).
+- 더 마크다운과 유사한 링크를 만들어: `GitHub <https://github.com/>`_ .
 
 .. _GitHub: https://github.com/
 ```
 
 
-## How to Use It
+## 사용 방법
 
-RST comes with docutils where you have `rst2html`, for example:
+RST는 docutils와 함께 제공되며, 예를 들어 `rst2html`이 있습니다.
 
 ```bash
 $ rst2html myfile.rst output.html
 ```
 
-*Note : On some systems the command could be rst2html.py*
+*참고: 일부 시스템에서는 명령어가 rst2html.py일 수 있습니다.*
 
-But there are more complex applications that use the RST format:
+하지만 RST 형식을 사용하는 더 복잡한 응용 프로그램이 있습니다.
 
-- [Pelican](http://blog.getpelican.com/), a static site generator
-- [Sphinx](http://sphinx-doc.org/), a documentation generator
-- and many others
+- [Pelican](http://blog.getpelican.com/), 정적 사이트 생성기
+- [Sphinx](http://sphinx-doc.org/), 문서 생성기
+- 그리고 다른 많은 것들
 
 
-## Readings
+## 읽을거리
 
-- [Official quick reference](http://docutils.sourceforge.net/docs/user/rst/quickref.html)
+- [공식 빠른 참조](http://docutils.sourceforge.net/docs/user/rst/quickref.html)

--- a/ko/rust.md
+++ b/ko/rust.md
@@ -7,140 +7,140 @@ contributors:
 filename: learnrust.rs
 ---
 
-Rust is a programming language developed by Mozilla Research.
-Rust combines low-level control over performance with high-level convenience and
-safety guarantees.
+Rust는 Mozilla Research에서 개발한 프로그래밍 언어입니다.
+Rust는 성능에 대한 저수준 제어와 고수준의 편의성 및
+안전 보장을 결합합니다.
 
-It achieves these goals without requiring a garbage collector or runtime, making
-it possible to use Rust libraries as a "drop-in replacement" for C.
+가비지 수집기나 런타임 없이 이러한 목표를 달성하므로
+Rust 라이브러리를 C의 "드롭인 대체품"으로 사용할 수 있습니다.
 
-Rust’s first release, 0.1, occurred in January 2012, and for 3 years development
-moved so quickly that until recently the use of stable releases was discouraged
-and instead the general advice was to use nightly builds.
+Rust의 첫 번째 릴리스인 0.1은 2012년 1월에 있었고, 3년 동안 개발이
+너무 빠르게 진행되어 최근까지 안정적인 릴리스 사용이 권장되지 않았으며
+대신 야간 빌드를 사용하라는 일반적인 조언이 있었습니다.
 
-On May 15th 2015, Rust 1.0 was released with a complete guarantee of backward
-compatibility. Improvements to compile times and other aspects of the compiler are
-currently available in the nightly builds. Rust has adopted a train-based release
-model with regular releases every six weeks. Rust 1.1 beta was made available at
-the same time of the release of Rust 1.0.
+2015년 5월 15일, Rust 1.0이 완전한 하위 호환성 보장과 함께
+릴리스되었습니다. 컴파일 시간 개선 및 컴파일러의 다른 측면에 대한
+개선 사항은 현재 야간 빌드에서 사용할 수 있습니다. Rust는 6주마다
+정기적으로 릴리스되는 기차 기반 릴리스 모델을 채택했습니다. Rust 1.1 베타는
+Rust 1.0 릴리스와 동시에 제공되었습니다.
 
-Although Rust is a relatively low-level language, it has some functional
-concepts that are generally found in higher-level languages. This makes
-Rust not only fast, but also easy and efficient to code in.
+Rust는 비교적 저수준 언어이지만, 일반적으로 고수준 언어에서
+발견되는 일부 함수형 개념을 가지고 있습니다. 이로 인해
+Rust는 빠를 뿐만 아니라 코딩하기 쉽고 효율적입니다.
 
 ```rust
-// This is a comment. Line comments look like this...
-// and extend multiple lines like this.
+// 이것은 주석입니다. 한 줄 주석은 이렇게 생겼습니다...
+// 그리고 이렇게 여러 줄로 확장됩니다.
 
-/* Block comments
-  /* can be nested. */ */
+/* 블록 주석
+  /* 중첩될 수 있습니다. */ */
 
-/// Documentation comments look like this and support markdown notation.
-/// # Examples
+/// 문서 주석은 이렇게 생겼으며 마크다운 표기법을 지원합니다.
+/// # 예제
 ///
 /// ```
 /// let five = 5
 /// ```
 
 ///////////////
-// 1. Basics //
+// 1. 기본 //
 ///////////////
 
 #[allow(dead_code)]
-// Functions
-// `i32` is the type for 32-bit signed integers
+// 함수
+// `i32`는 32비트 부호 있는 정수 타입입니다.
 fn add2(x: i32, y: i32) -> i32 {
-    // Implicit return (no semicolon)
+    // 암시적 반환 (세미콜론 없음)
     x + y
 }
 
 #[allow(unused_variables)]
 #[allow(unused_assignments)]
 #[allow(dead_code)]
-// Main function
+// 메인 함수
 fn main() {
-    // Numbers //
+    // 숫자 //
 
-    // Immutable bindings
+    // 불변 바인딩
     let x: i32 = 1;
 
-    // Integer/float suffixes
+    // 정수/부동 소수점 접미사
     let y: i32 = 13i32;
     let f: f64 = 1.3f64;
 
-    // Type inference
-    // Most of the time, the Rust compiler can infer what type a variable is, so
-    // you don’t have to write an explicit type annotation.
-    // Throughout this tutorial, types are explicitly annotated in many places,
-    // but only for demonstrative purposes. Type inference can handle this for
-    // you most of the time.
+    // 타입 추론
+    // 대부분의 경우 Rust 컴파일러는 변수의 타입을 추론할 수 있으므로
+    // 명시적인 타입 주석을 작성할 필요가 없습니다.
+    // 이 튜토리얼 전체에서 타입은 많은 곳에서 명시적으로 주석 처리되지만,
+    // 이는 시연 목적으로만 사용됩니다. 타입 추론은 대부분의 경우
+    // 이를 처리할 수 있습니다.
     let implicit_x = 1;
     let implicit_f = 1.3;
 
-    // Arithmetic
+    // 산술
     let sum = x + y + 13;
 
-    // Mutable variable
+    // 가변 변수
     let mut mutable = 1;
     mutable = 4;
     mutable += 2;
 
-    // Strings //
+    // 문자열 //
 
-    // String literals
+    // 문자열 리터럴
     let x: &str = "hello world!";
 
-    // Printing
+    // 출력
     println!("{} {}", f, x); // 1.3 hello world!
 
-    // A `String` – a heap-allocated string
-    // Stored as a `Vec<u8>` and always holds a valid UTF-8 sequence,
-    // which is not null terminated.
+    // `String` – 힙에 할당된 문자열
+    // `Vec<u8>`로 저장되며 항상 유효한 UTF-8 시퀀스를 포함하며,
+    // null로 종료되지 않습니다.
     let s: String = "hello world".to_string();
 
-    // A string slice – an immutable view into another string
-    // This is basically an immutable pointer and length of a string – it
-    // doesn’t actually contain the contents of a string, just a pointer to
-    // the beginning and a length of a string buffer,
-    // statically allocated or contained in another object (in this case, `s`).
-    // The string slice is like a view `&[u8]` into `Vec<T>`.
+    // 문자열 슬라이스 – 다른 문자열에 대한 불변 뷰
+    // 이것은 기본적으로 문자열의 불변 포인터와 길이입니다.
+    // 실제로 문자열의 내용을 포함하지 않고, 문자열 버퍼의 시작에 대한
+    // 포인터와 길이만 포함합니다.
+    // 정적으로 할당되거나 다른 객체에 포함됩니다(이 경우 `s`).
+    // 문자열 슬라이스는 `Vec<T>`에 대한 `&[u8]` 뷰와 같습니다.
     let s_slice: &str = &s;
 
     println!("{} {}", s, s_slice); // hello world hello world
 
-    // Vectors/arrays //
+    // 벡터/배열 //
 
-    // A fixed-size array
+    // 고정 크기 배열
     let four_ints: [i32; 4] = [1, 2, 3, 4];
 
-    // A dynamic array (vector)
+    // 동적 배열 (벡터)
     let mut vector: Vec<i32> = vec![1, 2, 3, 4];
     vector.push(5);
 
-    // A slice – an immutable view into a vector or array
-    // This is much like a string slice, but for vectors
+    // 슬라이스 – 벡터 또는 배열에 대한 불변 뷰
+    // 이것은 문자열 슬라이스와 매우 유사하지만 벡터용입니다.
     let slice: &[i32] = &vector;
 
-    // Use `{:?}` to print something debug-style
+    // 디버그 스타일로 무언가를 출력하려면 `{:?}`를 사용합니다.
     println!("{:?} {:?}", vector, slice); // [1, 2, 3, 4, 5] [1, 2, 3, 4, 5]
 
-    // Tuples //
+    // 튜플 //
 
-    // A tuple is a fixed-size set of values of possibly different types
+    // 튜플은 잠재적으로 다른 타입의 값의 고정 크기 집합입니다.
     let x: (i32, &str, f64) = (1, "hello", 3.4);
 
-    // Destructuring `let`
+    // `let` 구조 분해
     let (a, b, c) = x;
     println!("{} {} {}", a, b, c); // 1 hello 3.4
 
-    // Indexing
+    // 인덱싱
     println!("{}", x.1); // hello
 
     //////////////
-    // 2. Types //
+    // 2. 타입 //
     //////////////
 
-    // Struct
+    // 구조체
     struct Point {
         x: i32,
         y: i32,
@@ -148,12 +148,12 @@ fn main() {
 
     let origin: Point = Point { x: 0, y: 0 };
 
-    // A struct with unnamed fields, called a ‘tuple struct’
+    // 이름 없는 필드가 있는 구조체, '튜플 구조체'라고 함
     struct Point2(i32, i32);
 
     let origin2 = Point2(0, 0);
 
-    // Basic C-like enum
+    // 기본 C와 유사한 열거형
     enum Direction {
         Left,
         Right,
@@ -163,9 +163,9 @@ fn main() {
 
     let up = Direction::Up;
 
-    // Enum with fields
-    // If you want to make something optional, the standard
-    // library has `Option`
+    // 필드가 있는 열거형
+    // 무언가를 선택적으로 만들고 싶다면 표준 라이브러리에
+    // `Option`이 있습니다.
     enum OptionalI32 {
         AnI32(i32),
         Nothing,
@@ -174,29 +174,29 @@ fn main() {
     let two: OptionalI32 = OptionalI32::AnI32(2);
     let nothing = OptionalI32::Nothing;
 
-    // Generics //
+    // 제네릭 //
 
     struct Foo<T> { bar: T }
 
-    // This is defined in the standard library as `Option`
-    // `Option` is used in place of where a null pointer
-    // would normally be used.
+    // 이것은 표준 라이브러리에서 `Option`으로 정의됩니다.
+    // `Option`은 일반적으로 null 포인터가 사용되는
+    // 곳에 사용됩니다.
     enum Optional<T> {
         SomeVal(T),
         NoVal,
     }
 
-    // Methods //
+    // 메서드 //
 
     impl<T> Foo<T> {
-        // Methods take an explicit `self` parameter
-        fn bar(&self) -> &T { // self is borrowed
+        // 메서드는 명시적인 `self` 매개변수를 받습니다.
+        fn bar(&self) -> &T { // self는 빌려옵니다.
             &self.bar
         }
-        fn bar_mut(&mut self) -> &mut T { // self is mutably borrowed
+        fn bar_mut(&mut self) -> &mut T { // self는 가변적으로 빌려옵니다.
             &mut self.bar
         }
-        fn into_bar(self) -> T { // here self is consumed
+        fn into_bar(self) -> T { // 여기서 self는 소비됩니다.
             self.bar
         }
     }
@@ -204,7 +204,7 @@ fn main() {
     let a_foo = Foo { bar: 1 };
     println!("{}", a_foo.bar()); // 1
 
-    // Traits (known as interfaces or typeclasses in other languages) //
+    // 트레이트 (다른 언어에서는 인터페이스 또는 타입 클래스로 알려짐) //
 
     trait Frobnicate<T> {
         fn frobnicate(self) -> Option<T>;
@@ -219,7 +219,7 @@ fn main() {
     let another_foo = Foo { bar: 1 };
     println!("{:?}", another_foo.frobnicate()); // Some(1)
 
-    // Function pointer types //
+    // 함수 포인터 타입 //
 
     fn fibonacci(n: u32) -> u32 {
         match n {
@@ -235,7 +235,7 @@ fn main() {
     println!("Fib: {}", fib(4)); // 5
 
     /////////////////////////
-    // 3. Pattern matching //
+    // 3. 패턴 매칭 //
     /////////////////////////
 
     let foo = OptionalI32::AnI32(1);
@@ -244,7 +244,7 @@ fn main() {
         OptionalI32::Nothing  => println!("it’s nothing!"),
     }
 
-    // Advanced pattern matching
+    // 고급 패턴 매칭
     struct FooBar { x: i32, y: OptionalI32 }
     let bar = FooBar { x: 15, y: OptionalI32::AnI32(32) };
 
@@ -260,21 +260,21 @@ fn main() {
     }
 
     /////////////////////
-    // 4. Control flow //
+    // 4. 제어 흐름 //
     /////////////////////
 
-    // `for` loops/iteration
+    // `for` 루프/반복
     let array = [1, 2, 3];
     for i in array {
         println!("{}", i);
     }
 
-    // Ranges
+    // 범위
     for i in 0u32..10 {
         print!("{} ", i);
     }
     println!("");
-    // prints `0 1 2 3 4 5 6 7 8 9 `
+    // `0 1 2 3 4 5 6 7 8 9 ` 출력
 
     // `if`
     if 1 == 1 {
@@ -283,83 +283,84 @@ fn main() {
         println!("Oh no...");
     }
 
-    // `if` as expression
+    // 표현식으로서의 `if`
     let value = if true {
         "good"
     } else {
         "bad"
     };
 
-    // `while` loop
+    // `while` 루프
     while 1 == 1 {
         println!("The universe is operating normally.");
-        // break statement gets out of the while loop.
-        //  It avoids useless iterations.
+        // break 문은 while 루프를 빠져나갑니다.
+        //  쓸모없는 반복을 피합니다.
         break
     }
 
-    // Infinite loop
+    // 무한 루프
     loop {
         println!("Hello!");
-        // break statement gets out of the loop
+        // break 문은 루프를 빠져나갑니다.
         break
     }
 
     /////////////////////////////////
-    // 5. Memory safety & pointers //
+    // 5. 메모리 안전성 및 포인터 //
     /////////////////////////////////
 
-    // Owned pointer – only one thing can ‘own’ this pointer at a time
-    // This means that when the `Box` leaves its scope, it will be automatically deallocated safely.
+    // 소유된 포인터 – 한 번에 한 가지만 이 포인터를 '소유'할 수 있습니다.
+    // 이것은 `Box`가 범위를 벗어날 때 자동으로 안전하게
+    // 할당 해제됨을 의미합니다.
     let mut mine: Box<i32> = Box::new(3);
-    *mine = 5; // dereference
-    // Here, `now_its_mine` takes ownership of `mine`. In other words, `mine` is moved.
+    *mine = 5; // 역참조
+    // 여기서 `now_its_mine`은 `mine`의 소유권을 가져옵니다. 즉, `mine`은 이동됩니다.
     let mut now_its_mine = mine;
     *now_its_mine += 2;
 
     println!("{}", now_its_mine); // 7
-    // println!("{}", mine); // this would not compile because `now_its_mine` now owns the pointer
+    // println!("{}", mine); // `now_its_mine`이 이제 포인터를 소유하므로 컴파일되지 않습니다.
 
-    // Reference – an immutable pointer that refers to other data
-    // When a reference is taken to a value, we say that the value has been ‘borrowed’.
-    // While a value is borrowed immutably, it cannot be mutated or moved.
-    // A borrow is active until the last use of the borrowing variable.
+    // 참조 – 다른 데이터를 참조하는 불변 포인터
+    // 값에 대한 참조가 취해지면 해당 값은 '빌려왔다'고 말합니다.
+    // 값이 불변으로 빌려온 동안에는 변경하거나 이동할 수 없습니다.
+    // 빌림은 빌리는 변수의 마지막 사용까지 활성화됩니다.
     let mut var = 4;
     var = 3;
     let ref_var: &i32 = &var;
 
-    println!("{}", var); // Unlike `mine`, `var` can still be used
+    println!("{}", var); // `mine`과 달리 `var`는 여전히 사용할 수 있습니다.
     println!("{}", *ref_var);
-    // var = 5; // this would not compile because `var` is borrowed
-    // *ref_var = 6; // this would not either, because `ref_var` is an immutable reference
-    ref_var; // no-op, but counts as a use and keeps the borrow active
-    var = 2; // ref_var is no longer used after the line above, so the borrow has ended
+    // var = 5; // `var`가 빌려왔기 때문에 컴파일되지 않습니다.
+    // *ref_var = 6; // `ref_var`가 불변 참조이므로 이것도 컴파일되지 않습니다.
+    ref_var; // 아무 작업도 하지 않지만 사용으로 간주되어 빌림을 활성 상태로 유지합니다.
+    var = 2; // ref_var는 위 줄 이후 더 이상 사용되지 않으므로 빌림이 종료되었습니다.
 
-    // Mutable reference
-    // While a value is mutably borrowed, it cannot be accessed at all.
+    // 가변 참조
+    // 값이 가변적으로 빌려온 동안에는 전혀 액세스할 수 없습니다.
     let mut var2 = 4;
     let ref_var2: &mut i32 = &mut var2;
-    *ref_var2 += 2;         // '*' is used to point to the mutably borrowed var2
+    *ref_var2 += 2;         // '*'는 가변적으로 빌려온 var2를 가리키는 데 사용됩니다.
 
-    println!("{}", *ref_var2); // 6 , // var2 would not compile.
-    // ref_var2 is of type &mut i32, so stores a reference to an i32, not the value.
-    // var2 = 2; // this would not compile because `var2` is borrowed.
-    ref_var2; // no-op, but counts as a use and keeps the borrow active until here
+    println!("{}", *ref_var2); // 6 , // var2는 컴파일되지 않습니다.
+    // ref_var2는 &mut i32 타입이므로 값이 아닌 i32에 대한 참조를 저장합니다.
+    // var2 = 2; // `var2`가 빌려왔기 때문에 컴파일되지 않습니다.
+    ref_var2; // 아무 작업도 하지 않지만 사용으로 간주되어 여기까지 빌림을 활성 상태로 유지합니다.
 }
 ```
 
-## Further reading
+## 더 읽을거리
 
-For a deeper-yet-still-fast explanation into Rust and its symbols/keywords, the
-[half-hour to learn Rust](https://fasterthanli.me/articles/a-half-hour-to-learn-rust)
-article by Fasterthanlime explains (almost) everything in a clear and concise way!
+Rust와 그 기호/키워드에 대한 더 깊지만 여전히 빠른 설명을 보려면
+Fasterthanlime의 [Rust를 배우는 데 30분](https://fasterthanli.me/articles/a-half-hour-to-learn-rust)
+기사가 명확하고 간결한 방식으로 (거의) 모든 것을 설명합니다!
 
-There’s a lot more to Rust—this is just the basics of Rust so you can understand
-the most important things. To learn more about Rust, read [The Rust Programming
-Language](http://doc.rust-lang.org/book/index.html) and check out the
-[/r/rust](http://reddit.com/r/rust) subreddit. The folks on the #rust channel on
-irc.mozilla.org are also always keen to help newcomers.
+Rust에는 더 많은 것이 있습니다. 이것은 Rust의 기본 사항일 뿐이므로 가장
+중요한 것을 이해할 수 있습니다. Rust에 대해 더 자세히 알아보려면 [The Rust Programming
+Language](http://doc.rust-lang.org/book/index.html)를 읽고
+[/r/rust](http://reddit.com/r/rust) 서브레딧을 확인하십시오.
+irc.mozilla.org의 #rust 채널 사람들도 항상 신규 사용자를 돕고 싶어합니다.
 
-You can also try out features of Rust with an online compiler at the official
-[Rust Playground](https://play.rust-lang.org) or on the main
-[Rust website](http://rust-lang.org).
+공식 [Rust Playground](https://play.rust-lang.org) 또는
+주요 [Rust 웹사이트](http://rust-lang.org)에서 온라인 컴파일러로 Rust의 기능을
+시험해 볼 수도 있습니다.

--- a/ko/scala.md
+++ b/ko/scala.md
@@ -10,57 +10,57 @@ contributors:
     - ["Ha-Duong Nguyen", "http://reference-error.org"]
 ---
 
-Scala - the scalable language
+Scala - 확장 가능한 언어
 
 ```scala
 /////////////////////////////////////////////////
-// 0. Basics
+// 0. 기본
 /////////////////////////////////////////////////
 /*
-  Setup Scala:
+  Scala 설정:
 
-  1) Download Scala - http://www.scala-lang.org/downloads
-  2) Unzip/untar to your favorite location and put the bin subdir in your `PATH` environment variable
+  1) Scala 다운로드 - http://www.scala-lang.org/downloads
+  2) 원하는 위치에 압축을 풀고 bin 하위 디렉토리를 `PATH` 환경 변수에 추가
 */
 
 /*
-  Try the REPL
+  REPL 사용해보기
 
-  Scala has a tool called the REPL (Read-Eval-Print Loop) that is analogous to
-  commandline interpreters in many other languages. You may type any Scala
-  expression, and the result will be evaluated and printed.
+  Scala에는 REPL(Read-Eval-Print Loop)이라는 도구가 있으며, 이는 다른 많은 언어의
+  명령줄 인터프리터와 유사합니다. 모든 Scala 표현식을 입력하면
+  결과가 평가되어 출력됩니다.
 
-  The REPL is a very handy tool to test and verify code.  Use it as you read
-  this tutorial to quickly explore concepts on your own.
+  REPL은 코드를 테스트하고 확인하는 데 매우 유용한 도구입니다. 이 튜토리얼을
+  읽으면서 사용하여 개념을 직접 빠르게 탐색하십시오.
 */
 
-// Start a Scala REPL by running `scala`. You should see the prompt:
+// `scala`를 실행하여 Scala REPL을 시작합니다. 다음과 같은 프롬프트를 볼 수 있습니다:
 $ scala
 scala>
 
-// By default each expression you type is saved as a new numbered value
+// 기본적으로 입력하는 각 표현식은 새로운 번호가 매겨진 값으로 저장됩니다
 scala> 2 + 2
 res0: Int = 4
 
-// Default values can be reused.  Note the value type displayed in the result..
+// 기본값을 재사용할 수 있습니다. 결과에 표시되는 값 유형에 유의하십시오..
 scala> res0 + 2
 res1: Int = 6
 
-// Scala is a strongly typed language. You can use the REPL to check the type
-// without evaluating an expression.
+// Scala는 강력한 타입 언어입니다. REPL을 사용하여 표현식을 평가하지 않고
+// 타입을 확인할 수 있습니다.
 scala> :type (true, 2.0)
 (Boolean, Double)
 
-// REPL sessions can be saved
+// REPL 세션을 저장할 수 있습니다
 scala> :save /sites/repl-test.scala
 
-// Files can be loaded into the REPL
+// 파일을 REPL로 로드할 수 있습니다
 scala> :load /sites/repl-test.scala
 Loading /sites/repl-test.scala...
 res2: Int = 4
 res3: Int = 6
 
-// You can search your recent history
+// 최근 기록을 검색할 수 있습니다
 scala> :h?
 1 2 + 2
 2 res0 + 2
@@ -68,61 +68,61 @@ scala> :h?
 4 :load /sites/repl-test.scala
 5 :h?
 
-// Now that you know how to play, let's learn a little scala...
+// 이제 어떻게 사용하는지 알았으니, 스칼라를 조금 배워봅시다...
 
 /////////////////////////////////////////////////
-// 1. Basics
+// 1. 기본
 /////////////////////////////////////////////////
 
-// Single-line comments start with two forward slashes
+// 한 줄 주석은 두 개의 슬래시로 시작합니다
 
 /*
-  Multi-line comments, as you can already see from above, look like this.
+  위에서 이미 볼 수 있듯이 여러 줄 주석은 이렇습니다.
 */
 
-// Printing, and forcing a new line on the next print
+// 출력하고, 다음 출력에서 새 줄을 강제합니다
 println("Hello world!")
 println(10)
 // Hello world!
 // 10
 
-// Printing, without forcing a new line on next print
+// 출력하고, 다음 출력에서 새 줄을 강제하지 않습니다
 print("Hello world")
 print(10)
 // Hello world10
 
-// Declaring values is done using either var or val.
-// val declarations are immutable, whereas vars are mutable. Immutability is
-// a good thing.
-val x = 10 // x is now 10
-x = 20     // error: reassignment to val
+// 값 선언은 var 또는 val을 사용하여 수행됩니다.
+// val 선언은 불변인 반면, var는 가변입니다. 불변성은
+// 좋은 것입니다.
+val x = 10 // x는 이제 10입니다
+x = 20     // 오류: val에 재할당
 var y = 10
-y = 20     // y is now 20
+y = 20     // y는 이제 20입니다
 
 /*
-  Scala is a statically typed language, yet note that in the above declarations,
-  we did not specify a type. This is due to a language feature called type
-  inference. In most cases, Scala compiler can guess what the type of a variable
-  is, so you don't have to type it every time. We can explicitly declare the
-  type of a variable like so:
+  Scala는 정적 타입 언어이지만, 위 선언에서
+  타입을 지정하지 않았다는 점에 유의하십시오. 이는 타입 추론이라는
+  언어 기능 때문입니다. 대부분의 경우 Scala 컴파일러는 변수의
+  타입을 추측할 수 있으므로 매번 입력할 필요가 없습니다.
+  다음과 같이 변수의 타입을 명시적으로 선언할 수 있습니다:
 */
 val z: Int = 10
 val a: Double = 1.0
 
-// Notice automatic conversion from Int to Double, result is 10.0, not 10
+// Int에서 Double로의 자동 변환에 유의하십시오. 결과는 10이 아닌 10.0입니다.
 val b: Double = 10
 
-// Boolean values
+// 불리언 값
 true
 false
 
-// Boolean operations
+// 불리언 연산
 !true         // false
 !false        // true
 true == false // false
 10 > 5        // true
 
-// Math is as per usual
+// 수학은 평소와 같습니다
 1 + 1   // 2
 2 - 1   // 1
 5 * 3   // 15
@@ -132,56 +132,55 @@ true == false // false
 6 / 4.0 // 1.5
 
 
-// Evaluating an expression in the REPL gives you the type and value of the result
+// REPL에서 표현식을 평가하면 결과의 타입과 값이 제공됩니다
 
 1 + 7
 
-/* The above line results in:
+/* 위 줄의 결과는 다음과 같습니다:
 
   scala> 1 + 7
   res29: Int = 8
 
-  This means the result of evaluating 1 + 7 is an object of type Int with a
-  value of 8
+  이는 1 + 7을 평가한 결과가 값이 8인 Int 타입의 객체임을 의미합니다.
 
-  Note that "res29" is a sequentially generated variable name to store the
-  results of the expressions you typed, your output may differ.
+  "res29"는 입력한 표현식의 결과를 저장하기 위해 순차적으로 생성된
+  변수 이름이며, 출력은 다를 수 있습니다.
 */
 
-"Scala strings are surrounded by double quotes"
-'a' // A Scala Char
-// 'Single quote strings don't exist' <= This causes an error
+"Scala 문자열은 큰따옴표로 묶입니다"
+'a' // Scala Char
+// '작은따옴표 문자열은 존재하지 않습니다' <= 이로 인해 오류가 발생합니다
 
-// Strings have the usual Java methods defined on them
+// 문자열에는 일반적인 Java 메서드가 정의되어 있습니다
 "hello world".length
 "hello world".substring(2, 6)
 "hello world".replace("C", "3")
 
-// They also have some extra Scala methods. See also: scala.collection.immutable.StringOps
+// 추가 Scala 메서드도 있습니다. scala.collection.immutable.StringOps도 참조하십시오.
 "hello world".take(5)
 "hello world".drop(5)
 
-// String interpolation: notice the prefix "s"
+// 문자열 보간: 접두사 "s"에 유의하십시오
 val n = 45
 s"We have $n apples" // => "We have 45 apples"
 
-// Expressions inside interpolated strings are also possible
+// 보간된 문자열 내의 표현식도 가능합니다
 val a = Array(11, 9, 6)
 s"My second daughter is ${a(0) - a(2)} years old."    // => "My second daughter is 5 years old."
 s"We have double the amount of ${n / 2.0} in apples." // => "We have double the amount of 22.5 in apples."
 s"Power of 2: ${math.pow(2, 2)}"                      // => "Power of 2: 4"
 
-// Formatting with interpolated strings with the prefix "f"
+// 접두사 "f"를 사용하여 보간된 문자열로 서식 지정
 f"Power of 5: ${math.pow(5, 2)}%1.0f"         // "Power of 5: 25"
 f"Square root of 122: ${math.sqrt(122)}%1.4f" // "Square root of 122: 11.0454"
 
-// Raw strings, ignoring special characters.
+// 원시 문자열, 특수 문자 무시.
 raw"New line feed: \n. Carriage return: \r." // => "New line feed: \n. Carriage return: \r."
 
-// Some characters need to be "escaped", e.g. a double quote inside a string:
+// 일부 문자는 "이스케이프"해야 합니다. 예를 들어 문자열 내의 큰따옴표:
 "They stood outside the \"Rose and Crown\"" // => "They stood outside the "Rose and Crown""
 
-// Triple double-quotes let strings span multiple rows and contain quotes
+// 세 개의 큰따옴표는 문자열이 여러 줄에 걸쳐 있고 따옴표를 포함할 수 있도록 합니다
 val html = """<form id="daform">
                 <p>Press belo', Joe</p>
                 <input type="submit">
@@ -189,60 +188,57 @@ val html = """<form id="daform">
 
 
 /////////////////////////////////////////////////
-// 2. Functions
+// 2. 함수
 /////////////////////////////////////////////////
 
-// Functions are defined like so:
+// 함수는 다음과 같이 정의됩니다:
 //
 //   def functionName(args...): ReturnType = { body... }
 //
-// If you come from more traditional languages, notice the omission of the
-// return keyword. In Scala, the last expression in the function block is the
-// return value.
+// 더 전통적인 언어에서 온 경우 return 키워드의 생략에 유의하십시오.
+// Scala에서는 함수 블록의 마지막 표현식이 반환 값입니다.
 def sumOfSquares(x: Int, y: Int): Int = {
   val x2 = x * x
   val y2 = y * y
   x2 + y2
 }
 
-// The { } can be omitted if the function body is a single expression:
+// 함수 본문이 단일 표현식인 경우 { }를 생략할 수 있습니다:
 def sumOfSquaresShort(x: Int, y: Int): Int = x * x + y * y
 
-// Syntax for calling functions is familiar:
+// 함수 호출 구문은 익숙합니다:
 sumOfSquares(3, 4)  // => 25
 
-// You can use parameters names to specify them in different order
+// 매개변수 이름을 사용하여 다른 순서로 지정할 수 있습니다
 def subtract(x: Int, y: Int): Int = x - y
 
 subtract(10, 3)     // => 7
 subtract(y=10, x=3) // => -7
 
-// In most cases (with recursive functions the most notable exception), function
-// return type can be omitted, and the same type inference we saw with variables
-// will work with function return values:
-def sq(x: Int) = x * x  // Compiler can guess return type is Int
+// 대부분의 경우(재귀 함수가 가장 주목할 만한 예외) 함수
+// 반환 타입을 생략할 수 있으며, 변수에서 보았던 것과 동일한 타입 추론이
+// 함수 반환 값에서도 작동합니다:
+def sq(x: Int) = x * x  // 컴파일러는 반환 타입이 Int라고 추측할 수 있습니다
 
-// Functions can have default parameters:
+// 함수에는 기본 매개변수가 있을 수 있습니다:
 def addWithDefault(x: Int, y: Int = 5) = x + y
 addWithDefault(1, 2) // => 3
 addWithDefault(1)    // => 6
 
 
-// Anonymous functions look like this:
+// 익명 함수는 다음과 같습니다:
 (x: Int) => x * x
 
-// Unlike defs, even the input type of anonymous functions can be omitted if the
-// context makes it clear. Notice the type "Int => Int" which means a function
-// that takes Int and returns Int.
+// def와 달리, 컨텍스트가 명확하면 익명 함수의 입력 타입도 생략할 수 있습니다.
+// "Int => Int" 타입은 Int를 받아 Int를 반환하는 함수를 의미합니다.
 val sq: Int => Int = x => x * x
 
-// Anonymous functions can be called as usual:
+// 익명 함수는 평소와 같이 호출할 수 있습니다:
 sq(10)   // => 100
 
-// If each argument in your anonymous function is
-// used only once, Scala gives you an even shorter way to define them. These
-// anonymous functions turn out to be extremely common, as will be obvious in
-// the data structure section.
+// 익명 함수의 각 인수가 한 번만 사용되는 경우,
+// Scala는 더 짧은 방법으로 정의할 수 있습니다. 이러한
+// 익명 함수는 데이터 구조 섹션에서 명백해지겠지만 매우 일반적입니다.
 val addOne: Int => Int = _ + 1
 val weirdSum: (Int, Int) => Int = (_ * 2 + _ * 3)
 
@@ -250,24 +246,24 @@ addOne(5)      // => 6
 weirdSum(2, 4) // => 16
 
 
-// The return keyword exists in Scala, but it only returns from the inner-most
-// def that surrounds it.
-// WARNING: Using return in Scala is error-prone and should be avoided.
-// It has no effect on anonymous functions. For example here you may expect foo(7) should return 17 but it returns 7:
+// return 키워드는 Scala에 존재하지만, 가장 안쪽의
+// def에서만 반환합니다.
+// 경고: Scala에서 return을 사용하는 것은 오류가 발생하기 쉬우므로 피해야 합니다.
+// 익명 함수에는 영향을 미치지 않습니다. 예를 들어 여기서 foo(7)이 17을 반환할 것으로 예상할 수 있지만 7을 반환합니다:
 def foo(x: Int): Int = {
   val anonFunc: Int => Int = { z =>
     if (z > 5)
-      return z // This line makes z the return value of foo!
+      return z // 이 줄은 z를 foo의 반환 값으로 만듭니다!
     else
-      z + 2    // This line is the return value of anonFunc
+      z + 2    // 이 줄은 anonFunc의 반환 값입니다
   }
-  anonFunc(x) + 10  // This line is the return value of foo
+  anonFunc(x) + 10  // 이 줄은 foo의 반환 값입니다
 }
 
 foo(7) // => 7
 
 /////////////////////////////////////////////////
-// 3. Flow Control
+// 3. 제어 흐름
 /////////////////////////////////////////////////
 
 1 to 5
@@ -275,35 +271,35 @@ val r = 1 to 5
 r.foreach(println)
 
 r foreach println
-// NB: Scala is quite lenient when it comes to dots and brackets - study the
-// rules separately. This helps write DSLs and APIs that read like English
+// 참고: Scala는 점과 괄호에 대해 상당히 관대합니다 -
+// 규칙을 별도로 연구하십시오. 이는 영어처럼 읽히는 DSL 및 API를 작성하는 데 도움이 됩니다.
 
-// Why doesn't `println` need any parameters here?
-// Stay tuned for first-class functions in the Functional Programming section below!
+// 왜 여기서 `println`에 매개변수가 필요하지 않을까요?
+// 아래 함수형 프로그래밍 섹션의 일급 함수를 기대하십시오!
 (5 to 1 by -1) foreach (println)
 
-// A while loop
+// while 루프
 var i = 0
 while (i < 10) { println("i " + i); i += 1 }
 
-while (i < 10) { println("i " + i); i += 1 }   // Yes, again. What happened? Why?
+while (i < 10) { println("i " + i); i += 1 }   // 네, 다시. 무슨 일이 있었나요? 왜요?
 
-i    // Show the value of i. Note that while is a loop in the classical sense -
-     // it executes sequentially while changing the loop variable. while is very
-     // fast, but using the combinators and comprehensions above is easier
-     // to understand and parallelize
+i    // i의 값을 표시합니다. while은 고전적인 의미의 루프입니다 -
+     // 루프 변수를 변경하면서 순차적으로 실행됩니다. while은 매우
+     // 빠르지만, 위의 조합기 및 내포를 사용하는 것이 이해하기 쉽고
+     // 병렬화하기 쉽습니다.
 
-// A do-while loop
+// do-while 루프
 i = 0
 do {
   println("i is still less than 10")
   i += 1
 } while (i < 10)
 
-// Recursion is the idiomatic way of repeating an action in Scala (as in most
-// other functional languages).
-// Recursive functions need an explicit return type, the compiler can't infer it.
-// Here it's Unit, which is analogous to a `void` return type in Java
+// 재귀는 Scala에서 (대부분의 다른 함수형 언어에서와 같이)
+// 작업을 반복하는 관용적인 방법입니다.
+// 재귀 함수는 명시적인 반환 타입이 필요하며, 컴파일러는 이를 추론할 수 없습니다.
+// 여기서 Unit은 Java의 `void` 반환 타입과 유사합니다.
 def showNumbersInRange(a: Int, b: Int): Unit = {
   print(a)
   if (a < b)
@@ -312,7 +308,7 @@ def showNumbersInRange(a: Int, b: Int): Unit = {
 showNumbersInRange(1, 14)
 
 
-// Conditionals
+// 조건문
 
 val x = 10
 
@@ -326,18 +322,18 @@ val text = if (x == 10) "yeah" else "nope"
 
 
 /////////////////////////////////////////////////
-// 4. Data Structures
+// 4. 데이터 구조
 /////////////////////////////////////////////////
 
 val a = Array(1, 2, 3, 5, 8, 13)
 a(0)     // Int = 1
 a(3)     // Int = 5
-a(21)    // Throws an exception
+a(21)    // 예외 발생
 
 val m = Map("fork" -> "tenedor", "spoon" -> "cuchara", "knife" -> "cuchillo")
 m("fork")         // java.lang.String = tenedor
 m("spoon")        // java.lang.String = cuchara
-m("bottle")       // Throws an exception
+m("bottle")       // 예외 발생
 
 val safeM = m.withDefaultValue("no lo se")
 safeM("bottle")   // java.lang.String = no lo se
@@ -346,13 +342,13 @@ val s = Set(1, 3, 7)
 s(0)      // Boolean = false
 s(1)      // Boolean = true
 
-/* Look up the documentation of map here -
+/* 여기서 맵 설명서를 찾아보십시오 -
  * https://www.scala-lang.org/api/current/scala/collection/immutable/Map.html
- * and make sure you can read it
+ * 그리고 읽을 수 있는지 확인하십시오.
  */
 
 
-// Tuples
+// 튜플
 
 (1, 2)
 
@@ -362,21 +358,20 @@ s(1)      // Boolean = true
 
 (a, 2, "three")
 
-// Why have this?
+// 왜 이것이 있을까요?
 val divideInts = (x: Int, y: Int) => (x / y, x % y)
 
-// The function divideInts gives you the result and the remainder
+// divideInts 함수는 결과와 나머지를 제공합니다
 divideInts(10, 3)    // (Int, Int) = (3,1)
 
-// To access the elements of a tuple, use _._n where n is the 1-based index of
-// the element
+// 튜플의 요소에 액세스하려면 _._n을 사용하십시오. 여기서 n은 요소의 1-기반 인덱스입니다.
 val d = divideInts(10, 3)    // (Int, Int) = (3,1)
 
 d._1    // Int = 3
 d._2    // Int = 1
 
-// Alternatively you can do multiple-variable assignment to tuple, which is more
-// convenient and readable in many cases
+// 또는 튜플에 다중 변수 할당을 할 수 있으며, 이는 많은 경우에 더 편리하고
+// 읽기 쉽습니다.
 val (div, mod) = divideInts(10, 3)
 
 div     // Int = 3
@@ -384,40 +379,40 @@ mod     // Int = 1
 
 
 /////////////////////////////////////////////////
-// 5. Object Oriented Programming
+// 5. 객체 지향 프로그래밍
 /////////////////////////////////////////////////
 
 /*
-  Aside: Everything we've done so far in this tutorial has been simple
-  expressions (values, functions, etc). These expressions are fine to type into
-  the command-line interpreter for quick tests, but they cannot exist by
-  themselves in a Scala file. For example, you cannot have just "val x = 5" in
-  a Scala file. Instead, the only top-level constructs allowed in Scala are:
+  참고: 이 튜토리얼에서 지금까지 수행한 모든 작업은 간단한
+  표현식(값, 함수 등)이었습니다. 이러한 표현식은 빠른 테스트를 위해
+  명령줄 인터프리터에 입력하기에 좋지만, Scala 파일에
+  단독으로 존재할 수는 없습니다. 예를 들어 Scala 파일에 "val x = 5"만 있을 수는 없습니다.
+  대신 Scala에서 허용되는 유일한 최상위 구문은 다음과 같습니다:
 
   - objects
   - classes
   - case classes
   - traits
 
-  And now we will explain what these are.
+  이제 이것들이 무엇인지 설명하겠습니다.
 */
 
-// classes are similar to classes in other languages. Constructor arguments are
-// declared after the class name, and initialization is done in the class body.
+// 클래스는 다른 언어의 클래스와 유사합니다. 생성자 인수는
+// 클래스 이름 뒤에 선언되고, 초기화는 클래스 본문에서 수행됩니다.
 class Dog(br: String) {
-  // Constructor code here
+  // 생성자 코드 여기
   var breed: String = br
 
-  // Define a method called bark, returning a String
+  // bark라는 메서드를 정의하고 String을 반환합니다
   def bark = "Woof, woof!"
 
-  // Values and methods are assumed public. "protected" and "private" keywords
-  // are also available.
+  // 값과 메서드는 public으로 간주됩니다. "protected" 및 "private" 키워드도
+  // 사용할 수 있습니다.
   private def sleep(hours: Int) =
     println(s"I'm sleeping for $hours hours")
 
-  // Abstract methods are simply methods with no body. If we uncomment the
-  // def line below, class Dog would need to be declared abstract like so:
+  // 추상 메서드는 단순히 본문이 없는 메서드입니다. 아래 def 줄의 주석을
+  // 해제하면 Dog 클래스를 다음과 같이 abstract로 선언해야 합니다:
   //   abstract class Dog(...) { ... }
   // def chaseAfter(what: String): String
 }
@@ -427,48 +422,48 @@ println(mydog.breed) // => "greyhound"
 println(mydog.bark)  // => "Woof, woof!"
 
 
-// The "object" keyword creates a type AND a singleton instance of it. It is
-// common for Scala classes to have a "companion object", where the per-instance
-// behavior is captured in the classes themselves, but behavior related to all
-// instance of that class go in objects. The difference is similar to class
-// methods vs static methods in other languages. Note that objects and classes
-// can have the same name.
+// "object" 키워드는 타입과 해당 타입의 싱글턴 인스턴스를 생성합니다.
+// Scala 클래스가 "컴패니언 객체"를 갖는 것이 일반적이며, 여기서 인스턴스별
+// 동작은 클래스 자체에 캡처되지만, 해당 클래스의 모든
+// 인스턴스와 관련된 동작은 객체로 이동합니다. 차이점은 다른 언어의
+// 클래스 메서드와 정적 메서드와 유사합니다. 객체와 클래스는
+// 동일한 이름을 가질 수 있습니다.
 object Dog {
   def allKnownBreeds = List("pitbull", "shepherd", "retriever")
   def createDog(breed: String) = new Dog(breed)
 }
 
 
-// Case classes are classes that have extra functionality built in. A common
-// question for Scala beginners is when to use classes and when to use case
-// classes. The line is quite fuzzy, but in general, classes tend to focus on
-// encapsulation, polymorphism, and behavior. The values in these classes tend
-// to be private, and only methods are exposed. The primary purpose of case
-// classes is to hold immutable data. They often have few methods, and the
-// methods rarely have side-effects.
+// 케이스 클래스는 추가 기능이 내장된 클래스입니다. Scala 초보자를 위한
+// 일반적인 질문은 언제 클래스를 사용하고 언제 케이스 클래스를 사용해야 하는지입니다.
+// 경계가 모호하지만, 일반적으로 클래스는 캡슐화, 다형성 및
+// 동작에 중점을 둡니다. 이러한 클래스의 값은 private인 경향이 있으며,
+// 메서드만 노출됩니다. 케이스 클래스의 주요 목적은
+// 불변 데이터를 보유하는 것입니다. 메서드가 거의 없으며,
+// 메서드에는 부작용이 거의 없습니다.
 case class Person(name: String, phoneNumber: String)
 
-// Create a new instance. Note cases classes don't need "new"
+// 새 인스턴스를 만듭니다. 케이스 클래스는 "new"가 필요하지 않습니다.
 val george = Person("George", "1234")
 val kate = Person("Kate", "4567")
 
-// With case classes, you get a few perks for free, like getters:
+// 케이스 클래스를 사용하면 다음과 같은 몇 가지 특전을 무료로 얻을 수 있습니다.
 george.phoneNumber  // => "1234"
 
-// Per field equality (no need to override .equals)
+// 필드별 동등성 (.equals를 재정의할 필요 없음)
 Person("George", "1234") == Person("Kate", "1236")  // => false
 
-// Easy way to copy
+// 쉬운 복사 방법
 // otherGeorge == Person("George", "9876")
 val otherGeorge = george.copy(phoneNumber = "9876")
 
-// And many others. Case classes also get pattern matching for free, see below.
+// 그리고 다른 많은 것들. 케이스 클래스는 패턴 매칭도 무료로 얻습니다. 아래 참조.
 
-// Traits
-// Similar to Java interfaces, traits define an object type and method
-// signatures. Scala allows partial implementation of those methods.
-// Constructor parameters are not allowed. Traits can inherit from other
-// traits or classes without parameters.
+// 트레이트
+// Java 인터페이스와 유사하게, 트레이트는 객체 타입과 메서드
+// 시그니처를 정의합니다. Scala는 이러한 메서드의 부분 구현을 허용합니다.
+// 생성자 매개변수는 허용되지 않습니다. 트레이트는 매개변수 없이 다른
+// 트레이트나 클래스에서 상속할 수 있습니다.
 
 trait Dog {
 	def breed: String
@@ -491,8 +486,8 @@ res2: Boolean = true
 scala> b.bite
 res3: Boolean = false
 
-// A trait can also be used as Mixin. The class "extends" the first trait,
-// but the keyword "with" can add additional traits.
+// 트레이트는 믹스인으로도 사용할 수 있습니다. 클래스는 첫 번째 트레이트를 "extends"하지만,
+// "with" 키워드는 추가 트레이트를 추가할 수 있습니다.
 
 trait Bark {
 	def bark: String = "Woof"
@@ -513,59 +508,57 @@ res0: String = Woof
 
 
 /////////////////////////////////////////////////
-// 6. Pattern Matching
+// 6. 패턴 매칭
 /////////////////////////////////////////////////
 
-// Pattern matching is a powerful and commonly used feature in Scala. Here's how
-// you pattern match a case class. NB: Unlike other languages, Scala cases do
-// not need breaks, fall-through does not happen.
+// 패턴 매칭은 Scala에서 강력하고 일반적으로 사용되는 기능입니다. 다음은
+// 케이스 클래스를 패턴 매칭하는 방법입니다. 참고: 다른 언어와 달리 Scala 케이스는
+// break가 필요 없으며, fall-through가 발생하지 않습니다.
 
 def matchPerson(person: Person): String = person match {
-  // Then you specify the patterns:
+  // 그런 다음 패턴을 지정합니다:
   case Person("George", number) => "We found George! His number is " + number
   case Person("Kate", number)   => "We found Kate! Her number is " + number
   case Person(name, number)     => "We matched someone : " + name + ", phone : " + number
 }
 
-// Regular expressions are also built in.
-// Create a regex with the `r` method on a string:
+// 정규식도 내장되어 있습니다.
+// 문자열에서 `r` 메서드를 사용하여 정규식을 만듭니다:
 val email = "(.*)@(.*)".r
 
-// Pattern matching might look familiar to the switch statements in the C family
-// of languages, but this is much more powerful. In Scala, you can match much
-// more:
+// 패턴 매칭은 C 계열 언어의 switch 문과 비슷해 보일 수 있지만,
+// 훨씬 더 강력합니다. Scala에서는 훨씬 더 많은 것을 매칭할 수 있습니다:
 def matchEverything(obj: Any): String = obj match {
-  // You can match values:
+  // 값을 매칭할 수 있습니다:
   case "Hello world" => "Got the string Hello world"
 
-  // You can match by type:
+  // 타입별로 매칭할 수 있습니다:
   case x: Double => "Got a Double: " + x
 
-  // You can specify conditions:
+  // 조건을 지정할 수 있습니다:
   case x: Int if x > 10000 => "Got a pretty big number!"
 
-  // You can match case classes as before:
+  // 이전과 같이 케이스 클래스를 매칭할 수 있습니다:
   case Person(name, number) => s"Got contact info for $name!"
 
-  // You can match regular expressions:
+  // 정규식을 매칭할 수 있습니다:
   case email(name, domain) => s"Got email address $name@$domain"
 
-  // You can match tuples:
+  // 튜플을 매칭할 수 있습니다:
   case (a: Int, b: Double, c: String) => s"Got a tuple: $a, $b, $c"
 
-  // You can match data structures:
+  // 데이터 구조를 매칭할 수 있습니다:
   case List(1, b, c) => s"Got a list with three elements and starts with 1: 1, $b, $c"
 
-  // You can nest patterns:
+  // 패턴을 중첩할 수 있습니다:
   case List(List((1, 2, "YAY"))) => "Got a list of list of tuple"
 
-  // Match any case (default) if all previous haven't matched
+  // 이전 모든 것이 일치하지 않으면 모든 경우를 매칭합니다 (기본값)
   case _ => "Got unknown object"
 }
 
-// In fact, you can pattern match any object with an "unapply" method. This
-// feature is so powerful that Scala lets you define whole functions as
-// patterns:
+// 사실, "unapply" 메서드가 있는 모든 객체를 패턴 매칭할 수 있습니다. 이
+// 기능은 너무 강력해서 Scala는 전체 함수를 패턴으로 정의할 수 있습니다:
 val patternFunc: Person => String = {
   case Person("George", number) => s"George's number: $number"
   case Person(name, number) => s"Random person's number: $number"
@@ -573,29 +566,29 @@ val patternFunc: Person => String = {
 
 
 /////////////////////////////////////////////////
-// 7. Functional Programming
+// 7. 함수형 프로그래밍
 /////////////////////////////////////////////////
 
-// Scala allows methods and functions to return, or take as parameters, other
-// functions or methods.
+// Scala는 메서드와 함수가 다른 함수나 메서드를 반환하거나
+// 매개변수로 받을 수 있도록 허용합니다.
 
-val add10: Int => Int = _ + 10 // A function taking an Int and returning an Int
-List(1, 2, 3) map add10 // List(11, 12, 13) - add10 is applied to each element
+val add10: Int => Int = _ + 10 // Int를 받아 Int를 반환하는 함수
+List(1, 2, 3) map add10 // List(11, 12, 13) - add10이 각 요소에 적용됩니다
 
-// Anonymous functions can be used instead of named functions:
+// 명명된 함수 대신 익명 함수를 사용할 수 있습니다:
 List(1, 2, 3) map (x => x + 10)
 
-// And the underscore symbol, can be used if there is just one argument to the
-// anonymous function. It gets bound as the variable
+// 그리고 익명 함수에 인수가 하나만 있는 경우 밑줄 기호를 사용할 수 있습니다.
+// 변수로 바인딩됩니다.
 List(1, 2, 3) map (_ + 10)
 
-// If the anonymous block AND the function you are applying both take one
-// argument, you can even omit the underscore
+// 익명 블록과 적용하는 함수가 모두 인수를 하나만 받는 경우
+// 밑줄을 생략할 수도 있습니다.
 List("Dom", "Bob", "Natalia") foreach println
 
 
-// Combinators
-// Using `s` from above:
+// 조합기
+// 위에서 `s` 사용:
 // val s = Set(1, 3, 7)
 
 s.map(sq)
@@ -606,8 +599,8 @@ sSquared.filter(_ < 10)
 
 sSquared.reduce (_+_)
 
-// The filter function takes a predicate (a function from A -> Boolean) and
-// selects all elements which satisfy the predicate
+// filter 함수는 술어(A -> Boolean 함수)를 받아
+// 술어를 만족하는 모든 요소를 선택합니다
 List(1, 2, 3) filter (_ > 2) // List(3)
 case class Person(name: String, age: Int)
 List(
@@ -616,13 +609,13 @@ List(
 ).filter(_.age > 25) // List(Person("Bob", 30))
 
 
-// Certain collections (such as List) in Scala have a `foreach` method,
-// which takes as an argument a type returning Unit - that is, a void method
+// Scala의 특정 컬렉션(예: List)에는 `foreach` 메서드가 있으며,
+// Unit을 반환하는 타입을 인수로 받습니다. 즉, void 메서드입니다.
 val aListOfNumbers = List(1, 2, 3, 4, 10, 20, 100)
 aListOfNumbers foreach (x => println(x))
 aListOfNumbers foreach println
 
-// For comprehensions
+// For 내포
 
 for { n <- s } yield sq(n)
 
@@ -632,123 +625,120 @@ for { n <- nSquared2 if n < 10 } yield n
 
 for { n <- s; nSquared = n * n if nSquared < 10} yield nSquared
 
-/* NB Those were not for loops. The semantics of a for loop is 'repeat', whereas
-   a for-comprehension defines a relationship between two sets of data. */
+/* 참고: 이것들은 for 루프가 아니었습니다. for 루프의 의미는 '반복'인 반면,
+   for-내포는 두 데이터 집합 간의 관계를 정의합니다. */
 
 
 /////////////////////////////////////////////////
-// 8. Implicits
+// 8. 암시
 /////////////////////////////////////////////////
 
-/* WARNING WARNING: Implicits are a set of powerful features of Scala, and
- * therefore it is easy to abuse them. Beginners to Scala should resist the
- * temptation to use them until they understand not only how they work, but also
- * best practices around them. We only include this section in the tutorial
- * because they are so commonplace in Scala libraries that it is impossible to
- * do anything meaningful without using a library that has implicits. This is
- * meant for you to understand and work with implicits, not declare your own.
+/* 경고 경고: 암시는 Scala의 강력한 기능 집합이므로
+ * 남용하기 쉽습니다. Scala 초보자는 어떻게 작동하는지뿐만 아니라
+ * 그 주변의 모범 사례를 이해할 때까지 사용하려는 유혹을 참아야 합니다.
+ * 이 튜토리얼에 이 섹션을 포함하는 이유는 Scala 라이브러리에서 너무 흔해서
+ * 암시가 있는 라이브러리를 사용하지 않고는 의미 있는 작업을 수행하는 것이
+ * 불가능하기 때문입니다. 이것은 여러분이 암시를 이해하고 작업하기 위한 것이며,
+ * 직접 선언하기 위한 것이 아닙니다.
  */
 
-// Any value (vals, functions, objects, etc) can be declared to be implicit by
-// using the, you guessed it, "implicit" keyword. Note we are using the Dog
-// class from section 5 in these examples.
+// 모든 값(val, 함수, 객체 등)은 "implicit" 키워드를 사용하여
+// 암시적으로 선언될 수 있습니다. 이 예제에서는 5절의 Dog 클래스를 사용합니다.
 implicit val myImplicitInt = 100
 implicit def myImplicitFunction(breed: String) = new Dog("Golden " + breed)
 
-// By itself, implicit keyword doesn't change the behavior of the value, so
-// above values can be used as usual.
+// 그 자체로 implicit 키워드는 값의 동작을 변경하지 않으므로
+// 위 값은 평소와 같이 사용할 수 있습니다.
 myImplicitInt + 2                   // => 102
 myImplicitFunction("Pitbull").breed // => "Golden Pitbull"
 
-// The difference is that these values are now eligible to be used when another
-// piece of code "needs" an implicit value. One such situation is implicit
-// function arguments:
+// 차이점은 이러한 값이 이제 다른 코드 조각이
+// "암시적 값"을 "필요"할 때 사용될 수 있다는 것입니다. 한 가지 그러한 상황은
+// 암시적 함수 인수입니다:
 def sendGreetings(toWhom: String)(implicit howMany: Int) =
   s"Hello $toWhom, $howMany blessings to you and yours!"
 
-// If we supply a value for "howMany", the function behaves as usual
+// "howMany"에 대한 값을 제공하면 함수는 평소와 같이 동작합니다
 sendGreetings("John")(1000)  // => "Hello John, 1000 blessings to you and yours!"
 
-// But if we omit the implicit parameter, an implicit value of the same type is
-// used, in this case, "myImplicitInt":
+// 그러나 암시적 매개변수를 생략하면 동일한 타입의 암시적 값이
+// 사용됩니다. 이 경우 "myImplicitInt"입니다:
 sendGreetings("Jane")  // => "Hello Jane, 100 blessings to you and yours!"
 
-// Implicit function parameters enable us to simulate type classes in other
-// functional languages. It is so often used that it gets its own shorthand. The
-// following two lines mean the same thing:
+// 암시적 함수 매개변수를 사용하면 다른
+// 함수형 언어의 타입 클래스를 시뮬레이션할 수 있습니다. 너무 자주 사용되어
+// 자체 약어가 있습니다. 다음 두 줄은 동일한 의미입니다:
 // def foo[T](implicit c: C[T]) = ...
 // def foo[T : C] = ...
 
 
-// Another situation in which the compiler looks for an implicit is if you have
+// 컴파일러가 암시를 찾는 또 다른 상황은
 //   obj.method(...)
-// but "obj" doesn't have "method" as a method. In this case, if there is an
-// implicit conversion of type A => B, where A is the type of obj, and B has a
-// method called "method", that conversion is applied. So having
-// myImplicitFunction above in scope, we can say:
+// 이지만 "obj"에 "method"라는 메서드가 없는 경우입니다. 이 경우
+// A => B 타입의 암시적 변환이 있고, 여기서 A는 obj의 타입이고 B에
+// "method"라는 메서드가 있으면 해당 변환이 적용됩니다. 따라서
+// 위의 myImplicitFunction이 범위에 있으면 다음과 같이 말할 수 있습니다:
 "Retriever".breed // => "Golden Retriever"
 "Sheperd".bark    // => "Woof, woof!"
 
-// Here the String is first converted to Dog using our function above, and then
-// the appropriate method is called. This is an extremely powerful feature, but
-// again, it is not to be used lightly. In fact, when you defined the implicit
-// function above, your compiler should have given you a warning, that you
-// shouldn't do this unless you really know what you're doing.
+// 여기서 String은 먼저 위 함수를 사용하여 Dog로 변환된 다음
+// 적절한 메서드가 호출됩니다. 이것은 매우 강력한 기능이지만,
+// 다시 말하지만, 가볍게 사용해서는 안 됩니다. 사실, 위의 암시적 함수를
+// 정의했을 때 컴파일러는 정말로 무엇을 하는지 모르는 한
+// 이렇게 해서는 안 된다는 경고를 했을 것입니다.
 
 
 /////////////////////////////////////////////////
-// 9. Misc
+// 9. 기타
 /////////////////////////////////////////////////
 
-// Importing things
+// 항목 가져오기
 import scala.collection.immutable.List
 
-// Import all "sub packages"
+// 모든 "하위 패키지" 가져오기
 import scala.collection.immutable._
 
-// Import multiple classes in one statement
+// 한 문장으로 여러 클래스 가져오기
 import scala.collection.immutable.{List, Map}
 
-// Rename an import using '=>'
+// '=>'를 사용하여 가져오기 이름 바꾸기
 import scala.collection.immutable.{List => ImmutableList}
 
-// Import all classes, except some. The following excludes Map and Set:
+// 일부를 제외하고 모든 클래스 가져오기. 다음은 Map과 Set을 제외합니다:
 import scala.collection.immutable.{Map => _, Set => _, _}
 
-// Java classes can also be imported. Scala syntax can be used
+// Java 클래스도 가져올 수 있습니다. Scala 구문을 사용할 수 있습니다
 import java.swing.{JFrame, JWindow}
 
-// Your program's entry point is defined in a scala file using an object, with a
-// single method, main:
+// 프로그램의 진입점은 Scala 파일에서 단일 메서드 main이 있는 객체를 사용하여
+// 정의됩니다:
 object Application {
   def main(args: Array[String]): Unit = {
-    // stuff goes here.
+    // 여기에 내용이 들어갑니다.
   }
 }
 
-// Files can contain multiple classes and objects. Compile with scalac
+// 파일에는 여러 클래스와 객체가 포함될 수 있습니다. scalac으로 컴파일
 
 
+// 입출력
 
-
-// Input and output
-
-// To read a file line by line
+// 파일을 한 줄씩 읽으려면
 import scala.io.Source
 for(line <- Source.fromFile("myfile.txt").getLines())
   println(line)
 
-// To write a file use Java's PrintWriter
+// 파일을 쓰려면 Java의 PrintWriter를 사용하십시오
 val writer = new PrintWriter("myfile.txt")
 writer.write("Writing line for line" + util.Properties.lineSeparator)
 writer.write("Another line here" + util.Properties.lineSeparator)
 writer.close()
 ```
 
-## Further resources
+## 추가 자료
 
-* [Scala for the impatient](http://horstmann.com/scala/)
-* [Twitter Scala school](http://twitter.github.io/scala_school/)
-* [The scala documentation](http://docs.scala-lang.org/)
-* [Try Scala in your browser](http://scalatutorials.com/tour/)
-* Join the [Scala user group](https://groups.google.com/forum/#!forum/scala-user)
+* [성급한 사람들을 위한 스칼라](http://horstmann.com/scala/)
+* [트위터 스칼라 스쿨](http://twitter.github.io/scala_school/)
+* [스칼라 문서](http://docs.scala-lang.org/)
+* [브라우저에서 스칼라 사용해보기](http://scalatutorials.com/tour/)
+* [스칼라 사용자 그룹 가입](https://groups.google.com/forum/#!forum/scala-user)

--- a/ko/sed.md
+++ b/ko/sed.md
@@ -9,225 +9,188 @@ contributors:
 
 ---
 
-__Sed__ is a standard tool on every POSIX-compliant UNIX system.
-It's like an editor, such as Vim, Visual Studio Code, Atom, or Sublime.
-However, rather than typing the commands interactively, you
-provide them on the command line or in a file.
+__Sed__는 모든 POSIX 호환 유닉스 시스템의 표준 도구입니다.
+Vim, Visual Studio Code, Atom 또는 Sublime과 같은 편집기와 같습니다.
+그러나 대화식으로 명령을 입력하는 대신 명령줄이나 파일로 제공합니다.
 
-_Sed_'s advantages over an interactive editor is that it can be easily
-used to automate text processing tasks, and that it can process
-efficiently huge (terabyte-sized) files.
-It can perform more complex tasks than _grep_ and for many text
-processing tasks its commands are much shorter than what you would
-write in _awk_, _Perl_, or _Python_.
+대화형 편집기에 대한 _Sed_의 장점은 텍스트 처리 작업을 자동화하는 데 쉽게 사용할 수 있고 거대한(테라바이트 크기) 파일을 효율적으로 처리할 수 있다는 것입니다.
+_grep_보다 더 복잡한 작업을 수행할 수 있으며 많은 텍스트 처리 작업에서 해당 명령은 _awk_, _Perl_ 또는 _Python_으로 작성하는 것보다 훨씬 짧습니다.
 
-_Sed_ works by reading a line of text (by default from its standard
-input, unless some files are specified as arguments), processing
-it with the specified commands, and then outputting the result
-on its standard output.
-You can suppress the default output by specifying the `-n` command-line
-argument.
+_Sed_는 텍스트 한 줄을 읽고(기본적으로 인수로 일부 파일이 지정되지 않은 경우 표준 입력에서) 지정된 명령으로 처리한 다음 결과를 표준 출력으로 출력하여 작동합니다.
+-n 명령줄 인수를 지정하여 기본 출력을 표시하지 않을 수 있습니다.
 
 ```sed
 #!/usr/bin/sed -f
-# Files that begin with the above line and are given execute permission
-# can be run as regular scripts.
+# 위 줄로 시작하고 실행 권한이 부여된 파일은 일반 스크립트로 실행할 수 있습니다.
 
-# Comments are like this.
+# 주석은 이와 같습니다.
 
-# Commands consist of a single letter and many can be preceded
-# by a specification of the lines to which they apply.
+# 명령은 단일 문자로 구성되며 대부분의 경우 적용할 줄을 지정하여 앞에 올 수 있습니다.
 
-# Delete the input's third line.
+# 입력의 세 번째 줄을 삭제합니다.
 3d
 
-# The same command specified the command line as an argument to sed:
+# sed에 대한 인수로 명령줄에 지정된 동일한 명령:
 # sed 3d
 
-# For many commands the specification can consist of two addresses,
-# which select an inclusive range.
-# Addresses can be specified numerically ($ is the last line) or through
-# regular expressions delimited by /.
+# 많은 명령의 경우 사양은 포함 범위를 선택하는 두 개의 주소로 구성될 수 있습니다.
+# 주소는 숫자로 지정하거나(/로 구분된 정규식을 통해) 지정할 수 있습니다($는 마지막 줄).
 
-# Delete lines 1-10
+# 1-10행 삭제
 1,10d
 
-# Lines can also be specified as regular expressions, delimited by /.
+# 줄은 /로 구분된 정규식으로도 지정할 수 있습니다.
 
-# Delete empty lines.
+# 빈 줄 삭제.
 /^$/d
 
-# Delete blocks starting with SPOILER-BEGIN and ending with SPOILER-END.
+# SPOILER-BEGIN으로 시작하고 SPOILER-END로 끝나는 블록을 삭제합니다.
 /SPOILER-BEGIN/,/SPOILER-END/d
 
-# A command without an address is applied to all lines.
+# 주소가 없는 명령은 모든 줄에 적용됩니다.
 
-# List lines in in a visually unambiguous form (e.g. tab appears as \t).
+# 시각적으로 명확한 형식으로 줄을 나열합니다(예: 탭은 \t로 표시됨).
 l
 
-# A command prefixed by ! will apply to non-matching lines.
-# Keep only lines starting with a #.
+# !가 접두사로 붙은 명령은 일치하지 않는 줄에 적용됩니다.
+# #으로 시작하는 줄만 유지합니다.
 /^#/!d
 
-# Below are examples of the most often-used commands.
+# 다음은 가장 자주 사용되는 명령의 예입니다.
 
-# Substitute the first occurence in a line of John with Mary.
+# 한 줄에서 John의 첫 번째 항목을 Mary로 바꿉니다.
 s/John/Mary/
 
-# Remove all underscore characters (global substitution).
+# 모든 밑줄 문자를 제거합니다(전역 대체).
 s/_//g
 
-# Remove all HTML tags.
+# 모든 HTML 태그를 제거합니다.
 s/<[^>]*>//g
 
-# In the replacement string & is the regular expression matched.
+# 대체 문자열에서 &는 일치하는 정규식입니다.
 
-# Put each line inside double quotes.
+# 각 줄을 큰따옴표 안에 넣습니다.
 s/.*/"&"/
 
-# In the matched regular expression \(pattern\) is used to store
-# a pattern into a buffer.
-# In the replacement string \1 refers to the first pattern, \2 to the second
-# and so on. \u converts the following character to uppercase \l to lowercase.
+# 일치하는 정규식에서 \(패턴\)은 패턴을 버퍼에 저장하는 데 사용됩니다.
+# 대체 문자열에서 \1은 첫 번째 패턴을, \2는 두 번째 패턴을 나타냅니다. \u는 다음 문자를 대문자로, \l은 소문자로 변환합니다.
 
-# Convert snake_case_identifiers into camelCaseIdentifiers.
+# snake_case_identifiers를 camelCaseIdentifiers로 변환합니다.
 s/_\(.\)/\u\1/g
 
 
-# The p (print) command is typically used together with the -n
-# command-line option, which disables the print by default functionality.
-# Output all lines between ``` and ```.
+# p(인쇄) 명령은 일반적으로 기본적으로 인쇄 기능을 비활성화하는 -n 명령줄 옵션과 함께 사용됩니다.
+# ```와 ``` 사이의 모든 줄을 출력합니다.
 /```/,/```/p
 
 
-# The y command maps characters from one set to another.
-# Swap decimal and thousand separators (1,234,343.55 becomes 1.234.343,55).
+# y 명령은 한 세트의 문자를 다른 세트에 매핑합니다.
+# 소수점 및 천 단위 구분 기호를 바꿉니다(1,234,343.55는 1.234.343,55가 됨).
 y/.,/,./
 
-# Quit after printing the line starting with END.
+# END로 시작하는 줄을 인쇄한 후 종료합니다.
 /^END/q
 
-# You can stop reading here, and still get 80% of sed's benefits.
-# Below are examples of how you can specify multiple sed commands.
+# 여기서 읽기를 중단해도 sed의 이점 중 80%를 얻을 수 있습니다.
+# 다음은 여러 sed 명령을 지정하는 방법에 대한 예입니다.
 
-# You can apply multiple commands by separating them with a newline or
-# a semicolon.
+# 줄 바꿈이나 세미콜론으로 구분하여 여러 명령을 적용할 수 있습니다.
 
-# Delete the first and the last line.
+# 첫 번째 줄과 마지막 줄을 삭제합니다.
 1d
 $d
 
-# Delete the first and the last line.
+# 첫 번째 줄과 마지막 줄을 삭제합니다.
 1d;$d
 
 
-# You can group commands in { } blocks.
+# { } 블록으로 명령을 그룹화할 수 있습니다.
 
-# Convert first line to uppercase and print it.
+# 첫 번째 줄을 대문자로 변환하고 인쇄합니다.
 1 {
   s/./\u&/g
   p
 }
 
-# Convert first line to uppercase and print it (less readable one-liner).
+# 첫 번째 줄을 대문자로 변환하고 인쇄합니다(가독성이 낮은 한 줄짜리).
 1{s/./\u&/g;p;}
 
 
-# You can also stop reading here, if you're not interested in creating
-# sed script files.
+# sed 스크립트 파일을 만드는 데 관심이 없다면 여기서 읽기를 중단해도 됩니다.
 
-# Below are more advanced commands.  You typically put these in a file
-# rather than specify them on a command line.  If you have to use
-# many of these commands in a script, consider using a general purpose
-# scripting language, such as Python or Perl.
+# 다음은 더 고급 명령입니다. 일반적으로 명령줄에서 지정하는 대신 파일에 넣습니다. 스크립트에서 이러한 명령을 많이 사용해야 하는 경우 Python 또는 Perl과 같은 범용 스크립팅 언어를 사용하는 것을 고려하십시오.
 
-# Append a line containing "profile();" after each line ending with ";".
+# ";"로 끝나는 각 줄 뒤에 "profile();"이 포함된 줄을 추가합니다.
 /;$/a\
 profile();
 
-# Insert a line containing "profile();" before each line ending with ";".
+# ";"로 끝나는 각 줄 앞에 "profile();"이 포함된 줄을 삽입합니다.
 /;$/i\
 profile();
 
-# Change each line text inside REDACTED blocks into [REDACTED].
+# REDACTED 블록 안의 각 줄 텍스트를 [REDACTED]로 변경합니다.
 /REDACTED-BEGIN/,/REDACTED-END/c\
 [REDACTED]
 
-# Replace the tag "<ourstyle>" by reading and outputting the file style.css.
+# style.css 파일을 읽고 출력하여 "<ourstyle>" 태그를 바꿉니다.
 /<ourstyle>/ {
   r style.css
   d
 }
 
-# Change each line inside REDACTED blocks into [REDACTED].
-# Also write (append) a copy of the redacted text in the file redacted.txt.
+# REDACTED 블록 안의 각 줄을 [REDACTED]로 변경합니다.
+# 또한 수정된 텍스트의 복사본을 redacted.txt 파일에 씁니다(추가).
 /REDACTED-BEGIN/,/REDACTED-END/ {
   w redacted.txt
   c\
   [REDACTED]
 }
 
-# All operations described so far operate on a buffer called "pattern space".
-# In addition, sed offers another buffer called "hold space".
-# The following commands operate on the two, and can be used to keep
-# state or combine multiple lines.
+# 지금까지 설명한 모든 작업은 "패턴 공간"이라는 버퍼에서 작동합니다.
+# 또한 sed는 "홀드 공간"이라는 또 다른 버퍼를 제공합니다.
+# 다음 명령은 두 버퍼에서 작동하며 상태를 유지하거나 여러 줄을 결합하는 데 사용할 수 있습니다.
 
-# Replace the contents of the pattern space with the contents of
-# the hold space.
+# 패턴 공간의 내용을 홀드 공간의 내용으로 바꿉니다.
 g
 
-# Append a newline character followed by the contents of the hold
-# space to the pattern space.
+# 줄 바꿈 문자와 홀드 공간의 내용을 패턴 공간에 추가합니다.
 G
 
-# Replace the contents of the hold space with the contents of the
-# pattern space.
+# 홀드 공간의 내용을 패턴 공간의 내용으로 바꿉니다.
 h
 
-# Append a newline character followed by the contents of the
-# pattern space to the hold space.
+# 줄 바꿈 문자와 패턴 공간의 내용을 홀드 공간에 추가합니다.
 H
 
-# Delete the initial segment of the pattern space through the first
-# newline character and start the next cycle.
+# 첫 번째 줄 바꿈 문자까지 패턴 공간의 초기 세그먼트를 삭제하고 다음 주기를 시작합니다.
 D
 
-# Replace the contents of the pattern space with the contents of
-# the hold space.
+# 패턴 공간의 내용을 홀드 공간의 내용으로 바꿉니다.
 g
 
-# Append a newline character followed by the contents of the hold
-# space to the pattern space.
+# 줄 바꿈 문자와 홀드 공간의 내용을 패턴 공간에 추가합니다.
 G
 
-# Replace the contents of the hold space with the contents of the
-# pattern space.
+# 홀드 공간의 내용을 패턴 공간의 내용으로 바꿉니다.
 h
 
-# Append a newline character followed by the contents of the
-# pattern space to the hold space.
+# 줄 바꿈 문자와 패턴 공간의 내용을 홀드 공간에 추가합니다.
 H
 
-# Write the pattern space to the standard output if the default
-# output has not been suppressed, and replace the pattern space
-# with the next line of input.
+# 기본 출력이 표시되지 않은 경우 패턴 공간을 표준 출력에 쓰고 패턴 공간을 다음 입력 줄로 바꿉니다.
 n
 
-# Append the next line of input to the pattern space, using an
-# embedded newline character to separate the appended material from
-# the original contents.  Note that the current line number
-# changes.
+# 추가된 자료를 원래 내용과 구분하기 위해 포함된 줄 바꿈 문자를 사용하여 다음 입력 줄을 패턴 공간에 추가합니다. 현재 줄 번호가 변경됩니다.
 N
 
-# Write the pattern space, up to the first newline character to the
-# standard output.
+# 첫 번째 줄 바꿈 문자까지 패턴 공간을 표준 출력에 씁니다.
 P
 
-# Swap the contents of the pattern and hold spaces.
+# 패턴과 홀드 공간의 내용을 바꿉니다.
 x
 
-# Here is a complete example of some of the buffer commands.
-# Move the file's first line to its end.
+# 다음은 일부 버퍼 명령의 전체 예입니다.
+# 파일의 첫 번째 줄을 끝으로 이동합니다.
 1 {
   h
   d
@@ -239,49 +202,47 @@ $ {
 }
 
 
-# Three sed commands influence a script's control flow
+# 세 가지 sed 명령이 스크립트의 제어 흐름에 영향을 미칩니다.
 
-# Name this script position "my_label", to which the "b" and
-# "t" commands may branch.
+# 이 스크립트 위치를 "my_label"로 지정하면 "b" 및 "t" 명령이 분기할 수 있습니다.
 :my_label
 
-# Continue executing commands from the position of my_label.
+# my_label 위치에서 명령 실행을 계속합니다.
 b my_label
 
-# Branch to the end of the script.
+# 스크립트 끝으로 분기합니다.
 b
 
-# Branch to my_label if any substitutions have been made since the most
-# recent reading of an input line or execution of a "t" (test) function.
+# 가장 최근에 입력 줄을 읽거나 "t"(테스트) 함수를 실행한 이후에 대체가 이루어진 경우 my_label로 분기합니다.
 t my_label
 
-# Here is a complete example of branching:
-# Join lines that end with a backslash into a single space-separated one.
+# 다음은 분기의 전체 예입니다.
+# 백슬래시로 끝나는 줄을 공백으로 구분된 단일 줄로 결합합니다.
 
-# Name this position "loop"
+# 이 위치를 "loop"로 지정합니다.
 : loop
-# On lines ending with a backslash
+# 백슬래시로 끝나는 줄에서
 /\\$/ {
-  # Read the next line and append it to the pattern space
+  # 다음 줄을 읽고 패턴 공간에 추가합니다.
   N
-  # Substitute backslash newline with a space
+  # 백슬래시 줄 바꿈을 공백으로 바꿉니다.
   s/\\\n/ /
-  # Branch to the top for testing this line's ending
+  # 이 줄의 끝을 테스트하기 위해 맨 위로 분기합니다.
   b loop
 }
 ```
 
-Further Reading:
+더 읽을거리:
 
 * [The Open Group: sed - stream editor](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sed.html)
-  The POSIX standard regarding sed.
-  Follow this for maximum portability.
+  sed에 대한 POSIX 표준입니다.
+  최대 이식성을 위해 이를 따르십시오.
 * [FreeBSD sed -- stream editor](https://www.freebsd.org/cgi/man.cgi?query=sed&sektion=&n=1)
-  The BSD manual page.
-  This version of sed runs on BSD systems and macOS.
+  BSD 매뉴얼 페이지입니다.
+  이 버전의 sed는 BSD 시스템과 macOS에서 실행됩니다.
 * [Project GNU: sed, a stream editor](https://www.gnu.org/software/sed/manual/sed.html)
-  The GNU manual page. GNU sed is found on most Linux systems.
+  GNU 매뉴얼 페이지입니다. GNU sed는 대부분의 Linux 시스템에서 찾을 수 있습니다.
 * [Lee E. McMahon: SED -- A Non-interactive Text Editor](https://wolfram.schneider.org/bsd/7thEdManVol2/sed/sed.pdf)
-  The original sed documentation
+  원본 sed 문서
 * [A collection of sed resources](http://sed.sourceforge.net/)
 * [The sed FAQ](http://sed.sourceforge.net/sedfaq.html)

--- a/ko/self.md
+++ b/ko/self.md
@@ -7,52 +7,46 @@ contributors:
 filename: learnself.self
 ---
 
-Self is a fast prototype based OO language which runs in its own JIT vm. Most development is done through interacting with live objects through a visual development environment called *morphic* with integrated browsers and debugger.
+Self는 자체 JIT VM에서 실행되는 빠른 프로토타입 기반 객체 지향 언어입니다. 대부분의 개발은 통합된 브라우저와 디버거가 있는 *morphic*이라는 시각적 개발 환경을 통해 라이브 객체와 상호 작용하여 수행됩니다.
 
-Everything in Self is an object. All computation is done by sending messages to objects. Objects in Self can be understood as sets of key-value slots.
+Self의 모든 것은 객체입니다. 모든 계산은 객체에 메시지를 보내는 것으로 수행됩니다. Self의 객체는 키-값 슬롯의 집합으로 이해할 수 있습니다.
 
-# Constructing objects
+# 객체 생성
 
-The inbuild Self parser can construct objects, including method objects.
+내장된 Self 파서는 메서드 객체를 포함한 객체를 생성할 수 있습니다.
 
 ```
-"This is a comment"
+"이것은 주석입니다"
 
-"A string:"
-'This is a string with \'escaped\' characters.\n'
+"문자열:"
+'이스케이프 문자가 있는 문자열입니다.\n'
 
-"A 30 bit integer"
+"30비트 정수"
 23
 
-"A 30 bit float"
+"30비트 부동 소수점"
 3.2
 
 "-20"
 -14r16
 
-"An object which only understands one message, 'x' which returns 20"
+"하나의 메시지 'x'만 이해하고 20을 반환하는 객체"
 (|
   x = 20.
 |)
 
-"An object which also understands 'x:' which sets the x slot"
+"x 슬롯을 설정하는 'x:'도 이해하는 객체"
 (|
   x <- 20.
 |)
 
-"An object which understands the method 'doubleX' which
-doubles the value of x and then returns the object"
+"x의 값을 두 배로 늘린 다음 객체를 반환하는 'doubleX' 메서드를 이해하는 객체"
 (|
   x <- 20.
   doubleX = (x: x * 2. self)
 |)
 
-"An object which understands all the messages
-that 'traits point' understands". The parser
-looks up 'traits point' by sending the messages
-'traits' then 'point' to a known object called
-the 'lobby'. It looks up the 'true' object by
-also sending the message 'true' to the lobby."
+"'traits point'가 이해하는 모든 메시지를 이해하는 객체". 파서는 'lobby'라는 알려진 객체에 'traits' 다음 'point' 메시지를 보내 'traits point'를 찾습니다. 또한 로비에 'true' 메시지를 보내 'true' 객체를 찾습니다."
 (|     parent* = traits point.
        x = 7.
        y <- 5.
@@ -60,35 +54,33 @@ also sending the message 'true' to the lobby."
 |)
 ```
 
-# Sending messages to objects
+# 객체에 메시지 보내기
 
-Messages can either be unary, binary or keyword. Precedence is in that order. Unlike Smalltalk, the precedence of binary messages must be specified, and all keywords after the first must start with a capital letter. Messages are separated from their destination by whitespace.
+메시지는 단항, 이항 또는 키워드일 수 있습니다. 우선순위는 그 순서대로입니다. Smalltalk와 달리 이항 메시지의 우선순위는 지정해야 하며, 첫 번째 키워드 다음의 모든 키워드는 대문자로 시작해야 합니다. 메시지는 공백으로 대상과 구분됩니다.
 
 ```
-"unary message, sends 'printLine' to the object '23'
-which prints the string '23' to stdout and returns the receiving object (ie 23)"
+"단항 메시지, '23' 객체에 'printLine'을 보내 stdout에 '23' 문자열을 출력하고 수신 객체(즉, 23)를 반환합니다"
 23 printLine
 
-"sends the message '+' with '7' to '23', then the message '*' with '8' to the result"
+"'23'에 '7'과 함께 '+' 메시지를 보낸 다음 결과에 '8'과 함께 '*' 메시지를 보냅니다"
 (23 + 7) * 8
 
-"sends 'power:' to '2' with '8' returns 256"
+"'2'에 '8'과 함께 'power:'를 보내 256을 반환합니다"
 2 power: 8
 
-"sends 'keyOf:IfAbsent:' to 'hello' with arguments 'e' and '-1'.
-Returns 1, the index of 'e' in 'hello'."
+"'hello'에 인수 'e'와 '-1'을 사용하여 'keyOf:IfAbsent:'를 보냅니다. 'hello'에서 'e'의 인덱스인 1을 반환합니다."
 'hello' keyOf: 'e' IfAbsent: -1
 ```
 
-# Blocks
+# 블록
 
-Self defines flow control like Smalltalk and Ruby by way of blocks. Blocks are delayed computations of the form:
+Self는 Smalltalk 및 Ruby와 같이 블록을 통해 제어 흐름을 정의합니다. 블록은 다음과 같은 형식의 지연된 계산입니다:
 
 ```
 [|:x. localVar| x doSomething with: localVar]
 ```
 
-Examples of the use of a block:
+블록 사용 예:
 
 ```
 "returns 'HELLO'"
@@ -103,7 +95,7 @@ Examples of the use of a block:
             False: ['a']]
 ```
 
-Multiple expressions are separated by a period. ^ returns immediately.
+여러 표현식은 마침표로 구분됩니다. ^는 즉시 반환됩니다.
 
 ```
 "returns An 'E'! How icky!"
@@ -114,27 +106,24 @@ Multiple expressions are separated by a period. ^ returns immediately.
    ]
 ```
 
-Blocks are performed by sending them the message 'value' and inherit (delegate to) their contexts:
+블록은 'value' 메시지를 보내 수행되며 컨텍스트를 상속(위임)합니다:
 
 ```
 "returns 0"
 [|x|
     x: 15.
-    "Repeatedly sends 'value' to the first block while the result of sending 'value' to the
-     second block is the 'true' object"
+    "두 번째 블록에 'value'를 보낸 결과가 'true' 객체인 동안 첫 번째 블록에 'value'를 반복적으로 보냅니다"
     [x > 0] whileTrue: [x: x - 1].
     x
 ] value
 ```
 
-# Methods
+# 메서드
 
-Methods are like blocks but they are not within a context but instead are stored as values of slots. Unlike Smalltalk, methods by default return their final value not 'self'.
+메서드는 블록과 같지만 컨텍스트 내에 있지 않고 대신 슬롯의 값으로 저장됩니다. Smalltalk와 달리 메서드는 기본적으로 'self'가 아닌 최종 값을 반환합니다.
 
 ```
-"Here is an object with one assignable slot 'x' and a method 'reduceXTo: y'.
-Sending the message 'reduceXTo: 10' to this object will put
-the object '10' in the 'x' slot and return the original object"
+"여기 할당 가능한 슬롯 'x'와 메서드 'reduceXTo: y'가 있는 객체가 있습니다. 이 객체에 'reduceXTo: 10' 메시지를 보내면 'x' 슬롯에 '10' 객체를 넣고 원래 객체를 반환합니다"
 (|
     x <- 50.
     reduceXTo: y = (
@@ -144,9 +133,9 @@ the object '10' in the 'x' slot and return the original object"
 .
 ```
 
-# Prototypes
+# 프로토타입
 
-Self has no classes. The way to get an object is to find a prototype and copy it.
+Self에는 클래스가 없습니다. 객체를 얻는 방법은 프로토타입을 찾아 복사하는 것입니다.
 
 ```
 | d |
@@ -159,6 +148,6 @@ d at: 'goodbye' Put: 'No!.
 ( d at: 'hello' IfAbsent: -1 ) printLine.
 ```
 
-# Further information
+# 추가 정보
 
-The [Self handbook](http://handbook.selflanguage.org) has much more information, and nothing beats hand-on experience with Self by downloading it from the [homepage](http://www.selflanguage.org).
+[Self 핸드북](http://handbook.selflanguage.org)에는 훨씬 더 많은 정보가 있으며, [홈페이지](http://www.selflanguage.org)에서 Self를 다운로드하여 직접 경험하는 것보다 더 좋은 것은 없습니다.

--- a/ko/smalltalk.md
+++ b/ko/smalltalk.md
@@ -8,311 +8,311 @@ contributors:
     - ["tim Rowledge", "tim@rowledge.org"]
 ---
 
-- Smalltalk is a fully object-oriented, dynamically typed, reflective programming language with no 'non-object' types.
-- Smalltalk was created as the language to underpin the "new world" of computing exemplified by "human–computer symbiosis."
-- It was designed and created in part for educational use, more so for constructionist learning, at the Learning Research Group (LRG) of Xerox PARC by Alan Kay, Dan Ingalls, Adele Goldberg, Ted Kaehler, Scott Wallace, and others during the 1970s.
+- Smalltalk는 '비객체' 타입이 없는 완전한 객체 지향, 동적 타입, 반사적 프로그래밍 언어입니다.
+- Smalltalk는 "인간-컴퓨터 공생"으로 대표되는 "새로운 컴퓨팅 세계"를 뒷받침하는 언어로 만들어졌습니다.
+- 1970년대 Xerox PARC의 학습 연구 그룹(LRG)에서 Alan Kay, Dan Ingalls, Adele Goldberg, Ted Kaehler, Scott Wallace 등이 교육용, 특히 구성주의 학습을 위해 부분적으로 설계하고 만들었습니다.
 
-## The Basics
+## 기본
 
-### Everything is an object
-Yes, everything. Integers are instances of one of the numeric classes. Classes are instances of the class Metaclass and are just as manipulable as any other object. All classes are part of a single class tree; no disjoint class trees. Stack frames are objects and can be manipulated, which is how the debugger works. There are no pointers into memory locations that you can dereference and mess with.
+### 모든 것은 객체입니다
+네, 모든 것입니다. 정수는 숫자 클래스 중 하나의 인스턴스입니다. 클래스는 Metaclass 클래스의 인스턴스이며 다른 객체와 마찬가지로 조작할 수 있습니다. 모든 클래스는 단일 클래스 트리의 일부이며, 분리된 클래스 트리는 없습니다. 스택 프레임은 객체이며 조작할 수 있으며, 이것이 디버거가 작동하는 방식입니다. 역참조하여 조작할 수 있는 메모리 위치에 대한 포인터는 없습니다.
 
-### Functions are not called; messages are sent to objects
-- Work is done by sending messages to objects, which decide how to respond to that message and run a method as a result, which eventually returns some object to the original message sending code.
-- The system knows the class of the object receiving a message and looks up the message in that class's list of methods. If it is not found, the lookup continues in the super class until either it is found or the root of the classes is reached and there is still no relevant method.
-- If a suitable method is found the code is run, and the same process keeps on going with all the methods sent by that method and so on forever.
-- If no suitable method is found an exception is raised, which typically results in a user interface notifier to tell the user that the message was not understood. It is entirely possible to catch the exception and do something to fix the problem, which might range from 'ignore it' to 'load some new packages for this class and try again'.
-- A method (more strictly an instance of the class CompiledMethod) is a chunk of Smalltalk code that has been compiled into bytecodes. Executing methods start at the beginning and return to the sender when a return is encountered (we use ^ to signify 'return the following object') or the end of the code is reached, in which case the current object running the code is returned.
+### 함수는 호출되지 않고, 메시지가 객체로 전송됩니다
+- 작업은 객체에 메시지를 보내는 것으로 수행되며, 객체는 해당 메시지에 응답하는 방법을 결정하고 그 결과로 메서드를 실행하며, 결국 원래 메시지를 보낸 코드로 일부 객체를 반환합니다.
+- 시스템은 메시지를 수신하는 객체의 클래스를 알고 해당 클래스의 메서드 목록에서 메시지를 찾습니다. 찾지 못하면 상위 클래스에서 조회를 계속하며, 찾거나 클래스의 루트에 도달하고 여전히 관련 메서드가 없을 때까지 계속됩니다.
+- 적절한 메서드를 찾으면 코드가 실행되고, 해당 메서드가 보낸 모든 메서드와 함께 동일한 프로세스가 계속됩니다.
+- 적절한 메서드를 찾지 못하면 예외가 발생하며, 일반적으로 사용자에게 메시지를 이해할 수 없다는 것을 알리는 사용자 인터페이스 알림이 표시됩니다. 예외를 잡아 문제를 해결하기 위해 '무시'에서 '이 클래스에 대한 새 패키지를 로드하고 다시 시도'에 이르기까지 무언가를 수행하는 것이 전적으로 가능합니다.
+- 메서드(더 엄격하게는 CompiledMethod 클래스의 인스턴스)는 바이트코드로 컴파일된 Smalltalk 코드 덩어리입니다. 실행 메서드는 처음부터 시작하여 반환이 발생하면(다음에 오는 객체를 반환하기 위해 ^를 사용함) 또는 코드 끝에 도달하면 보낸 사람에게 반환되며, 이 경우 코드를 실행하는 현재 객체가 반환됩니다.
 
-### Simple syntax
-Smalltalk has a simple syntax with very few rules.
-The most basic operation is to send a message to an object
+### 간단한 구문
+Smalltalk는 규칙이 거의 없는 간단한 구문을 가지고 있습니다.
+가장 기본적인 작업은 객체에 메시지를 보내는 것입니다.
 `anObject aMessage`
 
-There are three sorts of messages
+세 가지 종류의 메시지가 있습니다.
 
-- unary - a single symbol that may be several words conjoined in what we call camelcase form, with no arguments. For example 'size', 'reverseBytes', 'convertToLargerFormatPixels'
-- binary - a small set of symbols of the sort often used for arithmetic operations in most languages, requiring a single argument. For example '+', '//', '@'. We do not use traditional arithmetic precedence, something to keep an eye on.
-- keyword - the general form where multiple arguments can be passed. As with the unary form we use camelcase to join words together but arguments are inserted in the midst of the message with colons used to separate them lexically. For example 'setTemperature:', 'at:put:', 'drawFrom:to:lineWidth:fillColor:'
+- 단항 - 인수가 없는 카멜케이스 형식으로 여러 단어가 결합된 단일 기호입니다. 예를 들어 'size', 'reverseBytes', 'convertToLargerFormatPixels'
+- 이항 - 대부분의 언어에서 산술 연산에 자주 사용되는 작은 기호 집합으로, 단일 인수가 필요합니다. 예를 들어 '+', '//', '@'. 전통적인 산술 우선순위를 사용하지 않으므로 주의해야 합니다.
+- 키워드 - 여러 인수를 전달할 수 있는 일반적인 형식입니다. 단항 형식과 마찬가지로 카멜케이스를 사용하여 단어를 결합하지만 인수는 콜론을 사용하여 어휘적으로 구분하여 메시지 중간에 삽입됩니다. 예를 들어 'setTemperature:', 'at:put:', 'drawFrom:to:lineWidth:fillColor:'
 
-#### An example
+#### 예시
 `result := myObject doSomethingWith: thatObject`
-We are sending the message 'doSomethingWith:' to myObject. This happens to be a message that has a single argument but that's not important yet.
-'myObject' is a 'MyExampleClass' instance so the system looks at the list of messages understood by MyExampleClass
+myObject에 'doSomethingWith:' 메시지를 보냅니다. 이것은 단일 인수가 있는 메시지이지만 아직 중요하지 않습니다.
+'myObject'는 'MyExampleClass' 인스턴스이므로 시스템은 MyExampleClass가 이해하는 메시지 목록을 살펴봅니다.
 
 - beClever
 - doWeirdThing:
 - doSomethingWith
 
-In searching we see what initially looks like a match - but no, it lacks the final colon. So we find the super class of MyExampleClass - BigExampleClass. Which has a list of known messages of its own
+검색에서 처음에는 일치하는 것처럼 보이지만 - 아니요, 마지막 콜론이 없습니다. 그래서 MyExampleClass의 상위 클래스인 BigExampleClass를 찾습니다. 여기에는 자체적으로 알려진 메시지 목록이 있습니다.
 
 - beClever
 - doSomethingWith:
 - buildCastleInAir
 - annoyUserByDoing:
 
-We find a proper exact match and start to execute the code:
+정확히 일치하는 것을 찾아 코드를 실행하기 시작합니다:
 
 ```smalltalk
 doSomethingWith: argumentObject
     self size > 4 ifTrue: [^argumentObject sizeRelatingTo: self].
 ```
 
-Everything here except the `^` involves sending more messages. Even the `ifTrue:` that you might think is a language control structure is just Smalltalk code.
+여기서 `^`를 제외한 모든 것은 더 많은 메시지를 보내는 것을 포함합니다. 언어 제어 구조라고 생각할 수 있는 `ifTrue:`조차도 Smalltalk 코드일 뿐입니다.
 
-We start by sending `size` to `self`. `self` is the object currently running the code - so in this case it is the myObject we started with. `size` is a very common message that we might anticipate tells us something about how big an object is; you could look it up with the Smalltalk tools very simply. The result we get is then sent the message `>` with the integer 4, which is an object too; no primitive types here. The `>` is a comparison that answers true or false. That boolean (which is actually a Boolean object in Smalltalk) is sent the message `ifTrue:` with the block of code between the `[]` as its argument; a true boolean is expected to run that block of code and a false to ignore it.
+`self`에 `size`를 보내는 것으로 시작합니다. `self`는 현재 코드를 실행하는 객체이므로 이 경우 우리가 시작한 myObject입니다. `size`는 객체의 크기에 대해 알려주는 매우 일반적인 메시지입니다. Smalltalk 도구를 사용하여 매우 간단하게 찾아볼 수 있습니다. 얻은 결과는 정수 4와 함께 `>` 메시지를 받으며, 이것도 객체입니다. 여기에는 기본 타입이 없습니다. `>`는 true 또는 false를 응답하는 비교입니다. 해당 부울(실제로 Smalltalk의 Boolean 객체임)은 `[]` 사이의 코드 블록을 인수로 사용하여 `ifTrue:` 메시지를 받습니다. true 부울은 해당 코드 블록을 실행하고 false는 무시할 것으로 예상됩니다.
 
-If the block is run then we do some more message sending to the argument object and noting the `^` we return the answer back to our starting point and it gets assigned to `result`. If the block is ignored we seem to run out of code and so `self` is returned and assigned to `result`.
+블록이 실행되면 인수 객체에 더 많은 메시지를 보내고 `^`를 기록하여 답을 시작 지점으로 반환하고 `result`에 할당됩니다. 블록이 무시되면 코드가 다 떨어져서 `self`가 반환되고 `result`에 할당됩니다.
 
-## Smalltalk quick reference cheat-sheet
-Taken from [Smalltalk Cheatsheet](http://www.angelfire.com/tx4/cus/notes/smalltalk.html)
+## Smalltalk 빠른 참조 치트 시트
+[Smalltalk 치트 시트](http://www.angelfire.com/tx4/cus/notes/smalltalk.html)에서 가져옴
 
-#### Allowable characters:
+#### 허용되는 문자:
 - a-z
 - A-Z
 - 0-9
 - .+/\*~<>@%|&?
-- blank, tab, cr, ff, lf
+- 공백, 탭, cr, ff, lf
 
-#### Variables:
-- variable names must be declared before use but are untyped
-- shared vars (globals, class vars) conventionally begin with uppercase (except the reserved names shown below)
-- local vars (instance vars, temporaries, method & block arguments) conventionally begin with lowercase
-- reserved names: `nil`, `true`, `false`, `self`, `super`, and `thisContext`
+#### 변수:
+- 변수 이름은 사용하기 전에 선언해야 하지만 타입이 지정되지 않았습니다.
+- 공유 변수(전역, 클래스 변수)는 관례적으로 대문자로 시작합니다(아래에 표시된 예약어 제외).
+- 지역 변수(인스턴스 변수, 임시 변수, 메서드 및 블록 인수)는 관례적으로 소문자로 시작합니다.
+- 예약어: `nil`, `true`, `false`, `self`, `super`, `thisContext`
 
-#### Variable scope:
-- Global: defined in a Dictionary named 'Smalltalk' and accessible by all objects in system
-- Special: (reserved) `Smalltalk`, `super`, `self`, `true`, `false`, & `nil`
-- Method Temporary: local to a method
-- Block Temporary: local to a block
-- Pool: variables in a Dictionary object, possibly shared with classes not directly related by inheritance
-- Method Parameters: automatic method temp vars that name the incoming parameters. Cannot be assigned to
-- Block Parameters: automatic block temp vars that name the incoming parameters. Cannot be assigned to
-- Class: shared with all instances of a class & its subclasses
-- Class Instance: unique to each instance of a class. Too commonly confused with class variables
-- Instance Variables: unique to each instance of a class
+#### 변수 범위:
+- 전역: 'Smalltalk'라는 Dictionary에 정의되어 있으며 시스템의 모든 객체에서 액세스할 수 있습니다.
+- 특수: (예약됨) `Smalltalk`, `super`, `self`, `true`, `false`, `nil`
+- 메서드 임시: 메서드에 로컬
+- 블록 임시: 블록에 로컬
+- 풀: Dictionary 객체의 변수로, 상속으로 직접 관련되지 않은 클래스와 공유될 수 있습니다.
+- 메서드 매개변수: 들어오는 매개변수의 이름을 지정하는 자동 메서드 임시 변수입니다. 할당할 수 없습니다.
+- 블록 매개변수: 들어오는 매개변수의 이름을 지정하는 자동 블록 임시 변수입니다. 할당할 수 없습니다.
+- 클래스: 클래스 및 하위 클래스의 모든 인스턴스와 공유됩니다.
+- 클래스 인스턴스: 클래스의 각 인스턴스에 고유합니다. 클래스 변수와 너무 흔하게 혼동됩니다.
+- 인스턴스 변수: 클래스의 각 인스턴스에 고유합니다.
 
-`"Comments are enclosed in quotes and may be arbitrary length"`
+`"주석은 따옴표로 묶이며 임의의 길이일 수 있습니다"`
 
-`"Period (.) is the statement separator. Not required on last line of a method"`
+`"마침표(.)는 문장 구분 기호입니다. 메서드의 마지막 줄에는 필요하지 않습니다"`
 
-#### Transcript:
+#### 트랜스크립트:
 ```smalltalk
-Transcript clear.                        "clear to transcript window"
-Transcript show: 'Hello World'.          "output string in transcript window"
-Transcript nextPutAll: 'Hello World'.    "output string in transcript window"
-Transcript nextPut: $A.                  "output character in transcript window"
-Transcript space.                        "output space character in transcript window"
-Transcript tab.                          "output tab character in transcript window"
-Transcript cr.                           "carriage return / linefeed"
-'Hello' printOn: Transcript.             "append print string into the window"
-'Hello' storeOn: Transcript.             "append store string into the window"
-Transcript endEntry.                     "flush the output buffer"
+Transcript clear.                        "트랜스크립트 창 지우기"
+Transcript show: 'Hello World'.          "트랜스크립트 창에 문자열 출력"
+Transcript nextPutAll: 'Hello World'.    "트랜스크립트 창에 문자열 출력"
+Transcript nextPut: $A.                  "트랜스크립트 창에 문자 출력"
+Transcript space.                        "트랜스크립트 창에 공백 문자 출력"
+Transcript tab.                          "트랜스크립트 창에 탭 문자 출력"
+Transcript cr.                           "캐리지 리턴 / 줄 바꿈"
+'Hello' printOn: Transcript.             "창에 인쇄 문자열 추가"
+'Hello' storeOn: Transcript.             "창에 저장 문자열 추가"
+Transcript endEntry.                     "출력 버퍼 플러시"
 ```
 
-#### Assignment:
+#### 할당:
 ```smalltalk
 | x y |
-x _ 4.                            "assignment (Squeak) <-"
-x := 5.                           "assignment"
-x := y := z := 6.                 "compound assignment"
+x _ 4.                            "할당 (Squeak) <-"
+x := 5.                           "할당"
+x := y := z := 6.                 "복합 할당"
 x := (y := 6) + 1.
-x := Object new.                  "bind to allocated instance of a class"
+x := Object new.                  "클래스의 할당된 인스턴스에 바인딩"
 ```
 
-#### Constants:
+#### 상수:
 ```smalltalk
 | b |
-b := true.                "true constant"
-b := false.               "false constant"
-x := nil.                 "nil object constant"
-x := 1.                   "integer constants"
-x := 3.14.                "float constants"
-x := 2e-2.                "fractional constants"
-x := 16r0F.               "hex constant".
-x := -1.                  "negative constants"
-x := 'Hello'.             "string constant"
-x := 'I''m here'.         "single quote escape"
-x := $A.                  "character constant"
-x := $ .                  "character constant (space)"
-x := #aSymbol.            "symbol constants"
-x := #(3 2 1).            "array constants"
-x := #('abc' 2 $a).       "mixing of types allowed"
+b := true.                "true 상수"
+b := false.               "false 상수"
+x := nil.                 "nil 객체 상수"
+x := 1.                   "정수 상수"
+x := 3.14.                "부동 소수점 상수"
+x := 2e-2.                "분수 상수"
+x := 16r0F.               "16진수 상수".
+x := -1.                  "음수 상수"
+x := 'Hello'.             "문자열 상수"
+x := 'I''m here'.         "작은따옴표 이스케이프"
+x := $A.                  "문자 상수"
+x := $ .                  "문자 상수 (공백)"
+x := #aSymbol.            "심볼 상수"
+x := #(3 2 1).            "배열 상수"
+x := #('abc' 2 $a).       "타입 혼합 허용"
 ```
 
-#### Booleans:
+#### 불리언:
 ```smalltalk
 | b x y |
 x := 1. y := 2.
-b := (x = y).                         "equals"
-b := (x ~= y).                         "not equals"
-b := (x == y).                         "identical"
-b := (x ~~ y).                         "not identical"
-b := (x > y).                          "greater than"
-b := (x < y).                          "less than"
-b := (x >= y).                         "greater than or equal"
-b := (x <= y).                         "less than or equal"
-b := b not.                            "boolean not"
-b := (x < 5) & (y > 1).                "boolean and"
-b := (x < 5) | (y > 1).                "boolean or"
-b := (x < 5) and: [y > 1].             "boolean and (short-circuit)"
-b := (x < 5) or: [y > 1].              "boolean or (short-circuit)"
-b := (x < 5) eqv: (y > 1).             "test if both true or both false"
-b := (x < 5) xor: (y > 1).             "test if one true and other false"
-b := 5 between: 3 and: 12.             "between (inclusive)"
-b := 123 isKindOf: Number.             "test if object is class or subclass of"
-b := 123 isMemberOf: SmallInteger.     "test if object is type of class"
-b := 123 respondsTo: #sqrt.             "test if object responds to message"
-b := x isNil.                          "test if object is nil"
-b := x isZero.                         "test if number is zero"
-b := x positive.                       "test if number is positive"
-b := x strictlyPositive.               "test if number is greater than zero"
-b := x negative.                       "test if number is negative"
-b := x even.                           "test if number is even"
-b := x odd.                            "test if number is odd"
-b := x isLiteral.                      "test if literal constant"
-b := x isInteger.                      "test if object is integer"
-b := x isFloat.                        "test if object is float"
-b := x isNumber.                       "test if object is number"
-b := $A isUppercase.                   "test if upper case character"
-b := $A isLowercase.                   "test if lower case character"
+b := (x = y).                         "같음"
+b := (x ~= y).                         "같지 않음"
+b := (x == y).                         "동일함"
+b := (x ~~ y).                         "동일하지 않음"
+b := (x > y).                          "보다 큼"
+b := (x < y).                          "보다 작음"
+b := (x >= y).                         "크거나 같음"
+b := (x <= y).                         "작거나 같음"
+b := b not.                            "불리언 부정"
+b := (x < 5) & (y > 1).                "불리언 and"
+b := (x < 5) | (y > 1).                "불리언 or"
+b := (x < 5) and: [y > 1].             "불리언 and (단락 회로)"
+b := (x < 5) or: [y > 1].              "불리언 or (단락 회로)"
+b := (x < 5) eqv: (y > 1).             "둘 다 참이거나 둘 다 거짓인지 테스트"
+b := (x < 5) xor: (y > 1).             "하나가 참이고 다른 하나가 거짓인지 테스트"
+b := 5 between: 3 and: 12.             "사이 (포함)"
+b := 123 isKindOf: Number.             "객체가 클래스 또는 하위 클래스인지 테스트"
+b := 123 isMemberOf: SmallInteger.     "객체가 클래스 타입인지 테스트"
+b := 123 respondsTo: #sqrt.             "객체가 메시지에 응답하는지 테스트"
+b := x isNil.                          "객체가 nil인지 테스트"
+b := x isZero.                         "숫자가 0인지 테스트"
+b := x positive.                       "숫자가 양수인지 테스트"
+b := x strictlyPositive.               "숫자가 0보다 큰지 테스트"
+b := x negative.                       "숫자가 음수인지 테스트"
+b := x even.                           "숫자가 짝수인지 테스트"
+b := x odd.                            "숫자가 홀수인지 테스트"
+b := x isLiteral.                      "리터럴 상수인지 테스트"
+b := x isInteger.                      "객체가 정수인지 테스트"
+b := x isFloat.                        "객체가 부동 소수점인지 테스트"
+b := x isNumber.                       "객체가 숫자인지 테스트"
+b := $A isUppercase.                   "대문자인지 테스트"
+b := $A isLowercase.                   "소문자인지 테스트"
 ```
 
-#### Arithmetic expressions:
+#### 산술 표현식:
 ```smalltalk
 | x |
-x := 6 + 3.                             "addition"
-x := 6 - 3.                             "subtraction"
-x := 6 * 3.                             "multiplication"
-x := 1 + 2 * 3.                         "evaluation always left to right (1 + 2) * 3"
-x := 5 / 3.                             "division with fractional result"
-x := 5.0 / 3.0.                         "division with float result"
-x := 5.0 // 3.0.                        "integer divide"
-x := 5.0 \\ 3.0.                        "integer remainder"
-x := -5.                                "unary minus"
-x := 5 sign.                            "numeric sign (1, -1 or 0)"
-x := 5 negated.                         "negate receiver"
-x := 1.2 integerPart.                   "integer part of number (1.0)"
-x := 1.2 fractionPart.                  "fractional part of number (0.2)"
-x := 5 reciprocal.                      "reciprocal function"
-x := 6 * 3.1.                           "auto convert to float"
-x := 5 squared.                         "square function"
-x := 25 sqrt.                           "square root"
-x := 5 raisedTo: 2.                     "power function"
-x := 5 raisedToInteger: 2.              "power function with integer"
-x := 5 exp.                             "exponential"
-x := -5 abs.                            "absolute value"
-x := 3.99 rounded.                      "round"
-x := 3.99 truncated.                    "truncate"
-x := 3.99 roundTo: 1.                   "round to specified decimal places"
-x := 3.99 truncateTo: 1.                "truncate to specified decimal places"
-x := 3.99 floor.                        "truncate"
-x := 3.99 ceiling.                      "round up"
-x := 5 factorial.                       "factorial"
-x := -5 quo: 3.                         "integer divide rounded toward zero"
-x := -5 rem: 3.                         "integer remainder rounded toward zero"
-x := 28 gcd: 12.                        "greatest common denominator"
-x := 28 lcm: 12.                        "least common multiple"
-x := 100 ln.                            "natural logarithm"
-x := 100 log.                           "base 10 logarithm"
-x := 100 log: 10.                       "floor of the log"
-x := 180 degreesToRadians.              "convert degrees to radians"
-x := 3.14 radiansToDegrees.             "convert radians to degrees"
-x := 0.7 sin.                           "sine"
-x := 0.7 cos.                           "cosine"
-x := 0.7 tan.                           "tangent"
-x := 0.7 arcSin.                        "arcsine"
-x := 0.7 arcCos.                        "arccosine"
-x := 0.7 arcTan.                        "arctangent"
-x := 10 max: 20.                        "get maximum of two numbers"
-x := 10 min: 20.                        "get minimum of two numbers"
-x := Float pi.                          "pi"
-x := Float e.                           "exp constant"
-x := Float infinity.                    "infinity"
-x := Float nan.                         "not-a-number"
-x := Random new next; yourself. x next. "random number stream (0.0 to 1.0)"
-x := 100 atRandom.                      "quick random number"
+x := 6 + 3.                             "덧셈"
+x := 6 - 3.                             "뺄셈"
+x := 6 * 3.                             "곱셈"
+x := 1 + 2 * 3.                         "평가는 항상 왼쪽에서 오른쪽으로 (1 + 2) * 3"
+x := 5 / 3.                             "분수 결과가 있는 나눗셈"
+x := 5.0 / 3.0.                         "부동 소수점 결과가 있는 나눗셈"
+x := 5.0 // 3.0.                        "정수 나눗셈"
+x := 5.0 \\ 3.0.                        "정수 나머지"
+x := -5.                                "단항 빼기"
+x := 5 sign.                            "숫자 부호 (1, -1 또는 0)"
+x := 5 negated.                         "수신자 부정"
+x := 1.2 integerPart.                   "숫자의 정수 부분 (1.0)"
+x := 1.2 fractionPart.                  "숫자의 분수 부분 (0.2)"
+x := 5 reciprocal.                      "역수 함수"
+x := 6 * 3.1.                           "부동 소수점으로 자동 변환"
+x := 5 squared.                         "제곱 함수"
+x := 25 sqrt.                           "제곱근"
+x := 5 raisedTo: 2.                     "거듭제곱 함수"
+x := 5 raisedToInteger: 2.              "정수 거듭제곱 함수"
+x := 5 exp.                             "지수"
+x := -5 abs.                            "절대값"
+x := 3.99 rounded.                      "반올림"
+x := 3.99 truncated.                    "버림"
+x := 3.99 roundTo: 1.                   "지정된 소수 자릿수로 반올림"
+x := 3.99 truncateTo: 1.                "지정된 소수 자릿수로 버림"
+x := 3.99 floor.                        "버림"
+x := 3.99 ceiling.                      "올림"
+x := 5 factorial.                       "팩토리얼"
+x := -5 quo: 3.                         "0을 향해 반올림하는 정수 나눗셈"
+x := -5 rem: 3.                         "0을 향해 반올림하는 정수 나머지"
+x := 28 gcd: 12.                        "최대공약수"
+x := 28 lcm: 12.                        "최소공배수"
+x := 100 ln.                            "자연 로그"
+x := 100 log.                           "밑이 10인 로그"
+x := 100 log: 10.                       "로그의 바닥"
+x := 180 degreesToRadians.              "도를 라디안으로 변환"
+x := 3.14 radiansToDegrees.             "라디안을 도로 변환"
+x := 0.7 sin.                           "사인"
+x := 0.7 cos.                           "코사인"
+x := 0.7 tan.                           "탄젠트"
+x := 0.7 arcSin.                        "아크사인"
+x := 0.7 arcCos.                        "아크코사인"
+x := 0.7 arcTan.                        "아크탄젠트"
+x := 10 max: 20.                        "두 숫자 중 최대값 가져오기"
+x := 10 min: 20.                        "두 숫자 중 최소값 가져오기"
+x := Float pi.                          "파이"
+x := Float e.                           "지수 상수"
+x := Float infinity.                    "무한대"
+x := Float nan.                         "숫자 아님"
+x := Random new next; yourself. x next. "난수 스트림 (0.0에서 1.0)"
+x := 100 atRandom.                      "빠른 난수"
 ```
 
-#### Bitwise Manipulation:
+#### 비트 조작:
 ```smalltalk
 | b x |
-x := 16rFF bitAnd: 16r0F.           "and bits"
-x := 16rF0 bitOr: 16r0F.            "or bits"
-x := 16rFF bitXor: 16r0F.           "xor bits"
-x := 16rFF bitInvert.               "invert bits"
-x := 16r0F bitShift: 4.             "left shift"
-x := 16rF0 bitShift: -4.            "right shift"
-"x := 16r80 bitAt: 7."              "bit at position (0|1) [!Squeak]"
-x := 16r80 highbit.                 "position of highest bit set"
-b := 16rFF allMask: 16r0F.          "test if all bits set in mask set in receiver"
-b := 16rFF anyMask: 16r0F.          "test if any bits set in mask set in receiver"
-b := 16rFF noMask: 16r0F.           "test if all bits set in mask clear in receiver"
+x := 16rFF bitAnd: 16r0F.           "비트 and"
+x := 16rF0 bitOr: 16r0F.            "비트 or"
+x := 16rFF bitXor: 16r0F.           "비트 xor"
+x := 16rFF bitInvert.               "비트 반전"
+x := 16r0F bitShift: 4.             "왼쪽 시프트"
+x := 16rF0 bitShift: -4.            "오른쪽 시프트"
+"x := 16r80 bitAt: 7."              "위치의 비트 (0|1) [!Squeak]"
+x := 16r80 highbit.                 "가장 높은 비트의 위치"
+b := 16rFF allMask: 16r0F.          "마스크에 설정된 모든 비트가 수신자에 설정되었는지 테스트"
+b := 16rFF anyMask: 16r0F.          "마스크에 설정된 비트 중 하나라도 수신자에 설정되었는지 테스트"
+b := 16rFF noMask: 16r0F.           "마스크에 설정된 모든 비트가 수신자에서 지워졌는지 테스트"
 ```
 
-#### Conversion:
+#### 변환:
 ```smalltalk
 | x |
-x := 3.99 asInteger.               "convert number to integer (truncates in Squeak)"
-x := 3.99 asFraction.              "convert number to fraction"
-x := 3 asFloat.                    "convert number to float"
-x := 65 asCharacter.               "convert integer to character"
-x := $A asciiValue.                "convert character to integer"
-x := 3.99 printString.             "convert object to string via printOn:"
-x := 3.99 storeString.             "convert object to string via storeOn:"
-x := 15 radix: 16.                 "convert to string in given base"
+x := 3.99 asInteger.               "숫자를 정수로 변환 (Squeak에서는 버림)"
+x := 3.99 asFraction.              "숫자를 분수로 변환"
+x := 3 asFloat.                    "숫자를 부동 소수점으로 변환"
+x := 65 asCharacter.               "정수를 문자로 변환"
+x := $A asciiValue.                "문자를 정수로 변환"
+x := 3.99 printString.             "printOn:을 통해 객체를 문자열로 변환"
+x := 3.99 storeString.             "storeOn:을 통해 객체를 문자열로 변환"
+x := 15 radix: 16.                 "지정된 기수로 문자열로 변환"
 x := 15 printStringBase: 16.
 x := 15 storeStringBase: 16.
 ```
 
-#### Blocks:
-- blocks are objects and may be assigned to a variable
-- value is last expression evaluated unless explicit return
-- blocks may be nested
-- specification [ arguments | | localvars | expressions ]
-- Squeak does not currently support localvars in blocks
-- max of three arguments allowed
-- `^`expression terminates block & method (exits all nested blocks)
-- blocks intended for long term storage should not contain `^`
+#### 블록:
+- 블록은 객체이며 변수에 할당될 수 있습니다.
+- 값은 명시적 반환이 없는 한 마지막으로 평가된 표현식입니다.
+- 블록은 중첩될 수 있습니다.
+- 사양 [ 인수 | | 지역 변수 | 표현식 ]
+- Squeak는 현재 블록의 지역 변수를 지원하지 않습니다.
+- 최대 세 개의 인수가 허용됩니다.
+- `^`표현식은 블록 및 메서드를 종료합니다(모든 중첩 블록 종료).
+- 장기 저장을 위한 블록에는 `^`가 포함되어서는 안 됩니다.
 
 ```smalltalk
 | x y z |
-x := [ y := 1. z := 2. ]. x value.                          "simple block usage"
-x := [ :argOne :argTwo |   argOne, ' and ' , argTwo.].      "set up block with argument passing"
-Transcript show: (x value: 'First' value: 'Second'); cr.    "use block with argument passing"
+x := [ y := 1. z := 2. ]. x value.                          "간단한 블록 사용"
+x := [ :argOne :argTwo |   argOne, ' and ' , argTwo.].      "인수 전달로 블록 설정"
+Transcript show: (x value: 'First' value: 'Second'); cr.    "인수 전달로 블록 사용"
 
-"x := [ | z | z := 1.]. *** localvars not available in squeak blocks"
+"x := [ | z | z := 1.]. *** Squeak 블록에서는 지역 변수를 사용할 수 없습니다"
 ```
 
-#### Method calls:
-- unary methods are messages with no arguments
-- binary methods
-- keyword methods are messages with selectors including colons standard categories/protocols:
-- initialize-release    (methods called for new instance)
-- accessing             (get/set methods)
-- testing               (boolean tests - is)
-- comparing             (boolean tests with parameter
-- displaying            (gui related methods)
-- printing              (methods for printing)
-- updating              (receive notification of changes)
-- private               (methods private to class)
-- instance-creation     (class methods for creating instance)
+#### 메서드 호출:
+- 단항 메서드는 인수가 없는 메시지입니다.
+- 이항 메서드
+- 키워드 메서드는 콜론을 포함하는 선택자가 있는 메시지입니다. 표준 범주/프로토콜:
+- initialize-release    (새 인스턴스에 대해 호출되는 메서드)
+- accessing             (get/set 메서드)
+- testing               (불리언 테스트 - is)
+- comparing             (매개변수가 있는 불리언 테스트)
+- displaying            (gui 관련 메서드)
+- printing              (인쇄용 메서드)
+- updating              (변경 알림 수신)
+- private               (클래스에 비공개인 메서드)
+- instance-creation     (인스턴스 생성을 위한 클래스 메서드)
 
 ```smalltalk
 | x |
-x := 2 sqrt.                                  "unary message"
-x := 2 raisedTo: 10.                          "keyword message"
-x := 194 * 9.                                 "binary message"
-Transcript show: (194 * 9) printString; cr.   "combination (chaining)"
-x := 2 perform: #sqrt.                        "indirect method invocation"
-Transcript                                    "Cascading - send multiple messages to receiver"
+x := 2 sqrt.                                  "단항 메시지"
+x := 2 raisedTo: 10.                          "키워드 메시지"
+x := 194 * 9.                                 "이항 메시지"
+Transcript show: (194 * 9) printString; cr.   "조합 (연쇄)"
+x := 2 perform: #sqrt.                        "간접 메서드 호출"
+Transcript                                    "연쇄 - 수신자에게 여러 메시지 보내기"
    show: 'hello ';
    show: 'world';
    cr.
-x := 3 + 2; * 100.                            "result=300. Sends message to same receiver (3)"
+x := 3 + 2; * 100.                            "결과=300. 동일한 수신자(3)에게 메시지 보내기"
 ```
 
-#### Conditional Statements:
+#### 조건문:
 ```smalltalk
 | x |
 x > 10 ifTrue: [Transcript show: 'ifTrue'; cr].     "if then"
@@ -334,7 +334,7 @@ Transcript
          ifFalse: ['ifFalse']);
    cr.
 
-"nested if then else"
+"중첩된 if then else"
 Transcript
    show:
       (x > 10
@@ -344,7 +344,7 @@ Transcript
          ifFalse: ['C']);
    cr.
 
-"switch functionality"
+"switch 기능"
 switch := Dictionary new.
 switch at: $A put: [Transcript show: 'Case A'; cr].
 switch at: $B put: [Transcript show: 'Case B'; cr].
@@ -352,328 +352,328 @@ switch at: $C put: [Transcript show: 'Case C'; cr].
 result := (switch at: $B) value.
 ```
 
-#### Iteration statements:
+#### 반복문:
 ```smalltalk
 | x y |
 x := 4. y := 1.
-[x > 0] whileTrue: [x := x - 1. y := y * 2].     "while true loop"
-[x >= 4] whileFalse: [x := x + 1. y := y * 2].   "while false loop"
-x timesRepeat: [y := y * 2].                     "times repeat loop (i := 1 to x)"
-1 to: x do: [:a | y := y * 2].                   "for loop"
-1 to: x by: 2 do: [:a | y := y / 2].             "for loop with specified increment"
-#(5 4 3) do: [:a | x := x + a].                  "iterate over array elements"
+[x > 0] whileTrue: [x := x - 1. y := y * 2].     "while true 루프"
+[x >= 4] whileFalse: [x := x + 1. y := y * 2].   "while false 루프"
+x timesRepeat: [y := y * 2].                     "times repeat 루프 (i := 1 to x)"
+1 to: x do: [:a | y := y * 2].                   "for 루프"
+1 to: x by: 2 do: [:a | y := y / 2].             "지정된 증분이 있는 for 루프"
+#(5 4 3) do: [:a | x := x + a].                  "배열 요소를 반복"
 ```
 
-#### Character:
+#### 문자:
 ```smalltalk
 | x y |
-x := $A.                         "character assignment"
-y := x isLowercase.              "test if lower case"
-y := x isUppercase.              "test if upper case"
-y := x isLetter.                 "test if letter"
-y := x isDigit.                  "test if digit"
-y := x isAlphaNumeric.           "test if alphanumeric"
-y := x isSeparator.              "test if separator char"
-y := x isVowel.                  "test if vowel"
-y := x digitValue.               "convert to numeric digit value"
-y := x asLowercase.              "convert to lower case"
-y := x asUppercase.              "convert to upper case"
-y := x asciiValue.               "convert to numeric ascii value"
-y := x asString.                 "convert to string"
-b := $A <= $B.                   "comparison"
+x := $A.                         "문자 할당"
+y := x isLowercase.              "소문자인지 테스트"
+y := x isUppercase.              "대문자인지 테스트"
+y := x isLetter.                 "문자인지 테스트"
+y := x isDigit.                  "숫자인지 테스트"
+y := x isAlphaNumeric.           "영숫자인지 테스트"
+y := x isSeparator.              "구분 문자인지 테스트"
+y := x isVowel.                  "모음인지 테스트"
+y := x digitValue.               "숫자 값으로 변환"
+y := x asLowercase.              "소문자로 변환"
+y := x asUppercase.              "대문자로 변환"
+y := x asciiValue.               "숫자 ascii 값으로 변환"
+y := x asString.                 "문자열로 변환"
+b := $A <= $B.                   "비교"
 y := $A max: $B.
 ```
 
-#### Symbol:
+#### 심볼:
 ```smalltalk
 | b x y |
-x := #Hello.                                      "symbol assignment"
-y := #Symbol, #Concatenation.                     "symbol concatenation (result is string)"
-b := x isEmpty.                                   "test if symbol is empty"
-y := x size.                                      "string size"
-y := x at: 2.                                     "char at location"
-y := x copyFrom: 2 to: 4.                         "substring"
-y := x indexOf: $e ifAbsent: [0].                 "first position of character within string"
-x do: [:a | Transcript show: a printString; cr].  "iterate over the string"
-b := x conform: [:a | (a >= $a) & (a <= $z)].     "test if all elements meet condition"
-y := x select: [:a | a > $a].                     "return all elements that meet condition"
-y := x asString.                                  "convert symbol to string"
-y := x asText.                                    "convert symbol to text"
-y := x asArray.                                   "convert symbol to array"
-y := x asOrderedCollection.                       "convert symbol to ordered collection"
-y := x asSortedCollection.                        "convert symbol to sorted collection"
-y := x asBag.                                     "convert symbol to bag collection"
-y := x asSet.                                     "convert symbol to set collection"
+x := #Hello.                                      "심볼 할당"
+y := #Symbol, #Concatenation.                     "심볼 연결 (결과는 문자열)"
+b := x isEmpty.                                   "심볼이 비어 있는지 테스트"
+y := x size.                                      "문자열 크기"
+y := x at: 2.                                     "위치의 문자"
+y := x copyFrom: 2 to: 4.                         "부분 문자열"
+y := x indexOf: $e ifAbsent: [0].                 "문자열 내 문자의 첫 번째 위치"
+x do: [:a | Transcript show: a printString; cr].  "문자열 반복"
+b := x conform: [:a | (a >= $a) & (a <= $z)].     "모든 요소가 조건을 충족하는지 테스트"
+y := x select: [:a | a > $a].                     "조건을 충족하는 모든 요소 반환"
+y := x asString.                                  "심볼을 문자열로 변환"
+y := x asText.                                    "심볼을 텍스트로 변환"
+y := x asArray.                                   "심볼을 배열로 변환"
+y := x asOrderedCollection.                       "심볼을 순서 있는 컬렉션으로 변환"
+y := x asSortedCollection.                        "심볼을 정렬된 컬렉션으로 변환"
+y := x asBag.                                     "심볼을 백 컬렉션으로 변환"
+y := x asSet.                                     "심볼을 세트 컬렉션으로 변환"
 ```
 
-#### String:
+#### 문자열:
 ```smalltalk
 | b x y |
-x := 'This is a string'.                           "string assignment"
-x := 'String', 'Concatenation'.                    "string concatenation"
-b := x isEmpty.                                    "test if string is empty"
-y := x size.                                       "string size"
-y := x at: 2.                                      "char at location"
-y := x copyFrom: 2 to: 4.                          "substring"
-y := x indexOf: $a ifAbsent: [0].                  "first position of character within string"
-x := String new: 4.                                "allocate string object"
-x                                                  "set string elements"
+x := 'This is a string'.                           "문자열 할당"
+x := 'String', 'Concatenation'.                    "문자열 연결"
+b := x isEmpty.                                    "문자열이 비어 있는지 테스트"
+y := x size.                                       "문자열 크기"
+y := x at: 2.                                      "위치의 문자"
+y := x copyFrom: 2 to: 4.                          "부분 문자열"
+y := x indexOf: $a ifAbsent: [0].                  "문자열 내 문자의 첫 번째 위치"
+x := String new: 4.                                "문자열 객체 할당"
+x                                                  "문자열 요소 설정"
    at: 1 put: $a;
    at: 2 put: $b;
    at: 3 put: $c;
    at: 4 put: $e.
-x := String with: $a with: $b with: $c with: $d.  "set up to 4 elements at a time"
-x do: [:a | Transcript show: a printString; cr].  "iterate over the string"
-b := x conform: [:a | (a >= $a) & (a <= $z)].     "test if all elements meet condition"
-y := x select: [:a | a > $a].                     "return all elements that meet condition"
-y := x asSymbol.                                  "convert string to symbol"
-y := x asArray.                                   "convert string to array"
-x := 'ABCD' asByteArray.                          "convert string to byte array"
-y := x asOrderedCollection.                       "convert string to ordered collection"
-y := x asSortedCollection.                        "convert string to sorted collection"
-y := x asBag.                                     "convert string to bag collection"
-y := x asSet.                                     "convert string to set collection"
-y := x shuffled.                                  "randomly shuffle string"
+x := String with: $a with: $b with: $c with: $d.  "한 번에 최대 4개 요소 설정"
+x do: [:a | Transcript show: a printString; cr].  "문자열 반복"
+b := x conform: [:a | (a >= $a) & (a <= $z)].     "모든 요소가 조건을 충족하는지 테스트"
+y := x select: [:a | a > $a].                     "조건을 충족하는 모든 요소 반환"
+y := x asSymbol.                                  "문자열을 심볼로 변환"
+y := x asArray.                                   "문자열을 배열로 변환"
+x := 'ABCD' asByteArray.                          "문자열을 바이트 배열로 변환"
+y := x asOrderedCollection.                       "문자열을 순서 있는 컬렉션으로 변환"
+y := x asSortedCollection.                        "문자열을 정렬된 컬렉션으로 변환"
+y := x asBag.                                     "문자열을 백 컬렉션으로 변환"
+y := x asSet.                                     "문자열을 세트 컬렉션으로 변환"
+y := x shuffled.                                  "문자열 무작위로 섞기"
 ```
 
-#### Array:
-Fixed length collection
-- ByteArray:     Array limited to byte elements (0-255)
-- WordArray:     Array limited to word elements (0-2^32)
+#### 배열:
+고정 길이 컬렉션
+- ByteArray:     바이트 요소로 제한된 배열 (0-255)
+- WordArray:     워드 요소로 제한된 배열 (0-2^32)
 
 ```smalltalk
 | b x y z sum max |
-x := #(4 3 2 1).                                 "constant array"
-z := #(1 2 3 'hi').                              "mixed type array"
-x := Array with: 5 with: 4 with: 3 with: 2.      "create array with up to 4 elements"
-x := Array new: 4.                               "allocate an array with specified size"
-x                                                "set array elements"
+x := #(4 3 2 1).                                 "상수 배열"
+z := #(1 2 3 'hi').                              "혼합 타입 배열"
+x := Array with: 5 with: 4 with: 3 with: 2.      "최대 4개 요소로 배열 생성"
+x := Array new: 4.                               "지정된 크기로 배열 할당"
+x                                                "배열 요소 설정"
    at: 1 put: 5;
    at: 2 put: 4;
    at: 3 put: 3;
    at: 4 put: 2.
-b := x isEmpty.                                  "test if array is empty"
-y := x size.                                     "array size"
-y := x at: 4.                                    "get array element at index"
-b := x includes: 3.                              "test if element is in array"
-y := x copyFrom: 2 to: 4.                        "subarray"
-y := x indexOf: 3 ifAbsent: [0].                 "first position of element within array"
-y := x occurrencesOf: 3.                         "number of times object in collection"
-x do: [:a | Transcript show: a printString; cr]. "iterate over the array"
-b := x conform: [:a | (a >= 1) & (a <= 4)].      "test if all elements meet condition"
-y := x select: [:a | a > 2].                     "return collection of elements that pass test"
-y := x reject: [:a | a < 2].                     "return collection of elements that fail test"
-y := x collect: [:a | a + a].                    "transform each element for new collection"
-y := x detect: [:a | a > 3] ifNone: [].          "find position of first element that passes test"
-sum := 0. x do: [:a | sum := sum + a]. sum.      "sum array elements"
+b := x isEmpty.                                  "배열이 비어 있는지 테스트"
+y := x size.                                     "배열 크기"
+y := x at: 4.                                    "인덱스에서 배열 요소 가져오기"
+b := x includes: 3.                              "배열에 요소가 있는지 테스트"
+y := x copyFrom: 2 to: 4.                        "부분 배열"
+y := x indexOf: 3 ifAbsent: [0].                 "배열 내 요소의 첫 번째 위치"
+y := x occurrencesOf: 3.                         "컬렉션에서 객체 수"
+x do: [:a | Transcript show: a printString; cr]. "배열 반복"
+b := x conform: [:a | (a >= 1) & (a <= 4)].      "모든 요소가 조건을 충족하는지 테스트"
+y := x select: [:a | a > 2].                     "테스트를 통과하는 요소의 컬렉션 반환"
+y := x reject: [:a | a < 2].                     "테스트에 실패하는 요소의 컬렉션 반환"
+y := x collect: [:a | a + a].                    "새 컬렉션을 위해 각 요소 변환"
+y := x detect: [:a | a > 3] ifNone: [].          "테스트를 통과하는 첫 번째 요소의 위치 찾기"
+sum := 0. x do: [:a | sum := sum + a]. sum.      "배열 요소 합계"
 sum := 0. 1 to: (x size)
-            do: [:a | sum := sum + (x at: a)].   "sum array elements"
-sum := x inject: 0 into: [:a :c | a + c].        "sum array elements"
-max := x inject: 0 into: [:a :c | (a > c)        "find max element in array"
+            do: [:a | sum := sum + (x at: a)].   "배열 요소 합계"
+sum := x inject: 0 into: [:a :c | a + c].        "배열 요소 합계"
+max := x inject: 0 into: [:a :c | (a > c)        "배열에서 최대 요소 찾기"
    ifTrue: [a]
    ifFalse: [c]].
-y := x shuffled.                                 "randomly shuffle collection"
-y := x asArray.                                  "convert to array"
-"y := x asByteArray."                            "note: this instruction not available on Squeak"
-y := x asWordArray.                              "convert to word array"
-y := x asOrderedCollection.                      "convert to ordered collection"
-y := x asSortedCollection.                       "convert to sorted collection"
-y := x asBag.                                    "convert to bag collection"
-y := x asSet.                                    "convert to set collection"
+y := x shuffled.                                 "컬렉션 무작위로 섞기"
+y := x asArray.                                  "배열로 변환"
+"y := x asByteArray."                            "참고: 이 지침은 Squeak에서 사용할 수 없습니다"
+y := x asWordArray.                              "워드 배열로 변환"
+y := x asOrderedCollection.                      "순서 있는 컬렉션으로 변환"
+y := x asSortedCollection.                       "정렬된 컬렉션으로 변환"
+y := x asBag.                                    "백 컬렉션으로 변환"
+y := x asSet.                                    "세트 컬렉션으로 변환"
 ```
 
 #### OrderedCollection:
-acts like an expandable array
+확장 가능한 배열처럼 작동합니다
 
 ```smalltalk
 | b x y sum max |
 x := OrderedCollection
-     with: 4 with: 3 with: 2 with: 1.            "create collection with up to 4 elements"
-x := OrderedCollection new.                      "allocate collection"
-x add: 3; add: 2; add: 1; add: 4; yourself.      "add element to collection"
-y := x addFirst: 5.                              "add element at beginning of collection"
-y := x removeFirst.                              "remove first element in collection"
-y := x addLast: 6.                               "add element at end of collection"
-y := x removeLast.                               "remove last element in collection"
-y := x addAll: #(7 8 9).                         "add multiple elements to collection"
-y := x removeAll: #(7 8 9).                      "remove multiple elements from collection"
-x at: 2 put: 3.                                  "set element at index"
-y := x remove: 5 ifAbsent: [].                   "remove element from collection"
-b := x isEmpty.                                  "test if empty"
-y := x size.                                     "number of elements"
-y := x at: 2.                                    "retrieve element at index"
-y := x first.                                    "retrieve first element in collection"
-y := x last.                                     "retrieve last element in collection"
-b := x includes: 5.                              "test if element is in collection"
-y := x copyFrom: 2 to: 3.                        "subcollection"
-y := x indexOf: 3 ifAbsent: [0].                 "first position of element within collection"
-y := x occurrencesOf: 3.                         "number of times object in collection"
-x do: [:a | Transcript show: a printString; cr]. "iterate over the collection"
-b := x conform: [:a | (a >= 1) & (a <= 4)].      "test if all elements meet condition"
-y := x select: [:a | a > 2].                     "return collection of elements that pass test"
-y := x reject: [:a | a < 2].                     "return collection of elements that fail test"
-y := x collect: [:a | a + a].                    "transform each element for new collection"
-y := x detect: [:a | a > 3] ifNone: [].          "find position of first element that passes test"
-sum := 0. x do: [:a | sum := sum + a]. sum.      "sum elements"
+     with: 4 with: 3 with: 2 with: 1.            "최대 4개 요소로 컬렉션 생성"
+x := OrderedCollection new.                      "컬렉션 할당"
+x add: 3; add: 2; add: 1; add: 4; yourself.      "컬렉션에 요소 추가"
+y := x addFirst: 5.                              "컬렉션 시작 부분에 요소 추가"
+y := x removeFirst.                              "컬렉션에서 첫 번째 요소 제거"
+y := x addLast: 6.                               "컬렉션 끝에 요소 추가"
+y := x removeLast.                               "컬렉션에서 마지막 요소 제거"
+y := x addAll: #(7 8 9).                         "컬렉션에 여러 요소 추가"
+y := x removeAll: #(7 8 9).                      "컬렉션에서 여러 요소 제거"
+x at: 2 put: 3.                                  "인덱스에 요소 설정"
+y := x remove: 5 ifAbsent: [].                   "컬렉션에서 요소 제거"
+b := x isEmpty.                                  "비어 있는지 테스트"
+y := x size.                                     "요소 수"
+y := x at: 2.                                    "인덱스에서 요소 검색"
+y := x first.                                    "컬렉션에서 첫 번째 요소 검색"
+y := x last.                                     "컬렉션에서 마지막 요소 검색"
+b := x includes: 5.                              "컬렉션에 요소가 있는지 테스트"
+y := x copyFrom: 2 to: 3.                        "부분 컬렉션"
+y := x indexOf: 3 ifAbsent: [0].                 "컬렉션 내 요소의 첫 번째 위치"
+y := x occurrencesOf: 3.                         "컬렉션에서 객체 수"
+x do: [:a | Transcript show: a printString; cr]. "컬렉션 반복"
+b := x conform: [:a | (a >= 1) & (a <= 4)].      "모든 요소가 조건을 충족하는지 테스트"
+y := x select: [:a | a > 2].                     "테스트를 통과하는 요소의 컬렉션 반환"
+y := x reject: [:a | a < 2].                     "테스트에 실패하는 요소의 컬렉션 반환"
+y := x collect: [:a | a + a].                    "새 컬렉션을 위해 각 요소 변환"
+y := x detect: [:a | a > 3] ifNone: [].          "테스트를 통과하는 첫 번째 요소의 위치 찾기"
+sum := 0. x do: [:a | sum := sum + a]. sum.      "요소 합계"
 sum := 0. 1 to: (x size)
-            do: [:a | sum := sum + (x at: a)].   "sum elements"
-sum := x inject: 0 into: [:a :c | a + c].        "sum elements"
-max := x inject: 0 into: [:a :c | (a > c)        "find max element in collection"
+            do: [:a | sum := sum + (x at: a)].   "요소 합계"
+sum := x inject: 0 into: [:a :c | a + c].        "요소 합계"
+max := x inject: 0 into: [:a :c | (a > c)        "컬렉션에서 최대 요소 찾기"
    ifTrue: [a]
    ifFalse: [c]].
-y := x shuffled.                                 "randomly shuffle collection"
-y := x asArray.                                  "convert to array"
-y := x asOrderedCollection.                      "convert to ordered collection"
-y := x asSortedCollection.                       "convert to sorted collection"
-y := x asBag.                                    "convert to bag collection"
-y := x asSet.                                    "convert to set collection"
+y := x shuffled.                                 "컬렉션 무작위로 섞기"
+y := x asArray.                                  "배열로 변환"
+y := x asOrderedCollection.                      "순서 있는 컬렉션으로 변환"
+y := x asSortedCollection.                       "정렬된 컬렉션으로 변환"
+y := x asBag.                                    "백 컬렉션으로 변환"
+y := x asSet.                                    "세트 컬렉션으로 변환"
 ```
 
 #### SortedCollection:
-like OrderedCollection except order of elements determined by sorting criteria
+요소 순서가 정렬 기준에 따라 결정된다는 점을 제외하고 OrderedCollection과 같습니다.
 
 ```smalltalk
 | b x y sum max |
 x := SortedCollection
-     with: 4 with: 3 with: 2 with: 1.              "create collection with up to 4 elements"
-x := SortedCollection new.                         "allocate collection"
-x := SortedCollection sortBlock: [:a :c | a > c].  "set sort criteria"
-x add: 3; add: 2; add: 1; add: 4; yourself.        "add element to collection"
-y := x addFirst: 5.                                "add element at beginning of collection"
-y := x removeFirst.                                "remove first element in collection"
-y := x addLast: 6.                                 "add element at end of collection"
-y := x removeLast.                                 "remove last element in collection"
-y := x addAll: #(7 8 9).                           "add multiple elements to collection"
-y := x removeAll: #(7 8 9).                        "remove multiple elements from collection"
-y := x remove: 5 ifAbsent: [].                     "remove element from collection"
-b := x isEmpty.                                    "test if empty"
-y := x size.                                       "number of elements"
-y := x at: 2.                                      "retrieve element at index"
-y := x first.                                      "retrieve first element in collection"
-y := x last.                                       "retrieve last element in collection"
-b := x includes: 4.                                "test if element is in collection"
-y := x copyFrom: 2 to: 3.                          "subcollection"
-y := x indexOf: 3 ifAbsent: [0].                   "first position of element within collection"
-y := x occurrencesOf: 3.                           "number of times object in collection"
-x do: [:a | Transcript show: a printString; cr].   "iterate over the collection"
-b := x conform: [:a | (a >= 1) & (a <= 4)].        "test if all elements meet condition"
-y := x select: [:a | a > 2].                       "return collection of elements that pass test"
-y := x reject: [:a | a < 2].                       "return collection of elements that fail test"
-y := x collect: [:a | a + a].                      "transform each element for new collection"
-y := x detect: [:a | a > 3] ifNone: [].            "find position of first element that passes test"
-sum := 0. x do: [:a | sum := sum + a]. sum.        "sum elements"
+     with: 4 with: 3 with: 2 with: 1.              "최대 4개 요소로 컬렉션 생성"
+x := SortedCollection new.                         "컬렉션 할당"
+x := SortedCollection sortBlock: [:a :c | a > c].  "정렬 기준 설정"
+x add: 3; add: 2; add: 1; add: 4; yourself.        "컬렉션에 요소 추가"
+y := x addFirst: 5.                                "컬렉션 시작 부분에 요소 추가"
+y := x removeFirst.                                "컬렉션에서 첫 번째 요소 제거"
+y := x addLast: 6.                                 "컬렉션 끝에 요소 추가"
+y := x removeLast.                                 "컬렉션에서 마지막 요소 제거"
+y := x addAll: #(7 8 9).                           "컬렉션에 여러 요소 추가"
+y := x removeAll: #(7 8 9).                        "컬렉션에서 여러 요소 제거"
+y := x remove: 5 ifAbsent: [].                     "컬렉션에서 요소 제거"
+b := x isEmpty.                                    "비어 있는지 테스트"
+y := x size.                                       "요소 수"
+y := x at: 2.                                      "인덱스에서 요소 검색"
+y := x first.                                      "컬렉션에서 첫 번째 요소 검색"
+y := x last.                                       "컬렉션에서 마지막 요소 검색"
+b := x includes: 4.                                "컬렉션에 요소가 있는지 테스트"
+y := x copyFrom: 2 to: 3.                          "부분 컬렉션"
+y := x indexOf: 3 ifAbsent: [0].                   "컬렉션 내 요소의 첫 번째 위치"
+y := x occurrencesOf: 3.                           "컬렉션에서 객체 수"
+x do: [:a | Transcript show: a printString; cr].   "컬렉션 반복"
+b := x conform: [:a | (a >= 1) & (a <= 4)].        "모든 요소가 조건을 충족하는지 테스트"
+y := x select: [:a | a > 2].                       "테스트를 통과하는 요소의 컬렉션 반환"
+y := x reject: [:a | a < 2].                       "테스트에 실패하는 요소의 컬렉션 반환"
+y := x collect: [:a | a + a].                      "새 컬렉션을 위해 각 요소 변환"
+y := x detect: [:a | a > 3] ifNone: [].            "테스트를 통과하는 첫 번째 요소의 위치 찾기"
+sum := 0. x do: [:a | sum := sum + a]. sum.        "요소 합계"
 sum := 0. 1 to: (x size)
-            do: [:a | sum := sum + (x at: a)].     "sum elements"
-sum := x inject: 0 into: [:a :c | a + c].          "sum elements"
-max := x inject: 0 into: [:a :c | (a > c)          "find max element in collection"
+            do: [:a | sum := sum + (x at: a)].     "요소 합계"
+sum := x inject: 0 into: [:a :c | a + c].          "요소 합계"
+max := x inject: 0 into: [:a :c | (a > c)          "컬렉션에서 최대 요소 찾기"
    ifTrue: [a]
    ifFalse: [c]].
-y := x asArray.                                     "convert to array"
-y := x asOrderedCollection.                         "convert to ordered collection"
-y := x asSortedCollection.                          "convert to sorted collection"
-y := x asBag.                                       "convert to bag collection"
-y := x asSet.                                       "convert to set collection"
+y := x asArray.                                     "배열로 변환"
+y := x asOrderedCollection.                         "순서 있는 컬렉션으로 변환"
+y := x asSortedCollection.                          "정렬된 컬렉션으로 변환"
+y := x asBag.                                       "백 컬렉션으로 변환"
+y := x asSet.                                       "세트 컬렉션으로 변환"
 ```
 
 #### Bag:
-like OrderedCollection except elements are in no particular order
+요소가 특정 순서가 아니라는 점을 제외하고 OrderedCollection과 같습니다.
 
 ```smalltalk
 | b x y sum max |
-x := Bag with: 4 with: 3 with: 2 with: 1.        "create collection with up to 4 elements"
-x := Bag new.                                    "allocate collection"
-x add: 4; add: 3; add: 1; add: 2; yourself.      "add element to collection"
-x add: 3 withOccurrences: 2.                     "add multiple copies to collection"
-y := x addAll: #(7 8 9).                         "add multiple elements to collection"
-y := x removeAll: #(7 8 9).                      "remove multiple elements from collection"
-y := x remove: 4 ifAbsent: [].                   "remove element from collection"
-b := x isEmpty.                                  "test if empty"
-y := x size.                                     "number of elements"
-b := x includes: 3.                              "test if element is in collection"
-y := x occurrencesOf: 3.                         "number of times object in collection"
-x do: [:a | Transcript show: a printString; cr]. "iterate over the collection"
-b := x conform: [:a | (a >= 1) & (a <= 4)].      "test if all elements meet condition"
-y := x select: [:a | a > 2].                     "return collection of elements that pass test"
-y := x reject: [:a | a < 2].                     "return collection of elements that fail test"
-y := x collect: [:a | a + a].                    "transform each element for new collection"
-y := x detect: [:a | a > 3] ifNone: [].          "find position of first element that passes test"
-sum := 0. x do: [:a | sum := sum + a]. sum.      "sum elements"
-sum := x inject: 0 into: [:a :c | a + c].        "sum elements"
-max := x inject: 0 into: [:a :c | (a > c)        "find max element in collection"
+x := Bag with: 4 with: 3 with: 2 with: 1.        "최대 4개 요소로 컬렉션 생성"
+x := Bag new.                                    "컬렉션 할당"
+x add: 4; add: 3; add: 1; add: 2; yourself.      "컬렉션에 요소 추가"
+x add: 3 withOccurrences: 2.                     "컬렉션에 여러 복사본 추가"
+y := x addAll: #(7 8 9).                         "컬렉션에 여러 요소 추가"
+y := x removeAll: #(7 8 9).                      "컬렉션에서 여러 요소 제거"
+y := x remove: 4 ifAbsent: [].                   "컬렉션에서 요소 제거"
+b := x isEmpty.                                  "비어 있는지 테스트"
+y := x size.                                     "요소 수"
+b := x includes: 3.                              "컬렉션에 요소가 있는지 테스트"
+y := x occurrencesOf: 3.                         "컬렉션에서 객체 수"
+x do: [:a | Transcript show: a printString; cr]. "컬렉션 반복"
+b := x conform: [:a | (a >= 1) & (a <= 4)].      "모든 요소가 조건을 충족하는지 테스트"
+y := x select: [:a | a > 2].                     "테스트를 통과하는 요소의 컬렉션 반환"
+y := x reject: [:a | a < 2].                     "테스트에 실패하는 요소의 컬렉션 반환"
+y := x collect: [:a | a + a].                    "새 컬렉션을 위해 각 요소 변환"
+y := x detect: [:a | a > 3] ifNone: [].          "테스트를 통과하는 첫 번째 요소의 위치 찾기"
+sum := 0. x do: [:a | sum := sum + a]. sum.      "요소 합계"
+sum := x inject: 0 into: [:a :c | a + c].        "요소 합계"
+max := x inject: 0 into: [:a :c | (a > c)        "컬렉션에서 최대 요소 찾기"
    ifTrue: [a]
    ifFalse: [c]].
-y := x asOrderedCollection.                       "convert to ordered collection"
-y := x asSortedCollection.                        "convert to sorted collection"
-y := x asBag.                                     "convert to bag collection"
-y := x asSet.                                     "convert to set collection"
+y := x asOrderedCollection.                       "순서 있는 컬렉션으로 변환"
+y := x asSortedCollection.                        "정렬된 컬렉션으로 변환"
+y := x asBag.                                     "백 컬렉션으로 변환"
+y := x asSet.                                     "세트 컬렉션으로 변환"
 ```
 
 #### Set:
-like Bag except duplicates not allowed
+중복이 허용되지 않는다는 점을 제외하고 Bag과 같습니다.
 
 #### IdentitySet:
-uses identity test (== rather than =)
+동일성 테스트를 사용합니다(== 대신 =)
 
 ```smalltalk
 | b x y sum max |
-x := Set with: 4 with: 3 with: 2 with: 1.        "create collection with up to 4 elements"
-x := Set new.                                    "allocate collection"
-x add: 4; add: 3; add: 1; add: 2; yourself.      "add element to collection"
-y := x addAll: #(7 8 9).                         "add multiple elements to collection"
-y := x removeAll: #(7 8 9).                      "remove multiple elements from collection"
-y := x remove: 4 ifAbsent: [].                   "remove element from collection"
-b := x isEmpty.                                  "test if empty"
-y := x size.                                     "number of elements"
-x includes: 4.                                   "test if element is in collection"
-x do: [:a | Transcript show: a printString; cr]. "iterate over the collection"
-b := x conform: [:a | (a >= 1) & (a <= 4)].      "test if all elements meet condition"
-y := x select: [:a | a > 2].                     "return collection of elements that pass test"
-y := x reject: [:a | a < 2].                     "return collection of elements that fail test"
-y := x collect: [:a | a + a].                    "transform each element for new collection"
-y := x detect: [:a | a > 3] ifNone: [].          "find position of first element that passes test"
-sum := 0. x do: [:a | sum := sum + a]. sum.      "sum elements"
-sum := x inject: 0 into: [:a :c | a + c].        "sum elements"
-max := x inject: 0 into: [:a :c | (a > c)        "find max element in collection"
+x := Set with: 4 with: 3 with: 2 with: 1.        "최대 4개 요소로 컬렉션 생성"
+x := Set new.                                    "컬렉션 할당"
+x add: 4; add: 3; add: 1; add: 2; yourself.      "컬렉션에 요소 추가"
+y := x addAll: #(7 8 9).                         "컬렉션에 여러 요소 추가"
+y := x removeAll: #(7 8 9).                      "컬렉션에서 여러 요소 제거"
+y := x remove: 4 ifAbsent: [].                   "컬렉션에서 요소 제거"
+b := x isEmpty.                                  "비어 있는지 테스트"
+y := x size.                                     "요소 수"
+x includes: 4.                                   "컬렉션에 요소가 있는지 테스트"
+x do: [:a | Transcript show: a printString; cr]. "컬렉션 반복"
+b := x conform: [:a | (a >= 1) & (a <= 4)].      "모든 요소가 조건을 충족하는지 테스트"
+y := x select: [:a | a > 2].                     "테스트를 통과하는 요소의 컬렉션 반환"
+y := x reject: [:a | a < 2].                     "테스트에 실패하는 요소의 컬렉션 반환"
+y := x collect: [:a | a + a].                    "새 컬렉션을 위해 각 요소 변환"
+y := x detect: [:a | a > 3] ifNone: [].          "테스트를 통과하는 첫 번째 요소의 위치 찾기"
+sum := 0. x do: [:a | sum := sum + a]. sum.      "요소 합계"
+sum := x inject: 0 into: [:a :c | a + c].        "요소 합계"
+max := x inject: 0 into: [:a :c | (a > c)        "컬렉션에서 최대 요소 찾기"
    ifTrue: [a]
    ifFalse: [c]].
-y := x asArray.                                  "convert to array"
-y := x asOrderedCollection.                      "convert to ordered collection"
-y := x asSortedCollection.                       "convert to sorted collection"
-y := x asBag.                                    "convert to bag collection"
-y := x asSet.                                    "convert to set collection"
+y := x asArray.                                  "배열로 변환"
+y := x asOrderedCollection.                      "순서 있는 컬렉션으로 변환"
+y := x asSortedCollection.                       "정렬된 컬렉션으로 변환"
+y := x asBag.                                    "백 컬렉션으로 변환"
+y := x asSet.                                    "세트 컬렉션으로 변환"
 ```
 
 #### Interval:
 ```smalltalk
 | b x y sum max |
-x := Interval from: 5 to: 10.                     "create interval object"
+x := Interval from: 5 to: 10.                     "간격 객체 생성"
 x := 5 to: 10.
-x := Interval from: 5 to: 10 by: 2.               "create interval object with specified increment"
+x := Interval from: 5 to: 10 by: 2.               "지정된 증분이 있는 간격 객체 생성"
 x := 5 to: 10 by: 2.
-b := x isEmpty.                                   "test if empty"
-y := x size.                                      "number of elements"
-x includes: 9.                                    "test if element is in collection"
-x do: [:k | Transcript show: k printString; cr].  "iterate over interval"
-b := x conform: [:a | (a >= 1) & (a <= 4)].       "test if all elements meet condition"
-y := x select: [:a | a > 7].                      "return collection of elements that pass test"
-y := x reject: [:a | a < 2].                      "return collection of elements that fail test"
-y := x collect: [:a | a + a].                     "transform each element for new collection"
-y := x detect: [:a | a > 3] ifNone: [].           "find position of first element that passes test"
-sum := 0. x do: [:a | sum := sum + a]. sum.       "sum elements"
+b := x isEmpty.                                   "비어 있는지 테스트"
+y := x size.                                      "요소 수"
+x includes: 9.                                    "컬렉션에 요소가 있는지 테스트"
+x do: [:k | Transcript show: k printString; cr].  "간격 반복"
+b := x conform: [:a | (a >= 1) & (a <= 4)].       "모든 요소가 조건을 충족하는지 테스트"
+y := x select: [:a | a > 7].                      "테스트를 통과하는 요소의 컬렉션 반환"
+y := x reject: [:a | a < 2].                      "테스트에 실패하는 요소의 컬렉션 반환"
+y := x collect: [:a | a + a].                     "새 컬렉션을 위해 각 요소 변환"
+y := x detect: [:a | a > 3] ifNone: [].           "테스트를 통과하는 첫 번째 요소의 위치 찾기"
+sum := 0. x do: [:a | sum := sum + a]. sum.       "요소 합계"
 sum := 0. 1 to: (x size)
-            do: [:a | sum := sum + (x at: a)].    "sum elements"
-sum := x inject: 0 into: [:a :c | a + c].         "sum elements"
-max := x inject: 0 into: [:a :c | (a > c)         "find max element in collection"
+            do: [:a | sum := sum + (x at: a)].    "요소 합계"
+sum := x inject: 0 into: [:a :c | a + c].         "요소 합계"
+max := x inject: 0 into: [:a :c | (a > c)         "컬렉션에서 최대 요소 찾기"
    ifTrue: [a]
    ifFalse: [c]].
-y := x asArray.                                   "convert to array"
-y := x asOrderedCollection.                       "convert to ordered collection"
-y := x asSortedCollection.                        "convert to sorted collection"
-y := x asBag.                                     "convert to bag collection"
-y := x asSet.                                     "convert to set collection"
+y := x asArray.                                   "배열로 변환"
+y := x asOrderedCollection.                       "순서 있는 컬렉션으로 변환"
+y := x asSortedCollection.                        "정렬된 컬렉션으로 변환"
+y := x asBag.                                     "백 컬렉션으로 변환"
+y := x asSet.                                     "세트 컬렉션으로 변환"
 ```
 
-#### Associations:
+#### 연관:
 ```smalltalk
 | x y |
 x := #myVar->'hello'.
@@ -681,77 +681,77 @@ y := x key.
 y := x value.
 ```
 
-#### Dictionary:
+#### 딕셔너리:
 #### IdentityDictionary:
-uses identity test (== rather than =)
+동일성 테스트를 사용합니다(== 대신 =)
 
 ```smalltalk
 | b x y |
-x := Dictionary new.                   "allocate collection"
+x := Dictionary new.                   "컬렉션 할당"
 x add: #a->4;
   add: #b->3;
   add: #c->1;
-  add: #d->2; yourself.                "add element to collection"
-x at: #e put: 3.                       "set element at index"
-b := x isEmpty.                        "test if empty"
-y := x size.                           "number of elements"
-y := x at: #a ifAbsent: [].            "retrieve element at index"
-y := x keyAtValue: 3 ifAbsent: [].     "retrieve key for given value with error block"
-y := x removeKey: #e ifAbsent: [].     "remove element from collection"
-b := x includes: 3.                    "test if element is in values collection"
-b := x includesKey: #a.                "test if element is in keys collection"
-y := x occurrencesOf: 3.               "number of times object in collection"
-y := x keys.                           "set of keys"
-y := x values.                         "bag of values"
-x do: [:a | Transcript show: a printString; cr].            "iterate over the values collection"
-x keysDo: [:a | Transcript show: a printString; cr].        "iterate over the keys collection"
-x associationsDo: [:a | Transcript show: a printString; cr]."iterate over the associations"
-x keysAndValuesDo: [:aKey :aValue | Transcript              "iterate over keys and values"
+  add: #d->2; yourself.                "컬렉션에 요소 추가"
+x at: #e put: 3.                       "인덱스에 요소 설정"
+b := x isEmpty.                        "비어 있는지 테스트"
+y := x size.                           "요소 수"
+y := x at: #a ifAbsent: [].            "인덱스에서 요소 검색"
+y := x keyAtValue: 3 ifAbsent: [].     "오류 블록이 있는 주어진 값에 대한 키 검색"
+y := x removeKey: #e ifAbsent: [].     "컬렉션에서 요소 제거"
+b := x includes: 3.                    "값 컬렉션에 요소가 있는지 테스트"
+b := x includesKey: #a.                "키 컬렉션에 요소가 있는지 테스트"
+y := x occurrencesOf: 3.               "컬렉션에서 객체 수"
+y := x keys.                           "키 집합"
+y := x values.                         "값 백"
+x do: [:a | Transcript show: a printString; cr].            "값 컬렉션 반복"
+x keysDo: [:a | Transcript show: a printString; cr].        "키 컬렉션 반복"
+x associationsDo: [:a | Transcript show: a printString; cr]."연관 반복"
+x keysAndValuesDo: [:aKey :aValue | Transcript              "키와 값 반복"
    show: aKey printString; space;
    show: aValue printString; cr].
-b := x conform: [:a | (a >= 1) & (a <= 4)].      "test if all elements meet condition"
-y := x select: [:a | a > 2].                     "return collection of elements that pass test"
-y := x reject: [:a | a < 2].                     "return collection of elements that fail test"
-y := x collect: [:a | a + a].                    "transform each element for new collection"
-y := x detect: [:a | a > 3] ifNone: [].          "find position of first element that passes test"
-sum := 0. x do: [:a | sum := sum + a]. sum.      "sum elements"
-sum := x inject: 0 into: [:a :c | a + c].        "sum elements"
-max := x inject: 0 into: [:a :c | (a > c)        "find max element in collection"
+b := x conform: [:a | (a >= 1) & (a <= 4)].      "모든 요소가 조건을 충족하는지 테스트"
+y := x select: [:a | a > 2].                     "테스트를 통과하는 요소의 컬렉션 반환"
+y := x reject: [:a | a < 2].                     "테스트에 실패하는 요소의 컬렉션 반환"
+y := x collect: [:a | a + a].                    "새 컬렉션을 위해 각 요소 변환"
+y := x detect: [:a | a > 3] ifNone: [].          "테스트를 통과하는 첫 번째 요소의 위치 찾기"
+sum := 0. x do: [:a | sum := sum + a]. sum.      "요소 합계"
+sum := x inject: 0 into: [:a :c | a + c].        "요소 합계"
+max := x inject: 0 into: [:a :c | (a > c)        "컬렉션에서 최대 요소 찾기"
    ifTrue: [a]
    ifFalse: [c]].
-y := x asArray.                                   "convert to array"
-y := x asOrderedCollection.                       "convert to ordered collection"
-y := x asSortedCollection.                        "convert to sorted collection"
-y := x asBag.                                     "convert to bag collection"
-y := x asSet.                                     "convert to set collection"
+y := x asArray.                                   "배열로 변환"
+y := x asOrderedCollection.                       "순서 있는 컬렉션으로 변환"
+y := x asSortedCollection.                        "정렬된 컬렉션으로 변환"
+y := x asBag.                                     "백 컬렉션으로 변환"
+y := x asSet.                                     "세트 컬렉션으로 변환"
 
-Smalltalk at: #CMRGlobal put: 'CMR entry'.        "put global in Smalltalk Dictionary"
-x := Smalltalk at: #CMRGlobal.                    "read global from Smalltalk Dictionary"
-Transcript show: (CMRGlobal printString).         "entries are directly accessible by name"
-Smalltalk keys do: [ :k |                         "print out all classes"
+Smalltalk at: #CMRGlobal put: 'CMR entry'.        "Smalltalk 딕셔너리에 전역 넣기"
+x := Smalltalk at: #CMRGlobal.                    "Smalltalk 딕셔너리에서 전역 읽기"
+Transcript show: (CMRGlobal printString).         "항목은 이름으로 직접 액세스 가능"
+Smalltalk keys do: [ :k |                         "모든 클래스 출력"
    ((Smalltalk at: k) isKindOf: Class)
       ifFalse: [Transcript show: k printString; cr]].
-Smalltalk at: #CMRDictionary put: (Dictionary new). "set up user defined dictionary"
-CMRDictionary at: #MyVar1 put: 'hello1'.            "put entry in dictionary"
-CMRDictionary add: #MyVar2->'hello2'.               "add entry to dictionary use key->value combo"
-CMRDictionary size.                                 "dictionary size"
-CMRDictionary keys do: [ :k |                       "print out keys in dictionary"
+Smalltalk at: #CMRDictionary put: (Dictionary new). "사용자 정의 딕셔너리 설정"
+CMRDictionary at: #MyVar1 put: 'hello1'.            "딕셔너리에 항목 넣기"
+CMRDictionary add: #MyVar2->'hello2'.               "키->값 조합을 사용하여 딕셔너리에 항목 추가"
+CMRDictionary size.                                 "딕셔너리 크기"
+CMRDictionary keys do: [ :k |                       "딕셔너리에서 키 출력"
    Transcript show: k printString; cr].
-CMRDictionary values do: [ :k |                     "print out values in dictionary"
+CMRDictionary values do: [ :k |                     "딕셔너리에서 값 출력"
    Transcript show: k printString; cr].
-CMRDictionary keysAndValuesDo: [:aKey :aValue |     "print out keys and values"
+CMRDictionary keysAndValuesDo: [:aKey :aValue |     "키와 값 출력"
    Transcript
       show: aKey printString;
       space;
       show: aValue printString;
       cr].
-CMRDictionary associationsDo: [:aKeyValue |           "another iterator for printing key values"
+CMRDictionary associationsDo: [:aKeyValue |           "키 값 인쇄를 위한 또 다른 반복자"
    Transcript show: aKeyValue printString; cr].
-Smalltalk removeKey: #CMRGlobal ifAbsent: [].         "remove entry from Smalltalk dictionary"
-Smalltalk removeKey: #CMRDictionary ifAbsent: [].     "remove user dictionary from Smalltalk dictionary"
+Smalltalk removeKey: #CMRGlobal ifAbsent: [].         "Smalltalk 딕셔너리에서 항목 제거"
+Smalltalk removeKey: #CMRDictionary ifAbsent: [].     "Smalltalk 딕셔너리에서 사용자 딕셔너리 제거"
 ```
 
-#### Internal Stream:
+#### 내부 스트림:
 ```smalltalk
 | b x ios |
 ios := ReadStream on: 'Hello read stream'.
@@ -779,7 +779,7 @@ x := ios contents.
 b := ios atEnd.
 ```
 
-#### FileStream:
+#### 파일 스트림:
 ```smalltalk
 | b x ios |
 ios := FileStream newFileNamed: 'ios.txt'.
@@ -799,130 +799,130 @@ b := ios atEnd.
 ios close.
 ```
 
-#### Date:
+#### 날짜:
 ```smalltalk
 | x y |
-x := Date today.                                "create date for today"
-x := Date dateAndTimeNow.                       "create date from current time/date"
-x := Date readFromString: '01/02/1999'.         "create date from formatted string"
-x := Date newDay: 12 month: #July year: 1999    "create date from parts"
-x := Date fromDays: 36000.                      "create date from elapsed days since 1/1/1901"
-y := Date dayOfWeek: #Monday.                   "day of week as int (1-7)"
-y := Date indexOfMonth: #January.               "month of year as int (1-12)"
-y := Date daysInMonth: 2 forYear: 1996.         "day of month as int (1-31)"
-y := Date daysInYear: 1996.                     "days in year (365|366)"
-y := Date nameOfDay: 1                          "weekday name (#Monday,...)"
-y := Date nameOfMonth: 1.                       "month name (#January,...)"
-y := Date leapYear: 1996.                       "1 if leap year; 0 if not leap year"
-y := x weekday.                                 "day of week (#Monday,...)"
-y := x previous: #Monday.                       "date for previous day of week"
-y := x dayOfMonth.                              "day of month (1-31)"
-y := x day.                                     "day of year (1-366)"
-y := x firstDayOfMonth.                         "day of year for first day of month"
-y := x monthName.                               "month of year (#January,...)"
-y := x monthIndex.                              "month of year (1-12)"
-y := x daysInMonth.                             "days in month (1-31)"
-y := x year.                                    "year (19xx)"
-y := x daysInYear.                              "days in year (365|366)"
-y := x daysLeftInYear.                          "days left in year (364|365)"
-y := x asSeconds.                               "seconds elapsed since 1/1/1901"
-y := x addDays: 10.                             "add days to date object"
-y := x subtractDays: 10.                        "subtract days to date object"
-y := x subtractDate: (Date today).              "subtract date (result in days)"
-y := x printFormat: #(2 1 3 $/ 1 1).            "print formatted date"
-b := (x <= Date today).                         "comparison"
+x := Date today.                                "오늘 날짜 생성"
+x := Date dateAndTimeNow.                       "현재 시간/날짜로 날짜 생성"
+x := Date readFromString: '01/02/1999'.         "형식화된 문자열에서 날짜 생성"
+x := Date newDay: 12 month: #July year: 1999    "부분에서 날짜 생성"
+x := Date fromDays: 36000.                      "1901년 1월 1일 이후 경과 일수에서 날짜 생성"
+y := Date dayOfWeek: #Monday.                   "요일을 정수로 (1-7)"
+y := Date indexOfMonth: #January.               "연중 월을 정수로 (1-12)"
+y := Date daysInMonth: 2 forYear: 1996.         "월의 일을 정수로 (1-31)"
+y := Date daysInYear: 1996.                     "연중 일수 (365|366)"
+y := Date nameOfDay: 1                          "요일 이름 (#Monday,...)"
+y := Date nameOfMonth: 1.                       "월 이름 (#January,...)"
+y := Date leapYear: 1996.                       "윤년이면 1; 아니면 0"
+y := x weekday.                                 "요일 (#Monday,...)"
+y := x previous: #Monday.                       "이전 요일의 날짜"
+y := x dayOfMonth.                              "월의 일 (1-31)"
+y := x day.                                     "연중 일 (1-366)"
+y := x firstDayOfMonth.                         "월의 첫째 날에 대한 연중 일"
+y := x monthName.                               "연중 월 (#January,...)"
+y := x monthIndex.                              "연중 월 (1-12)"
+y := x daysInMonth.                             "월의 일수 (1-31)"
+y := x year.                                    "연도 (19xx)"
+y := x daysInYear.                              "연중 일수 (365|366)"
+y := x daysLeftInYear.                          "연중 남은 일수 (364|365)"
+y := x asSeconds.                               "1901년 1월 1일 이후 경과 초"
+y := x addDays: 10.                             "날짜 객체에 일 추가"
+y := x subtractDays: 10.                        "날짜 객체에서 일 빼기"
+y := x subtractDate: (Date today).              "날짜 빼기 (결과는 일 단위)"
+y := x printFormat: #(2 1 3 $/ 1 1).            "형식화된 날짜 인쇄"
+b := (x <= Date today).                         "비교"
 ```
 
-#### Time:
+#### 시간:
 ```smalltalk
 | x y |
-x := Time now.                                      "create time from current time"
-x := Time dateAndTimeNow.                           "create time from current time/date"
-x := Time readFromString: '3:47:26 pm'.             "create time from formatted string"
-x := Time fromSeconds: (60 * 60 * 4).               "create time from elapsed time from midnight"
-y := Time millisecondClockValue.                    "milliseconds since midnight"
-y := Time totalSeconds.                             "total seconds since 1/1/1901"
-y := x seconds.                                     "seconds past minute (0-59)"
-y := x minutes.                                     "minutes past hour (0-59)"
-y := x hours.                                       "hours past midnight (0-23)"
-y := x addTime: (Time now).                         "add time to time object"
-y := x subtractTime: (Time now).                    "subtract time to time object"
-y := x asSeconds.                                   "convert time to seconds"
-x := Time millisecondsToRun: [                      "timing facility"
+x := Time now.                                      "현재 시간으로 시간 생성"
+x := Time dateAndTimeNow.                           "현재 시간/날짜로 시간 생성"
+x := Time readFromString: '3:47:26 pm'.             "형식화된 문자열에서 시간 생성"
+x := Time fromSeconds: (60 * 60 * 4).               "자정 이후 경과 시간으로 시간 생성"
+y := Time millisecondClockValue.                    "자정 이후 밀리초"
+y := Time totalSeconds.                             "1901년 1월 1일 이후 총 초"
+y := x seconds.                                     "분을 지난 초 (0-59)"
+y := x minutes.                                     "시간을 지난 분 (0-59)"
+y := x hours.                                       "자정을 지난 시간 (0-23)"
+y := x addTime: (Time now).                         "시간 객체에 시간 추가"
+y := x subtractTime: (Time now).                    "시간 객체에서 시간 빼기"
+y := x asSeconds.                                   "시간을 초로 변환"
+x := Time millisecondsToRun: [                      "타이밍 기능"
    1 to: 1000 do: [:index | y := 3.14 * index]].
-b := (x <= Time now).                               "comparison"
+b := (x <= Time now).                               "비교"
 ```
 
-#### Point:
+#### 점:
 ```smalltalk
 | x y |
-x := 200@100.                            "obtain a new point"
-y := x x.                                "x coordinate"
-y := x y.                                "y coordinate"
-x := 200@100 negated.                    "negates x and y"
-x := (-200@-100) abs.                    "absolute value of x and y"
-x := (200.5@100.5) rounded.              "round x and y"
-x := (200.5@100.5) truncated.            "truncate x and y"
-x := 200@100 + 100.                      "add scale to both x and y"
-x := 200@100 - 100.                      "subtract scale from both x and y"
-x := 200@100 * 2.                        "multiply x and y by scale"
-x := 200@100 / 2.                        "divide x and y by scale"
-x := 200@100 // 2.                       "divide x and y by scale"
-x := 200@100 \\ 3.                       "remainder of x and y by scale"
-x := 200@100 + 50@25.                    "add points"
-x := 200@100 - 50@25.                    "subtract points"
-x := 200@100 * 3@4.                      "multiply points"
-x := 200@100 // 3@4.                     "divide points"
-x := 200@100 max: 50@200.                "max x and y"
-x := 200@100 min: 50@200.                "min x and y"
-x := 20@5 dotProduct: 10@2.              "sum of product (x1*x2 + y1*y2)"
+x := 200@100.                            "새 점 얻기"
+y := x x.                                "x 좌표"
+y := x y.                                "y 좌표"
+x := 200@100 negated.                    "x와 y 부정"
+x := (-200@-100) abs.                    "x와 y의 절대값"
+x := (200.5@100.5) rounded.              "x와 y 반올림"
+x := (200.5@100.5) truncated.            "x와 y 버림"
+x := 200@100 + 100.                      "x와 y에 스케일 추가"
+x := 200@100 - 100.                      "x와 y에서 스케일 빼기"
+x := 200@100 * 2.                        "x와 y에 스케일 곱하기"
+x := 200@100 / 2.                        "x와 y를 스케일로 나누기"
+x := 200@100 // 2.                       "x와 y를 스케일로 나누기"
+x := 200@100 \\ 3.                       "x와 y를 스케일로 나눈 나머지"
+x := 200@100 + 50@25.                    "점 더하기"
+x := 200@100 - 50@25.                    "점 빼기"
+x := 200@100 * 3@4.                      "점 곱하기"
+x := 200@100 // 3@4.                     "점 나누기"
+x := 200@100 max: 50@200.                "x와 y의 최대값"
+x := 200@100 min: 50@200.                "x와 y의 최소값"
+x := 20@5 dotProduct: 10@2.              "곱의 합 (x1*x2 + y1*y2)"
 ```
 
-#### Rectangle:
+#### 사각형:
 ```smalltalk
 Rectangle fromUser.
 ```
 
-#### Pen:
+#### 펜:
 ```smalltalk
 | myPen |
 Display restoreAfter: [
    Display fillWhite.
 
-myPen := Pen new.                            "get graphic pen"
+myPen := Pen new.                            "그래픽 펜 얻기"
 myPen squareNib: 1.
-myPen color: (Color blue).                   "set pen color"
-myPen home.                                  "position pen at center of display"
-myPen up.                                    "makes nib unable to draw"
-myPen down.                                  "enable the nib to draw"
-myPen north.                                 "points direction towards top"
-myPen turn: -180.                            "add specified degrees to direction"
-myPen direction.                             "get current angle of pen"
-myPen go: 50.                                "move pen specified number of pixels"
-myPen location.                              "get the pen position"
-myPen goto: 200@200.                         "move to specified point"
-myPen place: 250@250.                        "move to specified point without drawing"
+myPen color: (Color blue).                   "펜 색상 설정"
+myPen home.                                  "디스플레이 중앙에 펜 위치"
+myPen up.                                    "펜촉을 그릴 수 없게 만듦"
+myPen down.                                  "펜촉을 그릴 수 있게 함"
+myPen north.                                 "방향을 위쪽으로 가리킴"
+myPen turn: -180.                            "방향에 지정된 각도 추가"
+myPen direction.                             "펜의 현재 각도 가져오기"
+myPen go: 50.                                "지정된 픽셀 수만큼 펜 이동"
+myPen location.                              "펜 위치 가져오기"
+myPen goto: 200@200.                         "지정된 지점으로 이동"
+myPen place: 250@250.                        "그리지 않고 지정된 지점으로 이동"
 myPen print: 'Hello World'
       withFont: (TextStyle default fontAt: 1).
-Display extent.                              "get display width@height"
-Display width.                               "get display width"
-Display height.                              "get display height"
+Display extent.                              "디스플레이 너비@높이 가져오기"
+Display width.                               "디스플레이 너비 가져오기"
+Display height.                              "디스플레이 높이 가져오기"
 
 ].
 ```
 
-#### Dynamic Message Calling/Compiling:
+#### 동적 메시지 호출/컴파일:
 ```smalltalk
 | receiver message result argument keyword1 keyword2 argument1 argument2 |
 
-"unary message"
+"단항 메시지"
 receiver := 5.
 message := 'factorial' asSymbol.
 result := receiver perform: message.
 result := Compiler evaluate: ((receiver storeString), ' ', message).
 result := (Message new setSelector: message arguments: #()) sentTo: receiver.
 
-"binary message"
+"이항 메시지"
 receiver := 1.
 message := '+' asSymbol.
 argument := 2.
@@ -930,7 +930,7 @@ result := receiver perform: message withArguments: (Array with: argument).
 result := Compiler evaluate: ((receiver storeString), ' ', message, ' ', (argument storeString)).
 result := (Message new setSelector: message arguments: (Array with: argument)) sentTo: receiver.
 
-"keyword messages"
+"키워드 메시지"
 receiver := 12.
 keyword1 := 'between:' asSymbol.
 keyword2 := 'and:' asSymbol.
@@ -951,79 +951,79 @@ result := (Message
    sentTo: receiver.
 ```
 
-#### Class/Meta-Class:
+#### 클래스/메타 클래스:
 ```smalltalk
 | b x |
-x := String name.                     "class name"
-x := String category.                 "organization category"
-x := String comment.                  "class comment"
-x := String kindOfSubclass.           "subclass type - subclass: variableSubclass, etc"
-x := String definition.               "class definition"
-x := String instVarNames.             "immediate instance variable names"
-x := String allInstVarNames.          "accumulated instance variable names"
-x := String classVarNames.            "immediate class variable names"
-x := String allClassVarNames.         "accumulated class variable names"
-x := String sharedPools.              "immediate dictionaries used as shared pools"
-x := String allSharedPools.           "accumulated dictionaries used as shared pools"
-x := String selectors.                "message selectors for class"
-x := String sourceCodeAt: #size.      "source code for specified method"
-x := String allInstances.             "collection of all instances of class"
-x := String superclass.               "immediate superclass"
-x := String allSuperclasses.          "accumulated superclasses"
-x := String withAllSuperclasses.      "receiver class and accumulated superclasses"
-x := String subclasses.               "immediate subclasses"
-x := String allSubclasses.            "accumulated subclasses"
-x := String withAllSubclasses.        "receiver class and accumulated subclasses"
-b := String instSize.                 "number of named instance variables"
-b := String isFixed.                  "true if no indexed instance variables"
-b := String isVariable.               "true if has indexed instance variables"
-b := String isPointers.               "true if index instance vars contain objects"
-b := String isBits.                   "true if index instance vars contain bytes/words"
-b := String isBytes.                  "true if index instance vars contain bytes"
-b := String isWords.                  "true if index instance vars contain words"
-Object withAllSubclasses size.        "get total number of class entries"
+x := String name.                     "클래스 이름"
+x := String category.                 "조직 범주"
+x := String comment.                  "클래스 주석"
+x := String kindOfSubclass.           "하위 클래스 타입 - subclass: variableSubclass 등"
+x := String definition.               "클래스 정의"
+x := String instVarNames.             "직접 인스턴스 변수 이름"
+x := String allInstVarNames.          "누적 인스턴스 변수 이름"
+x := String classVarNames.            "직접 클래스 변수 이름"
+x := String allClassVarNames.         "누적 클래스 변수 이름"
+x := String sharedPools.              "공유 풀로 사용되는 직접 딕셔너리"
+x := String allSharedPools.           "공유 풀로 사용되는 누적 딕셔너리"
+x := String selectors.                "클래스에 대한 메시지 선택자"
+x := String sourceCodeAt: #size.      "지정된 메서드의 소스 코드"
+x := String allInstances.             "클래스의 모든 인스턴스 컬렉션"
+x := String superclass.               "직접 상위 클래스"
+x := String allSuperclasses.          "누적 상위 클래스"
+x := String withAllSuperclasses.      "수신자 클래스 및 누적 상위 클래스"
+x := String subclasses.               "직접 하위 클래스"
+x := String allSubclasses.            "누적 하위 클래스"
+x := String withAllSubclasses.        "수신자 클래스 및 누적 하위 클래스"
+b := String instSize.                 "명명된 인스턴스 변수 수"
+b := String isFixed.                  "인덱싱된 인스턴스 변수가 없으면 true"
+b := String isVariable.               "인덱싱된 인스턴스 변수가 있으면 true"
+b := String isPointers.               "인덱스 인스턴스 변수에 객체가 포함되어 있으면 true"
+b := String isBits.                   "인덱스 인스턴스 변수에 바이트/워드가 포함되어 있으면 true"
+b := String isBytes.                  "인덱스 인스턴스 변수에 바이트가 포함되어 있으면 true"
+b := String isWords.                  "인덱스 인스턴스 변수에 워드가 포함되어 있으면 true"
+Object withAllSubclasses size.        "총 클래스 항목 수 가져오기"
 ```
 
-#### Debugging:
+#### 디버깅:
 ```smalltalk
 | a b x |
-x yourself.                             "returns receiver"
-String browse.                          "browse specified class"
-x inspect.                              "open object inspector window"
+x yourself.                             "수신자 반환"
+String browse.                          "지정된 클래스 탐색"
+x inspect.                              "객체 검사기 창 열기"
 x confirm: 'Is this correct?'.
-x halt.                                 "breakpoint to open debugger window"
+x halt.                                 "디버거 창을 열기 위한 중단점"
 x halt: 'Halt message'.
 x notify: 'Notify text'.
-x error: 'Error string'.                "open up error window with title"
-x doesNotUnderstand: #cmrMessage.       "flag message is not handled"
-x shouldNotImplement.                   "flag message should not be implemented"
-x subclassResponsibility.               "flag message as abstract"
-x errorImproperStore.                   "flag an improper store into indexable object"
-x errorNonIntegerIndex.                 "flag only integers should be used as index"
-x errorSubscriptBounds.                 "flag subscript out of bounds"
-x primitiveFailed.                      "system primitive failed"
+x error: 'Error string'.                "제목이 있는 오류 창 열기"
+x doesNotUnderstand: #cmrMessage.       "메시지가 처리되지 않음을 플래그"
+x shouldNotImplement.                   "메시지가 구현되어서는 안 됨을 플래그"
+x subclassResponsibility.               "메시지를 추상으로 플래그"
+x errorImproperStore.                   "인덱싱 가능한 객체에 대한 부적절한 저장을 플래그"
+x errorNonIntegerIndex.                 "정수만 인덱스로 사용해야 함을 플래그"
+x errorSubscriptBounds.                 "경계 밖의 첨자를 플래그"
+x primitiveFailed.                      "시스템 기본 실패"
 
-a := 'A1'. b := 'B2'. a become: b.      "switch two objects"
+a := 'A1'. b := 'B2'. a become: b.      "두 객체 교환"
 Transcript show: a, b; cr.
 ```
 
-#### Miscellaneous
+#### 기타
 ```smalltalk
 | x |
-x := 1.2 hash.                                  "hash value for object"
-y := x copy.                                    "copy object"
-y := x shallowCopy.                             "copy object (not overridden)"
-y := x deepCopy.                                "copy object and instance vars"
-y := x veryDeepCopy.                            "complete tree copy using a dictionary"
-"Smalltalk condenseChanges."                    "compress the change file"
-x := FillInTheBlank request: 'Prompt Me'.       "prompt user for input"
+x := 1.2 hash.                                  "객체에 대한 해시 값"
+y := x copy.                                    "객체 복사"
+y := x shallowCopy.                             "객체 복사 (재정의되지 않음)"
+y := x deepCopy.                                "객체 및 인스턴스 변수 복사"
+y := x veryDeepCopy.                            "딕셔너리를 사용한 전체 트리 복사"
+"Smalltalk condenseChanges."                    "변경 파일 압축"
+x := FillInTheBlank request: 'Prompt Me'.       "사용자에게 입력 프롬프트"
 Utilities openCommandKeyHelp
 ```
 
-## Ready For More?
+## 더 알아보기
 
-### Online Smalltalk systems
-Most Smalltalks are either free as in OSS or have a free downloadable version with some payment required for commercial usage.
+### 온라인 Smalltalk 시스템
+대부분의 Smalltalk는 OSS로 무료이거나 상업적 사용에 일부 지불이 필요한 무료 다운로드 버전이 있습니다.
 * [Squeak](https://www.squeak.org)
 * [Pharo](http://pharo.org)
 * [Smalltalk/X](https://www.exept.de/en/smalltalk-x.html)
@@ -1031,13 +1031,13 @@ Most Smalltalks are either free as in OSS or have a free downloadable version wi
 * [VA Smalltalk](http://www.instantiations.com/products/vasmalltalk/)
 * [VisualWorks Smalltalk](http://www.cincomsmalltalk.com/)
 
-### Online Smalltalk books and articles
-* [Smalltalk Cheatsheet](http://www.angelfire.com/tx4/cus/notes/smalltalk.html)
-* [Smalltalk-72 Manual](http://www.bitsavers.org/pdf/xerox/parc/techReports/Smalltalk-72_Instruction_Manual_Mar76.pdf)
-* [GNU Smalltalk User's Guide](https://www.gnu.org/software/smalltalk/manual/html_node/Tutorial.html)
+### 온라인 Smalltalk 책 및 기사
+* [Smalltalk 치트 시트](http://www.angelfire.com/tx4/cus/notes/smalltalk.html)
+* [Smalltalk-72 매뉴얼](http://www.bitsavers.org/pdf/xerox/parc/techReports/Smalltalk-72_Instruction_Manual_Mar76.pdf)
+* [GNU Smalltalk 사용자 가이드](https://www.gnu.org/software/smalltalk/manual/html_node/Tutorial.html)
 
-#### Historical Documentation(s)
-* [BYTE: A Special issue on Smalltalk](https://archive.org/details/byte-magazine-1981-08)
-* [Smalltalk-72 Manual](http://www.bitsavers.org/pdf/xerox/parc/techReports/Smalltalk-72_Instruction_Manual_Mar76.pdf)
-* [Smalltalk, Objects, and Design](https://books.google.co.in/books?id=W8_Une9cbbgC&printsec=frontcover&dq=smalltalk&hl=en&sa=X&ved=0CCIQ6AEwAWoVChMIw63Vo6CpyAIV0HGOCh3S2Alf#v=onepage&q=smalltalk&f=false)
-* [Smalltalk: An Introduction to Application Development Using VisualWorks](https://books.google.co.in/books?id=zalQAAAAMAAJ&q=smalltalk&dq=smalltalk&hl=en&sa=X&ved=0CCgQ6AEwAmoVChMIw63Vo6CpyAIV0HGOCh3S2Alf/)
+#### 역사적 문서
+* [BYTE: Smalltalk 특별호](https://archive.org/details/byte-magazine-1981-08)
+* [Smalltalk-72 매뉴얼](http://www.bitsavers.org/pdf/xerox/parc/techReports/Smalltalk-72_Instruction_Manual_Mar76.pdf)
+* [Smalltalk, 객체 및 디자인](https://books.google.co.in/books?id=W8_Une9cbbgC&printsec=frontcover&dq=smalltalk&hl=en&sa=X&ved=0CCIQ6AEwAWoVChMIw63Vo6CpyAIV0HGOCh3S2Alf#v=onepage&q=smalltalk&f=false)
+* [Smalltalk: VisualWorks를 사용한 애플리케이션 개발 소개](https://books.google.co.in/books?id=zalQAAAAMAAJ&q=smalltalk&dq=smalltalk&hl=en&sa=X&ved=0CCgQ6AEwAmoVChMIw63Vo6CpyAIV0HGOCh3S2Alf/)

--- a/ko/stylus.md
+++ b/ko/stylus.md
@@ -10,18 +10,18 @@ translators:
   - ["Divay Prakash", "https://github.com/divayprakash"]
 ---
 
-Stylus is a dynamic stylesheet preprocessor language that is compiled into CSS. It aims to add functionality to CSS without breaking compatibility across web browsers.
-It does this using variables, nesting, mixins, functions and more.
+Stylus는 CSS로 컴파일되는 동적 스타일시트 전처리기 언어입니다. 웹 브라우저 간의 호환성을 깨지 않으면서 CSS에 기능을 추가하는 것을 목표로 합니다.
+변수, 중첩, 믹스인, 함수 등을 사용하여 이를 수행합니다.
 
-Stylus syntax is very flexible. You can use standard CSS syntax and leave the semicolon (;), colon (:) and even the ({) and (}) optional, making your code even more readable.
+Stylus 구문은 매우 유연합니다. 표준 CSS 구문을 사용하고 세미콜론(;), 콜론(:) 및 ({)과 (})를 선택적으로 생략하여 코드를 더욱 읽기 쉽게 만들 수 있습니다.
 
-Stylus does not provide new style options, but gives functionality that lets you make your CSS much more dynamic.
+Stylus는 새로운 스타일 옵션을 제공하지 않지만 CSS를 훨씬 더 동적으로 만들 수 있는 기능을 제공합니다.
 
 ```scss
-/* Code style
+/* 코드 스타일
 ==============================*/
 
-/* Keys, semicolon, and colon are optional in Stylus. */
+/* Stylus에서는 키, 세미콜론 및 콜론이 선택 사항입니다. */
 
 body {
   background: #000;
@@ -44,15 +44,15 @@ body
 body
   background: #000
 
-// Single-line comments are removed when Stylus is compiled into CSS.
+// 한 줄 주석은 Stylus가 CSS로 컴파일될 때 제거됩니다.
 
-/* Multi-line comments are preserved. */
+/* 여러 줄 주석은 유지됩니다. */
 
 
-/* Selectors
+/* 선택자
 ==============================*/
 
-/* Selecting elements within another element */
+/* 다른 요소 내의 요소 선택 */
 body {
   background: #000000;
   h1 {
@@ -60,14 +60,14 @@ body {
   }
 }
 
-/* Or if you prefer... */
+/* 또는 원한다면... */
 body
   background #000000
   h1
     color #FF0000
 
 
-/* Getting parent element reference
+/* 부모 요소 참조 가져오기
 ==============================*/
 a {
   color: #0088dd;
@@ -77,29 +77,29 @@ a {
 }
 
 
-/* Variables
+/* 변수
 ==============================*/
 
 
 /*
-  You can store a CSS value (such as the color) of a variable.
-  Although it is optional, it is recommended to add $ before a variable name
-  so you can distinguish a variable from another CSS value.
+  변수의 CSS 값(예: 색상)을 저장할 수 있습니다.
+  선택 사항이지만 변수 이름 앞에 $를 추가하여
+  변수를 다른 CSS 값과 구별하는 것이 좋습니다.
 */
 
 $primary-color = #A3A4FF
 $secondary-color = #51527F
 $body-font = 'Roboto', sans-serif
 
-/* You can use variables throughout your style sheet.
-Now, if you want to change the color, you only have to make the change once. */
+/* 스타일시트 전체에서 변수를 사용할 수 있습니다.
+이제 색상을 변경하려면 한 번만 변경하면 됩니다. */
 
 body
   background-color $primary-color
   color $secondary-color
   font-family $body-font
 
-/* After compilation: */
+/* 컴파일 후: */
 body {
   background-color: #A3A4FF;
   color: #51527F;
@@ -107,16 +107,16 @@ body {
 }
 
 / *
-This is much easier to maintain than having to change color
-each time it appears throughout your style sheet.
+스타일시트 전체에서 색상이 나타날 때마다 색상을 변경하는 것보다
+유지 관리가 훨씬 쉽습니다.
 * /
 
 
-/* Mixins
+/* 믹스인
 ==============================*/
 
-/* If you find that you are writing the same code for more than one
-element, you may want to store that code in a mixin.
+/* 둘 이상의 요소에 대해 동일한 코드를 작성하고 있다는 것을
+알게 되면 해당 코드를 믹스인에 저장하고 싶을 수 있습니다.
 
 center()
   display block
@@ -125,13 +125,13 @@ center()
   left 0
   right 0
 
-/* Using the mixin */
+/* 믹스인 사용 */
 body {
   center()
   background-color: $primary-color
 }
 
-/* After compilation: */
+/* 컴파일 후: */
 div {
   display: block;
   margin-left: auto;
@@ -141,7 +141,7 @@ div {
   background-color: #A3A4FF;
 }
 
-/* You can use mixins to create a shorthand property. */
+/* 믹스인을 사용하여 약식 속성을 만들 수 있습니다. */
 
 size($width, $height)
   width $width
@@ -153,7 +153,7 @@ size($width, $height)
 .square
   size(40px, 40px)
 
-/* You can use a mixin as a CSS property. */
+/* 믹스인을 CSS 속성으로 사용할 수 있습니다. */
 circle($ratio)
   width $ratio * 2
   height $ratio * 2
@@ -163,7 +163,7 @@ circle($ratio)
   circle 25px
 
 
-/* Interpolation
+/* 보간
 ==============================*/
 
 vendor(prop, args)
@@ -181,16 +181,16 @@ button
   border-radius 1px 2px / 3px 4px
 
 
-/* Functions
+/* 함수
 ==============================*/
 
-/* Functions in Stylus allow you to perform a variety of tasks, such as recalling some data. */
+/* Stylus의 함수를 사용하면 일부 데이터를 다시 호출하는 등 다양한 작업을 수행할 수 있습니다. */
 
 body {
-  background darken(#0088DD, 50%) // Dim color #0088DD by 50%
+  background darken(#0088DD, 50%) // 색상 #0088DD를 50% 어둡게 합니다.
 }
 
-/* Creating your own function */
+/* 자신만의 함수 만들기 */
 add(a, b)
   a + b
 
@@ -198,7 +198,7 @@ body
   padding add(10px, 5)
 
 
-/* Conditions
+/* 조건
 ==============================*/
 compare(a, b)
   if a > b
@@ -213,17 +213,17 @@ compare(1, 5)   // => smaller
 compare(10, 10) // => equal
 
 
-/* Iterations
+/* 반복
 ==============================*/
 
 /*
-Repeat loop syntax for:
+반복 루프 구문:
 for <val-name> [, <key-name>] in <expression>
 */
 
-for $item in (1..2) /* Repeat block 12 times */
+for $item in (1..2) /* 블록 12번 반복 */
   .col-{$item}
-    width ($item / 12) * 100% /* Calculate row by column number */
+    width ($item / 12) * 100% /* 열 번호로 행 계산 */
 ```
 
-Now that you know a little about this powerful CSS preprocessor, you're ready to create more dynamic style sheets. To learn more, visit the official stylus documentation at [stylus-lang.com](https://stylus-lang.com).
+이제 이 강력한 CSS 전처리기에 대해 조금 알았으니 더 동적인 스타일 시트를 만들 준비가 되었습니다. 더 자세히 알아보려면 공식 스타일러스 문서 [stylus-lang.com](https://stylus-lang.com)을 방문하십시오.

--- a/ko/swift.md
+++ b/ko/swift.md
@@ -14,80 +14,80 @@ contributors:
 filename: learnswift.swift
 ---
 
-Swift is a programming language created by Apple for development across all Apple operating systems. Designed to coexist with Objective-C while being more resilient against erroneous code, Swift was introduced in 2014 at Apple's developer conference WWDC. It features automatic memory management, type safety, and modern syntax that makes code more readable and less error-prone.
+Swift는 모든 Apple 운영 체제에서 개발하기 위해 Apple이 만든 프로그래밍 언어입니다. 오류가 있는 코드에 대해 더 탄력적이면서 Objective-C와 공존하도록 설계된 Swift는 2014년 Apple의 개발자 컨퍼런스 WWDC에서 소개되었습니다. 자동 메모리 관리, 타입 안전성 및 코드를 더 읽기 쉽고 오류가 적게 만드는 현대적인 구문을 특징으로 합니다.
 
-Swift is open source and also runs on Linux and Windows. The language is built with the LLVM compiler and is included in Xcode.
+Swift는 오픈 소스이며 Linux 및 Windows에서도 실행됩니다. 이 언어는 LLVM 컴파일러로 빌드되었으며 Xcode에 포함되어 있습니다.
 
-The official reference is *The Swift Programming Language* guide, available at [docs.swift.org](https://docs.swift.org/swift-book/documentation/the-swift-programming-language). This comprehensive guide is regularly updated with the latest Swift features and is the recommended starting point for learning the language.
+공식 참조는 [docs.swift.org](https://docs.swift.org/swift-book/documentation/the-swift-programming-language)에서 제공되는 *The Swift Programming Language* 가이드입니다. 이 포괄적인 가이드는 최신 Swift 기능으로 정기적으로 업데이트되며 언어를 배우기 위한 권장 시작점입니다.
 
 ```swift
-// import a module
+// 모듈 가져오기
 import Foundation
 
-// Single-line comments are prefixed with //
-// Multi-line comments start with /* and end with */
-/* Nested multiline comments
- /* ARE */
- allowed
+// 한 줄 주석은 //로 시작합니다.
+// 여러 줄 주석은 /*로 시작하여 */로 끝납니다.
+/* 중첩된 여러 줄 주석
+ /* 은 */
+ 허용됩니다.
  */
 
-// Xcode supports landmarks to annotate your code and lists them in the jump bar
-// MARK: Section mark
-// MARK: - Section mark with a separator line
-// TODO: Do something soon
-// FIXME: Fix this code
+// Xcode는 코드에 주석을 달고 점프 바에 나열하는 랜드마크를 지원합니다.
+// MARK: 섹션 마크
+// MARK: - 구분선이 있는 섹션 마크
+// TODO: 곧 무언가 해야 함
+// FIXME: 이 코드 수정
 
 //MARK: Hello, World
-// From Swift 3 on, to print, just use the `print` method.
-// It automatically appends a new line.
+// Swift 3부터는 `print` 메서드를 사용하여 출력합니다.
+// 자동으로 새 줄을 추가합니다.
 print("Hello, world")
 
 //
-// MARK: - Variables
+// MARK: - 변수
 //
 
 
-//Use `let` to declare a constant and `var` to declare a variable.
+//상수를 선언하려면 `let`을, 변수를 선언하려면 `var`를 사용합니다.
 let theAnswer = 42
 var theQuestion = "What is the Answer?"
 theQuestion = "How many roads must a man walk down?"
 theQuestion = "What is six by nine?"
-// Atttempting to reassign a constant throws a compile-time error
+// 상수를 재할당하려고 하면 컴파일 타임 오류가 발생합니다.
 //theAnswer = 54
 
-// Both variables and constants can be declared before they are given a value,
-//   but must be given a value before they are used
+// 변수와 상수 모두 값을 할당하기 전에 선언할 수 있지만,
+// 사용하기 전에 값을 할당해야 합니다.
 let someConstant: Int
 var someVariable: String
-// These lines will throw errors:
+// 이 줄은 오류를 발생시킵니다.
 //print(someConstant)
 //print(someVariable)
 someConstant = 0
 someVariable = "0"
-// These lines are now valid:
+// 이 줄은 이제 유효합니다.
 print(someConstant)
 print(someVariable)
 
-// As you can see above, variable types are automatically inferred.
-//   To explicitly declare the type, write it after the variable name,
-//   separated by a colon.
+// 위에서 볼 수 있듯이 변수 타입은 자동으로 추론됩니다.
+// 타입을 명시적으로 선언하려면 변수 이름 뒤에
+// 콜론으로 구분하여 작성합니다.
 let aString: String = "A string"
 let aDouble: Double = 0
 
-// Values are never implicitly converted to another type.
-// Explicitly make instances of the desired type.
+// 값은 다른 타입으로 암시적으로 변환되지 않습니다.
+// 원하는 타입의 인스턴스를 명시적으로 만듭니다.
 let stringWithDouble = aString + String(aDouble)
 let intFromDouble = Int(aDouble)
 
-// For strings, use string interpolation
+// 문자열의 경우 문자열 보간을 사용합니다.
 let descriptionString = "The value of aDouble is \(aDouble)"
-// You can put any expression inside string interpolation.
+// 문자열 보간 안에 모든 표현식을 넣을 수 있습니다.
 let equation = "Six by nine is \(6 * 9), not 42!"
-// To avoid escaping double quotes and backslashes, change the string delimiter
+// 큰따옴표와 백슬래시 이스케이프를 피하려면 문자열 구분 기호를 변경하십시오.
 let explanationString = #"The string I used was "The value of aDouble is \(aDouble)" and the result was \#(descriptionString)"#
-// You can put as many number signs as you want before the opening quote,
-//   just match them at the ending quote. They also change the escape character
-//   to a backslash followed by the same number of number signs.
+// 여는 따옴표 앞에 원하는 만큼 숫자 기호를 넣을 수 있습니다.
+// 닫는 따옴표에서 일치시키기만 하면 됩니다. 또한 이스케이프 문자를
+// 백슬래시 뒤에 동일한 수의 숫자 기호로 변경합니다.
 
 let multiLineString = """
     This is a multi-line string.
@@ -96,173 +96,173 @@ let multiLineString = """
     You can include " or "" in multi-line strings because the delimiter is three "s.
     """
 
-// Arrays
-let shoppingList = ["catfish", "water", "tulips",] //commas are allowed after the last element
-let secondElement = shoppingList[1] // Arrays are 0-indexed
+// 배열
+let shoppingList = ["catfish", "water", "tulips",] //마지막 요소 뒤에 쉼표를 허용합니다.
+let secondElement = shoppingList[1] // 배열은 0부터 인덱싱됩니다.
 
-// Arrays declared with let are immutable; the following line throws a compile-time error
+// let으로 선언된 배열은 불변입니다. 다음 줄은 컴파일 타임 오류를 발생시킵니다.
 //shoppingList[2] = "mango"
 
-// Arrays are structs (more on that later), so this creates a copy instead of referencing the same object
+// 배열은 구조체이므로(나중에 자세히 설명), 동일한 객체를 참조하는 대신 복사본을 만듭니다.
 var mutableShoppingList = shoppingList
 mutableShoppingList[2] = "mango"
 
-// == is equality
+// ==는 동등성입니다.
 shoppingList == mutableShoppingList // false
 
-// Dictionaries declared with let are also immutable
+// let으로 선언된 딕셔너리도 불변입니다.
 var occupations = [
     "Malcolm": "Captain",
     "Kaylee": "Mechanic"
 ]
 occupations["Jayne"] = "Public Relations"
-// Dictionaries are also structs, so this also creates a copy
+// 딕셔너리도 구조체이므로 이것도 복사본을 만듭니다.
 let immutableOccupations = occupations
 
 immutableOccupations == occupations // true
 
-// Arrays and dictionaries both automatically grow as you add elements
+// 배열과 딕셔너리는 모두 요소를 추가하면 자동으로 커집니다.
 mutableShoppingList.append("blue paint")
 occupations["Tim"] = "CEO"
 
-// They can both be set to empty
+// 둘 다 비울 수 있습니다.
 mutableShoppingList = []
 occupations = [:]
 
 let emptyArray = [String]()
-let emptyArray2 = Array<String>() // same as above
-// [T] is shorthand for Array<T>
-let emptyArray3: [String] = [] // Declaring the type explicitly allows you to set it to an empty array
-let emptyArray4: Array<String> = [] // same as above
+let emptyArray2 = Array<String>() // 위와 동일
+// [T]는 Array<T>의 약어입니다.
+let emptyArray3: [String] = [] // 타입을 명시적으로 선언하면 빈 배열로 설정할 수 있습니다.
+let emptyArray4: Array<String> = [] // 위와 동일
 
-// [Key: Value] is shorthand for Dictionary<Key, Value>
+// [Key: Value]는 Dictionary<Key, Value>의 약어입니다.
 let emptyDictionary = [String: Double]()
-let emptyDictionary2 = Dictionary<String, Double>() // same as above
+let emptyDictionary2 = Dictionary<String, Double>() // 위와 동일
 var emptyMutableDictionary: [String: Double] = [:]
-var explicitEmptyMutableDictionary: Dictionary<String, Double> = [:] // same as above
+var explicitEmptyMutableDictionary: Dictionary<String, Double> = [:] // 위와 동일
 
-// MARK: Other variables
-let øπΩ = "value" // unicode variable names
-let 🤯 = "wow" // emoji variable names
+// MARK: 기타 변수
+let øπΩ = "value" // 유니코드 변수 이름
+let 🤯 = "wow" // 이모티콘 변수 이름
 
-// Keywords can be used as variable names
-// These are contextual keywords that wouldn't be used now, so are allowed
+// 키워드를 변수 이름으로 사용할 수 있습니다.
+// 이것들은 지금 사용되지 않는 문맥 키워드이므로 허용됩니다.
 let convenience = "keyword"
 let weak = "another keyword"
 let override = "another keyword"
 
-// Using backticks allows keywords to be used as variable names even if they wouldn't be allowed normally
+// 백틱을 사용하면 일반적으로 허용되지 않는 경우에도 키워드를 변수 이름으로 사용할 수 있습니다.
 let `class` = "keyword"
 
-// MARK: - Optionals
+// MARK: - 옵셔널
 
 /*
- Optionals are a Swift language feature that either contains a value,
- or contains nil (no value) to indicate that a value is missing.
- Nil is roughly equivalent to `null` in other languages.
- A question mark (?) after the type marks the value as optional of that type.
+ 옵셔널은 값이 있거나 값이 없음을 나타내는 nil(값 없음)을
+ 포함하는 Swift 언어 기능입니다.
+ Nil은 다른 언어의 `null`과 거의 동일합니다.
+ 타입 뒤의 물음표(?)는 해당 타입의 옵셔널 값으로 표시합니다.
 
- If a type is not optional, it is guaranteed to have a value.
+ 타입이 옵셔널이 아닌 경우 값이 보장됩니다.
 
- Because Swift requires every property to have a type, even nil must be
- explicitly stored as an Optional value.
+ Swift는 모든 속성에 타입이 있어야 하므로 nil조차도
+ 명시적으로 옵셔널 값으로 저장해야 합니다.
 
- Optional<T> is an enum, with the cases .none (nil) and .some(T) (the value)
+ Optional<T>는 .none (nil)과 .some(T) (값) 케이스가 있는 열거형입니다.
  */
 
-var someOptionalString: String? = "optional" // Can be nil
-// T? is shorthand for Optional<T> — ? is a postfix operator (syntax candy)
+var someOptionalString: String? = "optional" // nil일 수 있음
+// T?는 Optional<T>의 약어입니다. — ?는 후위 연산자입니다 (구문 설탕)
 let someOptionalString2: Optional<String> = nil
-let someOptionalString3 = String?.some("optional") // same as the first one
+let someOptionalString3 = String?.some("optional") // 첫 번째와 동일
 let someOptionalString4 = String?.none //nil
 
 /*
- To access the value of an optional that has a value, use the postfix
- operator !, which force-unwraps it. Force-unwrapping is like saying, "I
- know that this optional definitely has a value, please give it to me."
+ 값이 있는 옵셔널의 값에 액세스하려면 후위 연산자 !를
+ 사용하여 강제 언래핑합니다. 강제 언래핑은 "이 옵셔널에
+ 확실히 값이 있다는 것을 알고 있으니 주세요"라고 말하는 것과 같습니다.
 
- Trying to use ! to access a non-existent optional value triggers a
- runtime error. Always make sure that an optional contains a non-nil
- value before using ! to force-unwrap its value.
+ !를 사용하여 존재하지 않는 옵셔널 값에 액세스하려고 하면
+ 런타임 오류가 발생합니다. !를 사용하여 값을 강제 언래핑하기 전에
+ 항상 옵셔널에 nil이 아닌 값이 포함되어 있는지 확인하십시오.
  */
 
 if someOptionalString != nil {
-    // I am not nil
+    // nil이 아님
     if someOptionalString!.hasPrefix("opt") {
         print("has the prefix")
     }
 }
 
-// Swift supports "optional chaining," which means that you can call functions
-//   or get properties of optional values and they are optionals of the appropriate type.
-// You can even do this multiple times, hence the name "chaining."
+// Swift는 "옵셔널 체이닝"을 지원합니다. 즉, 옵셔널 값의 함수를
+// 호출하거나 속성을 가져올 수 있으며 적절한 타입의 옵셔널이 됩니다.
+// 이 작업을 여러 번 수행할 수 있으므로 "체이닝"이라는 이름이 붙었습니다.
 
 let empty = someOptionalString?.isEmpty // Bool?
 
-// if-let structure -
-// if-let is a special structure in Swift that allows you to check
-//   if an Optional rhs holds a value, and if it does unwrap
-//   and assign it to the lhs.
+// if-let 구조 -
+// if-let은 Swift의 특별한 구조로, 옵셔널 rhs에
+// 값이 있는지 확인하고, 있으면 언래핑하여
+// lhs에 할당할 수 있습니다.
 if let someNonOptionalStringConstant = someOptionalString {
-    // has `Some` value, non-nil
-    // someOptionalStringConstant is of type String, not type String?
+    // `Some` 값이 있음, nil이 아님
+    // someOptionalStringConstant는 String? 타입이 아닌 String 타입입니다.
     if !someNonOptionalStringConstant.hasPrefix("ok") {
-        // does not have the prefix
+        // 접두사가 없음
     }
 }
 
-//if-var is allowed too!
+//if-var도 허용됩니다!
 if var someNonOptionalString = someOptionalString {
     someNonOptionalString = "Non optional AND mutable"
     print(someNonOptionalString)
 }
 
-// You can bind multiple optional values in one if-let statement.
-//   If any of the bound values are nil, the if statement does not execute.
+// 하나의 if-let 문에서 여러 옵셔널 값을 바인딩할 수 있습니다.
+// 바인딩된 값 중 하나라도 nil이면 if 문이 실행되지 않습니다.
 if let first = someOptionalString, let second = someOptionalString2,
     let third = someOptionalString3, let fourth = someOptionalString4 {
     print("\(first), \(second), \(third), and \(fourth) are all not nil")
 }
 
-//if-let supports "," (comma) clauses, which can be used to
-//   enforce conditions on newly-bound optional values.
-// Both the assignment and the "," clause must pass.
+//if-let은 ","(쉼표) 절을 지원하며, 이는 새로 바인딩된
+// 옵셔널 값에 대한 조건을 강제하는 데 사용할 수 있습니다.
+// 할당과 "," 절 모두 통과해야 합니다.
 let someNumber: Int? = 7
 if let num = someNumber, num > 3 {
     print("num is not nil and is greater than 3")
 }
 
-// Implicitly unwrapped optional — An optional value that doesn't need to be unwrapped
+// 암시적으로 언래핑된 옵셔널 — 언래핑할 필요가 없는 옵셔널 값
 let unwrappedString: String! = "Value is expected."
 
-// Here's the difference:
-let forcedString = someOptionalString! // requires an exclamation mark
-let implicitString = unwrappedString // doesn't require an exclamation mark
+// 차이점은 다음과 같습니다.
+let forcedString = someOptionalString! // 느낌표 필요
+let implicitString = unwrappedString // 느낌표 필요 없음
 
 /*
- You can think of an implicitly unwrapped optional as giving permission
- for the optional to be unwrapped automatically whenever it's used.
- Rather than placing an exclamation mark after the optional's name each time you use it,
- you place an exclamation mark after the optional's type when you declare it.
+ 암시적으로 언래핑된 옵셔널은 사용될 때마다 자동으로
+ 언래핑되도록 허용하는 것으로 생각할 수 있습니다.
+ 사용할 때마다 옵셔널 이름 뒤에 느낌표를 붙이는 대신,
+ 선언할 때 옵셔널 타입 뒤에 느낌표를 붙입니다.
  */
 
-// Otherwise, you can treat an implicitly unwrapped optional the same way the you treat a normal optional
-//   (i.e., if-let, != nil, etc.)
+// 그렇지 않으면 암시적으로 언래핑된 옵셔널을 일반 옵셔널과 동일하게
+// 취급할 수 있습니다 (예: if-let, != nil 등).
 
-// Pre-Swift 5, T! was shorthand for ImplicitlyUnwrappedOptional<T>
-// Swift 5 and later, using ImplicitlyUnwrappedOptional throws a compile-time error.
-//var unwrappedString2: ImplicitlyUnwrappedOptional<String> = "Value is expected." //error
+// Swift 5 이전에는 T!가 ImplicitlyUnwrappedOptional<T>의 약어였습니다.
+// Swift 5 이상에서는 ImplicitlyUnwrappedOptional을 사용하면 컴파일 타임 오류가 발생합니다.
+//var unwrappedString2: ImplicitlyUnwrappedOptional<String> = "Value is expected." //오류
 
-// The nil-coalescing operator ?? unwraps an optional if it contains a non-nil value, or returns a default value.
+// nil 병합 연산자 ??는 옵셔널이 nil이 아닌 값을 포함하는 경우 언래핑하거나 기본값을 반환합니다.
 someOptionalString = nil
 let someString = someOptionalString ?? "abc"
 print(someString) // abc
-// a ?? b is shorthand for a != nil ? a! : b
+// a ?? b는 a != nil ? a! : b의 약어입니다.
 
-// MARK: - Control Flow
+// MARK: - 제어 흐름
 
 let condition = true
-if condition { print("condition is true") } // can't omit the braces
+if condition { print("condition is true") } // 중괄호를 생략할 수 없음
 
 if theAnswer > 50 {
     print("theAnswer > 50")
@@ -272,121 +272,121 @@ if theAnswer > 50 {
     print("Neither are true")
 }
 
-// The condition in an `if` statement must be a `Bool`, so the following code is an error, not an implicit comparison to zero
+// `if` 문의 조건은 `Bool`이어야 하므로 다음 코드는 오류이며, 0과 암시적으로 비교되지 않습니다.
 //if 5 {
 //    print("5 is not zero")
 //}
 
 // Switch
-// Must be exhaustive
-// Does not implicitly fall through, use the fallthrough keyword
-// Very powerful, think `if` statements with syntax candy
-// They support String, object instances, and primitives (Int, Double, etc)
+// 철저해야 함
+// 암시적으로 fall through하지 않음, fallthrough 키워드 사용
+// 매우 강력함, `if` 문에 구문 설탕을 더한 것으로 생각
+// String, 객체 인스턴스 및 기본 타입(Int, Double 등) 지원
 let vegetable = "red pepper"
 let vegetableComment: String
 switch vegetable {
 case "celery":
     vegetableComment = "Add some raisins and make ants on a log."
-case "cucumber", "watercress": // match multiple values
+case "cucumber", "watercress": // 여러 값 일치
     vegetableComment = "That would make a good tea sandwich."
 case let localScopeValue where localScopeValue.hasSuffix("pepper"):
     vegetableComment = "Is it a spicy \(localScopeValue)?"
-default: // required (in order to cover all possible input)
+default: // 필수 (모든 가능한 입력을 처리하기 위해)
     vegetableComment = "Everything tastes good in soup."
 }
 print(vegetableComment)
 
-// You use the `for-in` loop to iterate over a sequence, such as an array, dictionary, range, etc.
+// `for-in` 루프를 사용하여 배열, 딕셔너리, 범위 등과 같은 시퀀스를 반복합니다.
 for element in shoppingList {
-    print(element) // shoppingList is of type `[String]`, so element is of type `String`
+    print(element) // shoppingList는 `[String]` 타입이므로 element는 `String` 타입입니다.
 }
-//Iterating through a dictionary does not guarantee any specific order
+//딕셔너리를 반복해도 특정 순서가 보장되지 않습니다.
 for (person, job) in immutableOccupations {
     print("\(person)'s job is \(job)")
 }
 for i in 1...5 {
-    print(i, terminator: " ") // Prints "1 2 3 4 5"
+    print(i, terminator: " ") // "1 2 3 4 5" 출력
 }
 for i in 0..<5 {
-    print(i, terminator: " ") // Prints "0 1 2 3 4"
+    print(i, terminator: " ") // "0 1 2 3 4" 출력
 }
-//for index in range can replace a C-style for loop:
+//for index in range는 C 스타일 for 루프를 대체할 수 있습니다.
 //    for (int i = 0; i < 10; i++) {
-//        //code
+//        //코드
 //    }
-//becomes:
+//는 다음과 같습니다.
 //    for i in 0..<10 {
-//        //code
+//        //코드
 //    }
-//To step by more than one, use the stride(from:to:by:) or stride(from:through:by) functions
-//`for i in stride(from: 0, to: 10, by: 2)` is the same as `for (int i = 0; i < 10; i += 2)`
-//`for i in stride(from: 0, through: 10, by: 2)` is the same as `for (int i = 0; i <= 10; i += 2)
+//1보다 큰 단계로 이동하려면 stride(from:to:by:) 또는 stride(from:through:by) 함수를 사용합니다.
+//`for i in stride(from: 0, to: 10, by: 2)`는 `for (int i = 0; i < 10; i += 2)`와 동일합니다.
+//`for i in stride(from: 0, through: 10, by: 2)`는 `for (int i = 0; i <= 10; i += 2)`와 동일합니다.
 
-// while loops are just like most languages
+// while 루프는 대부분의 언어와 같습니다.
 var i = 0
 while i < 5 {
     i += Bool.random() ? 1 : 0
     print(i)
 }
 
-// This is like a do-while loop in other languages — the body of the loop executes a minimum of once
+// 이것은 다른 언어의 do-while 루프와 같습니다. — 루프의 본문은 최소 한 번 실행됩니다.
 repeat {
     i -= 1
     i += Int.random(in: 0...3)
 } while i < 5
 
-// The continue statement continues executing a loop at the next iteration
-// The break statement ends a loop immediately
+// continue 문은 다음 반복에서 루프를 계속 실행합니다.
+// break 문은 루프를 즉시 종료합니다.
 
-// MARK: - Functions
+// MARK: - 함수
 
-// Functions are a first-class type, meaning they can be nested in functions and can be passed around.
+// 함수는 일급 타입이므로 함수에 중첩될 수 있으며 전달될 수 있습니다.
 
-// Function with Swift header docs (format as Swift-modified Markdown syntax)
+// Swift 헤더 문서가 있는 함수 (Swift 수정 마크다운 구문으로 서식 지정)
 
-/// A greet operation.
+/// 인사 작업입니다.
 ///
-/// - Parameters:
-///   - name: A name.
-///   - day: A day.
-/// - Returns: A string containing the name and day value.
+/// - 매개변수:
+///   - name: 이름입니다.
+///   - day: 요일입니다.
+/// - 반환값: 이름과 요일 값을 포함하는 문자열입니다.
 func greet(name: String, day: String) -> String {
     return "Hello \(name), today is \(day)."
 }
 greet(name: "Bob", day: "Tuesday")
 
-// Ideally, function names and parameter labels combine to make function calls similar to sentences.
+// 이상적으로는 함수 이름과 매개변수 레이블이 결합되어 문장과 유사한 함수 호출을 만듭니다.
 func sayHello(to name: String, onDay day: String) -> String {
     return "Hello \(name), the day is \(day)"
 }
 sayHello(to: "John", onDay: "Sunday")
 
-//Functions that don't return anything can omit the return arrow; they don't need to say that they return Void (although they can).
+//아무것도 반환하지 않는 함수는 반환 화살표를 생략할 수 있습니다. Void를 반환한다고 말할 필요가 없습니다(물론 가능합니다).
 func helloWorld() {
     print("Hello, World!")
 }
 
-// Argument labels can be blank
+// 인수 레이블은 비워 둘 수 있습니다.
 func say(_ message: String) {
     print(#"I say "\#(message)""#)
 }
 say("Hello")
 
-// Default parameters can be omitted when calling the function.
+// 기본 매개변수는 함수를 호출할 때 생략할 수 있습니다.
 func printParameters(requiredParameter r: Int, optionalParameter o: Int = 10) {
     print("The required parameter was \(r) and the optional parameter was \(o)")
 }
 printParameters(requiredParameter: 3)
 printParameters(requiredParameter: 3, optionalParameter: 6)
 
-// Variadic args — only one set per function.
+// 가변 인자 — 함수당 한 세트만.
 func setup(numbers: Int...) {
-    // it's an array
+    // 배열입니다.
     let _ = numbers[0]
     let _ = numbers.count
 }
 
-// pass by ref
+// 참조에 의한 전달
 func swapTwoInts(a: inout Int, b: inout Int) {
     let tempA = a
     a = b
@@ -394,13 +394,13 @@ func swapTwoInts(a: inout Int, b: inout Int) {
 }
 var someIntA = 7
 var someIntB = 3
-swapTwoInts(a: &someIntA, b: &someIntB) //must be called with an & before the variable name.
+swapTwoInts(a: &someIntA, b: &someIntB) //변수 이름 앞에 &를 붙여 호출해야 합니다.
 print(someIntB) // 7
 
 type(of: greet) // (String, String) -> String
 type(of: helloWorld) // () -> Void
 
-// Passing and returning functions
+// 함수 전달 및 반환
 func makeIncrementer() -> ((Int) -> Int) {
     func addOne(number: Int) -> Int {
         return 1 + number
@@ -415,18 +415,18 @@ func performFunction(_ function: (String, String) -> String, on string1: String,
     print("The result of calling the function on \(string1) and \(string2) was \(result)")
 }
 
-// Function that returns multiple items in a tuple
+// 튜플로 여러 항목을 반환하는 함수
 func getGasPrices() -> (Double, Double, Double) {
     return (3.59, 3.69, 3.79)
 }
 let pricesTuple = getGasPrices()
 let price = pricesTuple.2 // 3.79
-// Ignore Tuple (or other) values by using _ (underscore)
+// _ (밑줄)을 사용하여 튜플(또는 다른) 값 무시
 let (_, price1, _) = pricesTuple // price1 == 3.69
 print(price1 == pricesTuple.1) // true
 print("Gas price: \(price)")
 
-// Labeled/named tuple params
+// 레이블/이름이 있는 튜플 매개변수
 func getGasPrices2() -> (lowestPrice: Double, highestPrice: Double, midPrice: Double) {
     return (1.77, 37.70, 7.37)
 }
@@ -436,57 +436,57 @@ let (_, price3, _) = pricesTuple2
 print(pricesTuple2.highestPrice == pricesTuple2.1) // true
 print("Highest gas price: \(pricesTuple2.highestPrice)")
 
-// guard statements
+// guard 문
 func testGuard() {
-    // guards provide early exits or breaks, placing the error handler code near the conditions.
-    // it places variables it declares in the same scope as the guard statement.
-    // They make it easier to avoid the "pyramid of doom"
+    // guard는 조기 종료 또는 중단을 제공하여 오류 처리 코드를 조건에 가깝게 배치합니다.
+    // 선언하는 변수를 guard 문과 동일한 범위에 배치합니다.
+    // "파멸의 피라미드"를 피하기 쉽게 만듭니다.
     guard let aNumber = Optional<Int>(7) else {
-        return // guard statements MUST exit the scope that they are in.
-        // They generally use `return` or `throw`.
+        return // guard 문은 반드시 있는 범위를 종료해야 합니다.
+        // 일반적으로 `return` 또는 `throw`를 사용합니다.
     }
 
     print("number is \(aNumber)")
 }
 testGuard()
 
-// Note that the print function is declared like so:
+// print 함수는 다음과 같이 선언됩니다.
 //     func print(_ input: Any..., separator: String = " ", terminator: String = "\n")
-// To print without a newline:
+// 줄 바꿈 없이 출력하려면:
 print("No newline", terminator: "")
 print("!")
 
-// MARK: - Closures
+// MARK: - 클로저
 
 var numbers = [1, 2, 6]
 
-// Functions are special case closures ({})
+// 함수는 특수한 경우의 클로저({})입니다.
 
-// Closure example.
-// `->` separates the arguments and return type
-// `in` separates the closure header from the closure body
+// 클로저 예제.
+// `->`는 인수와 반환 타입을 구분합니다.
+// `in`은 클로저 헤더와 클로저 본문을 구분합니다.
 numbers.map({
     (number: Int) -> Int in
     let result = 3 * number
     return result
 })
 
-// When the type is known, like above, we can do this
+// 위와 같이 타입이 알려진 경우 다음과 같이 할 수 있습니다.
 numbers = numbers.map({ number in 3 * number })
-// Or even this
+// 또는 이렇게도 할 수 있습니다.
 //numbers = numbers.map({ $0 * 3 })
 
 print(numbers) // [3, 6, 18]
 
-// Trailing closure
+// 후행 클로저
 numbers = numbers.sorted { $0 > $1 }
 
 print(numbers) // [18, 6, 3]
 
-// MARK: - Enums
+// MARK: - 열거형
 
-// Enums can optionally be of a specific type or on their own.
-// They can contain methods like classes.
+// 열거형은 선택적으로 특정 타입이거나 자체적으로 있을 수 있습니다.
+// 클래스처럼 메서드를 포함할 수 있습니다.
 
 enum Suit {
     case spades, hearts, diamonds, clubs
@@ -504,12 +504,13 @@ enum Suit {
     }
 }
 
-// Enum values allow short hand syntax, no need to type the enum type
-// when the variable is explicitly declared
+// 열거형 값은 약식 구문을 허용하며, 변수가 명시적으로
+// 선언된 경우 열거형 타입을 입력할 필요가 없습니다.
 var suitValue: Suit = .hearts
 
-// Conforming to the CaseIterable protocol automatically synthesizes the allCases property,
-//   which contains all the values. It works on enums without associated values or @available attributes.
+// CaseIterable 프로토콜을 준수하면 모든 값을 포함하는
+// allCases 속성이 자동으로 합성됩니다.
+// 연관된 값이나 @available 속성이 없는 열거형에서 작동합니다.
 enum Rank: CaseIterable {
     case ace
     case two, three, four, five, six, seven, eight, nine, ten
@@ -552,23 +553,23 @@ for suit in [Suit.clubs, .diamonds, .hearts, .spades] {
     }
 }
 
-// String enums can have direct raw value assignments
-// or their raw values will be derived from the Enum field
+// 문자열 열거형은 직접적인 원시 값 할당을 가질 수 있거나
+// 원시 값은 열거형 필드에서 파생됩니다.
 enum BookName: String {
     case john
     case luke = "Luke"
 }
 print("Name: \(BookName.john.rawValue)")
 
-// Enum with associated Values
+// 연관된 값이 있는 열거형
 enum Furniture {
-    // Associate with Int
+    // Int와 연관
     case desk(height: Int)
-    // Associate with String and Int
+    // String 및 Int와 연관
     case chair(String, Int)
 
     func description() -> String {
-        //either placement of let is acceptable
+        // let의 두 위치 모두 허용됩니다.
         switch self {
         case .desk(let height):
             return "Desk with \(height) cm"
@@ -583,45 +584,45 @@ print(desk.description())     // "Desk with 80 cm"
 var chair = Furniture.chair("Foo", 40)
 print(chair.description())    // "Chair of Foo with 40 cm"
 
-// MARK: - Structures & Classes
+// MARK: - 구조체 및 클래스
 
 /*
- Structures and classes in Swift have many things in common. Both can:
- - Define properties to store values
- - Define methods to provide functionality
- - Define subscripts to provide access to their values using subscript syntax
- - Define initializers to set up their initial state
- - Be extended to expand their functionality beyond a default implementation
- - Conform to protocols to provide standard functionality of a certain kind
+ Swift의 구조체와 클래스는 많은 공통점을 가지고 있습니다. 둘 다 다음을 할 수 있습니다.
+ - 값을 저장하기 위한 속성 정의
+ - 기능을 제공하기 위한 메서드 정의
+ - 첨자 구문을 사용하여 값에 액세스하기 위한 첨자 정의
+ - 초기 상태를 설정하기 위한 초기화자 정의
+ - 기본 구현을 넘어 기능을 확장하기 위해 확장
+ - 특정 종류의 표준 기능을 제공하기 위해 프로토콜 준수
 
- Classes have additional capabilities that structures don't have:
- - Inheritance enables one class to inherit the characteristics of another.
- - Type casting enables you to check and interpret the type of a class instance at runtime.
- - Deinitializers enable an instance of a class to free up any resources it has assigned.
- - Reference counting allows more than one reference to a class instance.
+ 클래스는 구조체에 없는 추가 기능을 가지고 있습니다.
+ - 상속을 통해 한 클래스가 다른 클래스의 특성을 상속할 수 있습니다.
+ - 타입 캐스팅을 통해 런타임에 클래스 인스턴스의 타입을 확인하고 해석할 수 있습니다.
+ - 소멸자를 통해 클래스 인스턴스가 할당한 모든 리소스를 해제할 수 있습니다.
+ - 참조 계산을 통해 클래스 인스턴스에 대한 참조가 둘 이상 있을 수 있습니다.
 
- Unless you need to use a class for one of these reasons, use a struct.
+ 이러한 이유 중 하나로 클래스를 사용해야 하는 경우가 아니라면 구조체를 사용하십시오.
 
- Structures are value types, while classes are reference types.
+ 구조체는 값 타입이고 클래스는 참조 타입입니다.
  */
 
-// MARK: Structures
+// MARK: 구조체
 
 struct NamesTable {
     let names: [String]
 
-    // Custom subscript
+    // 사용자 정의 첨자
     subscript(index: Int) -> String {
         return names[index]
     }
 }
 
-// Structures have an auto-generated (implicit) designated "memberwise" initializer
+// 구조체에는 자동 생성된(암시적) 지정된 "멤버별" 초기화자가 있습니다.
 let namesTable = NamesTable(names: ["Me", "Them"])
 let name = namesTable[1]
 print("Name is \(name)") // Name is Them
 
-// MARK: Classes
+// MARK: 클래스
 
 class Shape {
     func getArea() -> Int {
@@ -632,31 +633,31 @@ class Shape {
 class Rect: Shape {
     var sideLength: Int = 1
 
-    // Custom getter and setter property
+    // 사용자 정의 getter 및 setter 속성
     var perimeter: Int {
         get {
             return 4 * sideLength
         }
         set {
-            // `newValue` is an implicit variable available to setters
+            // `newValue`는 setter에서 사용할 수 있는 암시적 변수입니다.
             sideLength = newValue / 4
         }
     }
 
-    // Computed properties must be declared as `var`, you know, cause' they can change
+    // 계산된 속성은 변경될 수 있으므로 `var`로 선언해야 합니다.
     var smallestSideLength: Int {
         return self.sideLength - 1
     }
 
-    // Lazily load a property
-    // subShape remains nil (uninitialized) until getter called
+    // 속성을 지연 로드합니다.
+    // subShape는 getter가 호출될 때까지 nil(초기화되지 않음)으로 유지됩니다.
     lazy var subShape = Rect(sideLength: 4)
 
-    // If you don't need a custom getter and setter,
-    // but still want to run code before and after getting or setting
-    // a property, you can use `willSet` and `didSet`
+    // 사용자 정의 getter 및 setter가 필요하지 않지만
+    // 속성을 가져오거나 설정하기 전후에 코드를 실행하려면
+    // `willSet` 및 `didSet`을 사용할 수 있습니다.
     var identifier: String = "defaultID" {
-        // the `someIdentifier` arg will be the variable name for the new value
+        // `someIdentifier` 인수는 새 값의 변수 이름이 됩니다.
         willSet(someIdentifier) {
             print(someIdentifier)
         }
@@ -664,7 +665,7 @@ class Rect: Shape {
 
     init(sideLength: Int) {
         self.sideLength = sideLength
-        // always super.init last when init custom properties
+        // 사용자 정의 속성을 초기화할 때 항상 super.init을 마지막에 호출합니다.
         super.init()
     }
 
@@ -679,11 +680,11 @@ class Rect: Shape {
     }
 }
 
-// A simple class `Square` extends `Rect`
+// 간단한 클래스 `Square`는 `Rect`를 확장합니다.
 class Square: Rect {
-    // Use a convenience initializer to make calling a designated initializer faster and more "convenient".
-    // Convenience initializers call other initializers in the same class and pass default values to one or more of their parameters.
-    // Convenience initializers can have parameters as well, which are useful to customize the called initializer parameters or choose a proper initializer based on the value passed.
+    // 편의 초기화자를 사용하여 지정된 초기화자를 더 빠르고 "편리하게" 호출합니다.
+    // 편의 초기화자는 동일한 클래스의 다른 초기화자를 호출하고 하나 이상의 매개변수에 기본값을 전달합니다.
+    // 편의 초기화자도 매개변수를 가질 수 있으며, 이는 호출된 초기화자 매개변수를 사용자 정의하거나 전달된 값에 따라 적절한 초기화자를 선택하는 데 유용합니다.
     convenience init() {
         self.init(sideLength: 5)
     }
@@ -694,28 +695,28 @@ print(mySquare.getArea()) // 25
 mySquare.shrink()
 print(mySquare.sideLength) // 4
 
-// cast instance
+// 인스턴스 캐스팅
 let aShape = mySquare as Shape
 
-// downcast instance:
-// Because downcasting can fail, the result can be an optional (as?) or an implicitly unwrpped optional (as!).
-let anOptionalSquare = aShape as? Square // This will return nil if aShape is not a Square
-let aSquare = aShape as! Square // This will throw a runtime error if aShape is not a Square
+// 인스턴스 다운캐스팅:
+// 다운캐스팅은 실패할 수 있으므로 결과는 옵셔널(as?) 또는 암시적으로 언래핑된 옵셔널(as!)일 수 있습니다.
+let anOptionalSquare = aShape as? Square // aShape가 Square가 아니면 nil을 반환합니다.
+let aSquare = aShape as! Square // aShape가 Square가 아니면 런타임 오류가 발생합니다.
 
-// compare instances, not the same as == which compares objects (equal to)
+// 객체를 비교하는 ==와 달리 인스턴스를 비교합니다.
 if mySquare === mySquare {
     print("Yep, it's mySquare")
 }
 
-// Optional init
+// 옵셔널 초기화
 class Circle: Shape {
     var radius: Int
     override func getArea() -> Int {
         return 3 * radius * radius
     }
 
-    // Place a question mark postfix after `init` is an optional init
-    // which can return nil
+    // `init` 뒤에 물음표 접미사는 옵셔널 초기화입니다.
+    // nil을 반환할 수 있습니다.
     init?(radius: Int) {
         self.radius = radius
         super.init()
@@ -732,160 +733,160 @@ print(myCircle!.getArea())    // 3
 var myEmptyCircle = Circle(radius: -1)
 print(myEmptyCircle?.getArea())    // "nil"
 if let circle = myEmptyCircle {
-    // will not execute since myEmptyCircle is nil
+    // myEmptyCircle이 nil이므로 실행되지 않습니다.
     print("circle is not nil")
 }
 
-// MARK: - Protocols
+// MARK: - 프로토콜
 
-// protocols are also known as interfaces in some other languages
+// 프로토콜은 다른 언어의 인터페이스라고도 합니다.
 
-// `protocol`s can require that conforming types have specific
-// instance properties, instance methods, type methods,
-// operators, and subscripts.
+// `protocol`은 준수하는 타입이 특정
+// 인스턴스 속성, 인스턴스 메서드, 타입 메서드,
+// 연산자 및 첨자를 갖도록 요구할 수 있습니다.
 
 protocol ShapeGenerator {
     var enabled: Bool { get set }
     func buildShape() -> Shape
 }
 
-// MARK: - Other
+// MARK: - 기타
 
-// MARK: Typealiases
+// MARK: 타입 별칭
 
-// Typealiases allow one type (or composition of types) to be referred to by another name
+// 타입 별칭을 사용하면 한 타입(또는 타입의 구성)을 다른 이름으로 참조할 수 있습니다.
 typealias Integer = Int
 let myInteger: Integer = 0
 
-// MARK: = Operator
+// MARK: = 연산자
 
-// Assignment does not return a value. This means it can't be used in conditional statements,
-//   and the following statement is also illegal
+// 할당은 값을 반환하지 않습니다. 즉, 조건문에서 사용할 수 없으며,
+// 다음 문장도 불법입니다.
 //    let multipleAssignment = theQuestion = "No questions asked"
-//But you can do this:
+//하지만 이렇게 할 수 있습니다.
 let multipleAssignment = "No questions asked", secondConstant = "No answers given"
 
-// MARK: Ranges
+// MARK: 범위
 
-// The ..< and ... operators create ranges.
+// ..< 및 ... 연산자는 범위를 생성합니다.
 
-// ... is inclusive on both ends (a "closed range") — mathematically, [0, 10]
+// ...는 양쪽 끝을 포함합니다("닫힌 범위") — 수학적으로 [0, 10]
 let _0to10 = 0...10
-// ..< is inclusive on the left, exclusive on the right (a "range") — mathematically, [0, 10)
+// ..<는 왼쪽은 포함하고 오른쪽은 제외합니다("범위") — 수학적으로 [0, 10)
 let singleDigitNumbers = 0..<10
-// You can omit one end (a "PartialRangeFrom") — mathematically, [0, ∞)
+// 한쪽 끝을 생략할 수 있습니다("PartialRangeFrom") — 수학적으로 [0, ∞)
 let toInfinityAndBeyond = 0...
-// Or the other end (a "PartialRangeTo") — mathematically, (-∞, 0)
+// 또는 다른 쪽 끝("PartialRangeTo") — 수학적으로 (-∞, 0)
 let negativeInfinityToZero = ..<0
-// (a "PartialRangeThrough") — mathematically, (-∞, 0]
+// ("PartialRangeThrough") — 수학적으로 (-∞, 0]
 let negativeInfinityThroughZero = ...0
 
-// MARK: Wildcard operator
+// MARK: 와일드카드 연산자
 
-// In Swift, _ (underscore) is the wildcard operator, which allows values to be ignored
+// Swift에서 _(밑줄)은 와일드카드 연산자로, 값을 무시할 수 있습니다.
 
-// It allows functions to be declared without argument labels:
+// 인수 레이블 없이 함수를 선언할 수 있습니다.
 func function(_ labelLessParameter: Int, label labeledParameter: Int, labelAndParameterName: Int) {
     print(labelLessParameter, labeledParameter, labelAndParameterName)
 }
 function(0, label: 0, labelAndParameterName: 0)
 
-// You can ignore the return values of functions
+// 함수의 반환 값을 무시할 수 있습니다.
 func printAndReturn(_ str: String) -> String {
     print(str)
     return str
 }
 let _ = printAndReturn("Some String")
 
-// You can ignore part of a tuple and keep part of it
+// 튜플의 일부를 무시하고 일부를 유지할 수 있습니다.
 func returnsTuple() -> (Int, Int) {
     return (1, 2)
 }
 let (_, two) = returnsTuple()
 
-// You can ignore closure parameters
+// 클로저 매개변수를 무시할 수 있습니다.
 let closure: (Int, Int) -> String = { someInt, _ in
     return "\(someInt)"
 }
-closure(1, 2) // returns 1
+closure(1, 2) // 1 반환
 
-// You can ignore the value in a for loop
+// for 루프에서 값을 무시할 수 있습니다.
 for _ in 0..<10 {
-    // Code to execute 10 times
+    // 10번 실행할 코드
 }
 
-// MARK: Access Control
+// MARK: 접근 제어
 
 /*
- Swift has five levels of access control:
- - Open: Accessible *and subclassible* in any module that imports it.
- - Public: Accessible in any module that imports it, subclassible in the module it is declared in.
- - Internal: Accessible and subclassible in the module it is declared in.
- - Fileprivate: Accessible and subclassible in the file it is declared in.
- - Private: Accessible and subclassible in the enclosing declaration (think inner classes/structs/enums)
+ Swift에는 5가지 수준의 접근 제어가 있습니다.
+ - Open: 가져오는 모든 모듈에서 액세스 가능하고 하위 클래스화 가능합니다.
+ - Public: 가져오는 모든 모듈에서 액세스 가능하며, 선언된 모듈에서 하위 클래스화 가능합니다.
+ - Internal: 선언된 모듈에서 액세스 가능하고 하위 클래스화 가능합니다.
+ - Fileprivate: 선언된 파일에서 액세스 가능하고 하위 클래스화 가능합니다.
+ - Private: 둘러싸는 선언에서 액세스 가능하고 하위 클래스화 가능합니다(내부 클래스/구조체/열거형 생각).
 
- See more here: https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html
+ 자세한 내용은 여기를 참조하십시오: https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html
  */
 
-// MARK: Preventing Overrides
+// MARK: 재정의 방지
 
-// You can add keyword `final` before a class or instance method, or a property to prevent it from being overridden
+// 클래스나 인스턴스 메서드, 또는 속성 앞에 `final` 키워드를 추가하여 재정의를 방지할 수 있습니다.
 class Shape {
     final var finalInteger = 10
 }
 
-// Prevent a class from being subclassed
+// 클래스가 하위 클래스화되는 것을 방지
 final class ViewManager {
 }
 
-// MARK: Conditional Compilation, Compile-Time Diagnostics, & Availability Conditions
+// MARK: 조건부 컴파일, 컴파일 타임 진단 및 가용성 조건
 
-// Conditional Compilation
+// 조건부 컴파일
 #if false
 print("This code will not be compiled")
 #else
 print("This code will be compiled")
 #endif
 /*
- Options are:
+ 옵션은 다음과 같습니다.
  os()                   macOS, iOS, watchOS, tvOS, Linux
  arch()                 i386, x86_64, arm, arm64
- swift()                >= or < followed by a version number
- compiler()             >= or < followed by a version number
- canImport()            A module name
+ swift()                >= 또는 < 뒤에 버전 번호
+ compiler()             >= 또는 < 뒤에 버전 번호
+ canImport()            모듈 이름
  targetEnvironment()    simulator
  */
 #if swift(<3)
 println()
 #endif
 
-// Compile-Time Diagnostics
-// You can use #warning(message) and #error(message) to have the compiler emit warnings and/or errors
+// 컴파일 타임 진단
+// #warning(message) 및 #error(message)를 사용하여 컴파일러가 경고 및/또는 오류를 내도록 할 수 있습니다.
 #warning("This will be a compile-time warning")
 //  #error("This would be a compile-time error")
 
-//Availability Conditions
+//가용성 조건
 if #available(iOSMac 10.15, *) {
-    // macOS 10.15 is available, you can use it here
+    // macOS 10.15를 사용할 수 있으므로 여기에서 사용할 수 있습니다.
 } else {
-    // macOS 10.15 is not available, use alternate APIs
+    // macOS 10.15를 사용할 수 없으므로 대체 API를 사용합니다.
 }
 
-// MARK: Any and AnyObject
+// MARK: Any 및 AnyObject
 
-// Swift has support for storing a value of any type.
-// For that purpose there are two keywords: `Any` and `AnyObject`
-// `AnyObject` == `id` from Objective-C
-// `Any` works with any values (class, Int, struct, etc.)
+// Swift는 모든 타입의 값을 저장하는 것을 지원합니다.
+// 이를 위해 `Any`와 `AnyObject`라는 두 가지 키워드가 있습니다.
+// `AnyObject` == Objective-C의 `id`
+// `Any`는 모든 값(클래스, Int, 구조체 등)과 함께 작동합니다.
 var anyVar: Any = 7
 anyVar = "Changed value to a string, not good practice, but possible."
 let anyObjectVar: AnyObject = Int(1) as NSNumber
 
-// MARK: Extensions
+// MARK: 확장
 
-// Extensions allow you to add extra functionality to an already-declared type, even one that you don't have the source code for.
+// 확장을 사용하면 이미 선언된 타입에 추가 기능을 추가할 수 있으며, 소스 코드가 없는 타입에도 추가할 수 있습니다.
 
-// Square now "conforms" to the `CustomStringConvertible` protocol
+// Square는 이제 `CustomStringConvertible` 프로토콜을 "준수"합니다.
 extension Square: CustomStringConvertible {
     var description: String {
         return "Area: \(self.getArea()) - ID: \(self.identifier)"
@@ -894,7 +895,7 @@ extension Square: CustomStringConvertible {
 
 print("Square: \(mySquare)")
 
-// You can also extend built-in types
+// 내장 타입을 확장할 수도 있습니다.
 extension Int {
     var doubled: Int {
         return self * 2
@@ -912,10 +913,10 @@ extension Int {
 print(7.doubled) // 14
 print(7.doubled.multipliedBy(num: 3)) // 42
 
-// MARK: Generics
+// MARK: 제네릭
 
-// Generics: Similar to Java and C#. Use the `where` keyword to specify the
-//   requirements of the generics.
+// 제네릭: Java 및 C#과 유사합니다. `where` 키워드를 사용하여
+// 제네릭의 요구 사항을 지정합니다.
 
 func findIndex<T: Equatable>(array: [T], valueToFind: T) -> Int? {
     for (index, value) in array.enumerated() {
@@ -927,7 +928,7 @@ func findIndex<T: Equatable>(array: [T], valueToFind: T) -> Int? {
 }
 findIndex(array: [1, 2, 3, 4], valueToFind: 3) // Optional(2)
 
-// You can extend types with generics as well
+// 제네릭으로 타입을 확장할 수도 있습니다.
 extension Array where Array.Element == Int {
     var sum: Int {
         var total = 0
@@ -938,28 +939,28 @@ extension Array where Array.Element == Int {
     }
 }
 
-// MARK: Operators
+// MARK: 연산자
 
-// Custom operators can start with the characters:
+// 사용자 정의 연산자는 다음 문자로 시작할 수 있습니다.
 //      / = - + * % < > ! & | ^ . ~
-// or
-// Unicode math, symbol, arrow, dingbat, and line/box drawing characters.
+// 또는
+// 유니코드 수학, 기호, 화살표, 딩뱃 및 선/상자 그리기 문자.
 prefix operator !!!
 
-// A prefix operator that triples the side length when used
+// 사용 시 측면 길이를 세 배로 늘리는 접두사 연산자
 prefix func !!! (shape: inout Square) -> Square {
     shape.sideLength *= 3
     return shape
 }
 
-// current value
+// 현재 값
 print(mySquare.sideLength) // 4
 
-// change side length using custom !!! operator, increases size by 3
+// 사용자 정의 !!! 연산자를 사용하여 측면 길이 변경, 크기를 3배 증가
 !!!mySquare
 print(mySquare.sideLength) // 12
 
-// Operators can also be generics
+// 연산자는 제네릭일 수도 있습니다.
 infix operator <->
 func <-><T: Equatable> (a: inout T, b: inout T) {
     let c = a
@@ -973,15 +974,15 @@ var bar: Float = 20
 foo <-> bar
 print("foo is \(foo), bar is \(bar)") // "foo is 20.0, bar is 10.0"
 
-// MARK: - Error Handling
+// MARK: - 오류 처리
 
-// The `Error` protocol is used when throwing errors to catch
+// `Error` 프로토콜은 오류를 throw하고 catch할 때 사용됩니다.
 enum MyError: Error {
     case badValue(msg: String)
     case reallyBadValue(msg: String)
 }
 
-// functions marked with `throws` must be called using `try`
+// `throws`로 표시된 함수는 `try`를 사용하여 호출해야 합니다.
 func fakeFetch(value: Int) throws -> String {
     guard 7 == value else {
         throw MyError.reallyBadValue(msg: "Some really bad value")
@@ -991,20 +992,20 @@ func fakeFetch(value: Int) throws -> String {
 }
 
 func testTryStuff() {
-    // assumes there will be no error thrown, otherwise a runtime exception is raised
+    // 오류가 발생하지 않을 것으로 가정하고, 그렇지 않으면 런타임 예외가 발생합니다.
     let _ = try! fakeFetch(value: 7)
 
-    // if an error is thrown, then it proceeds, but if the value is nil
-    // it also wraps every return value in an optional, even if its already optional
+    // 오류가 발생하면 계속 진행하지만, 값이 nil이면
+    // 이미 옵셔널인 경우에도 모든 반환 값을 옵셔널로 래핑합니다.
     let _ = try? fakeFetch(value: 7)
 
     do {
-        // normal try operation that provides error handling via `catch` block
+        // `catch` 블록을 통해 오류 처리를 제공하는 일반적인 try 작업
         try fakeFetch(value: 1)
     } catch MyError.badValue(let msg) {
         print("Error message: \(msg)")
     } catch {
-        // must be exhaustive
+        // 철저해야 함
     }
 }
 testTryStuff()

--- a/ko/tailspin.md
+++ b/ko/tailspin.md
@@ -8,62 +8,62 @@ contributors:
 
 ---
 
-**Tailspin** works with streams of values in pipelines. You may often feel
-that your program is the machine and that the input data is the program.
+**Tailspin**은 파이프라인에서 값의 스트림으로 작동합니다. 종종
+프로그램이 기계이고 입력 데이터가 프로그램이라고 느낄 수 있습니다.
 
-While Tailspin is unlikely to become mainstream, or even production-ready,
-it will change the way you think about programming in a good way.
+Tailspin이 주류가 되거나 프로덕션 준비가 될 가능성은 낮지만,
+좋은 방향으로 프로그래밍에 대한 생각을 바꿀 것입니다.
 
 ```c
-// Comment to end of line
+// 줄 끝까지 주석
 
-// Process data in a pipeline with steps separated by ->
-// String literals are delimited by single quotes
-// A bang (!) indicates a sink, or end of the pipe
-// OUT is the standard output object, ::write is the message to write output
+// ->로 구분된 단계가 있는 파이프라인에서 데이터 처리
+// 문자열 리터럴은 작은따옴표로 구분됩니다.
+// 느낌표(!)는 싱크 또는 파이프의 끝을 나타냅니다.
+// OUT은 표준 출력 객체이고, ::write는 출력을 쓰는 메시지입니다.
 'Hello, World!' -> !OUT::write
 
-// Output a newline by just entering it in the string (multiline strings)
+// 문자열에 입력하여 줄 바꿈 출력 (여러 줄 문자열)
 '
 ' -> !OUT::write
-// Or output the decimal unicode value for newline (10) between $# and ;
+// 또는 $#와 ; 사이에 줄 바꿈(10)에 대한 10진수 유니코드 값 출력
 '$#10;' -> !OUT::write
 
-// Define an immutable named value. Value syntax is very literal.
+// 불변의 명명된 값 정의. 값 구문은 매우 리터럴합니다.
 def names: ['Adam', 'George', 'Jenny', 'Lucy'];
 
-// Stream the list to process each name. Note the use of $ to get the value.
-// The current value in the pipeline is always just $
-// String interpolation starts with a $ and ends with ;
+// 각 이름을 처리하기 위해 목록 스트리밍. $를 사용하여 값을 가져오는 것에 유의하십시오.
+// 파이프라인의 현재 값은 항상 $입니다.
+// 문자열 보간은 $로 시작하여 ;로 끝납니다.
 $names... -> 'Hello $;!
 ' -> !OUT::write
 
-// You can also stream in the interpolation and nest interpolations
-// Note the list indexing with parentheses and the slice extraction
-// Note the use of ~ to signify an exclusive bound to the range
-// Outputs 'Hello Adam, George, Jenny and Lucy!'
+// 보간에 스트리밍하고 보간을 중첩할 수도 있습니다.
+// 괄호를 사용한 목록 인덱싱 및 슬라이스 추출에 유의하십시오.
+// ~를 사용하여 범위에 대한 배타적 경계를 나타내는 것에 유의하십시오.
+// 'Hello Adam, George, Jenny and Lucy!'를 출력합니다.
 'Hello $names(first);$names(first~..~last)... -> ', $;'; and $names(last);!
 ' -> !OUT::write
 
-// Conditionally say different things to different people
-// Matchers (conditional expressions) are delimited by angle brackets
-// A set of matchers, evaluated top down, must be in templates (a function)
-// Here it is an inline templates delimited by \( to \)
-// Note the doubled '' and $$ to get a literal ' and $
+// 다른 사람에게 다른 말을 조건부로 합니다.
+// 매처(조건식)는 꺾쇠괄호로 구분됩니다.
+// 위에서 아래로 평가되는 매처 집합은 템플릿(함수)에 있어야 합니다.
+// 여기서는 \(에서 \)로 구분된 인라인 템플릿입니다.
+// 리터럴 ' 및 $를 얻기 위해 이중 '' 및 $$를 사용하는 것에 유의하십시오.
 $names... -> \(
   when <='Adam'> do 'What''s up $;?' !
   when <='George'> do 'George, where are the $$10 you owe me?' !
   otherwise 'Hello $;!' !
 \) -> '$;$#10;' -> !OUT::write
 
-// You can also define templates (functions)
-// A lone ! emits the value into the calling pipeline without returning control
-// The # sends the value to be matched by the matchers
-// Note that templates always take one input value and emit 0 or more outputs
+// 템플릿(함수)을 정의할 수도 있습니다.
+// 단독 !는 제어를 반환하지 않고 호출 파이프라인으로 값을 내보냅니다.
+// #은 매처에 의해 일치될 값을 보냅니다.
+// 템플릿은 항상 하나의 입력 값을 받고 0개 이상의 출력을 내보냅니다.
 templates collatz-sequence
   when <..0> do 'The start seed must be a positive integer' !
   when <=1> do $!
-// The ?( to ) allows matching a computed value. Can be concatenated as "and"
+// ?(에서 )까지는 계산된 값을 일치시킬 수 있습니다. "and"로 연결할 수 있습니다.
   when <?($ mod 2 <=1>)> do
     $ !
     3 * $ + 1 -> #
@@ -72,25 +72,25 @@ templates collatz-sequence
     $ ~/ 2 -> #
 end collatz-sequence
 
-// Collatz sequence from random start on one line separated by spaces
+// 한 줄에 공백으로 구분된 임의의 시작점에서 콜라츠 시퀀스
 1000 -> SYS::randomInt -> $ + 1 -> collatz-sequence -> '$; ' -> !OUT::write
 '
 ' -> !OUT::write
 
-// Collatz sequence formatted ten per line by an indexed list template
-// Note the square brackets creates a list of the enclosed pipeline results
-// The \[i]( to \) defines a templates to apply to each value of a list,
-// the i (or whatever identifier you choose) holds the index
+// 인덱싱된 목록 템플릿으로 한 줄에 10개씩 서식이 지정된 콜라츠 시퀀스
+// 대괄호는 묶인 파이프라인 결과의 목록을 생성합니다.
+// \[i](에서 \)까지는 목록의 각 값에 적용할 템플릿을 정의하며,
+// i(또는 선택한 식별자)는 인덱스를 보유합니다.
 [1000 -> SYS::randomInt -> $ + 1 -> collatz-sequence]
 -> \[i](
   when <=1|?($i mod 10 <=0>)> do '$;$#10;' !
   otherwise '$; ' !
 \)... -> !OUT::write
 
-// A range can have an optional stride
+// 범위에는 선택적 보폭이 있을 수 있습니다.
 def odd-numbers: [1..100:2];
 
-// Use mutable state locally. One variable per templates, always called @
+// 로컬에서 가변 상태 사용. 템플릿당 하나의 변수, 항상 @라고 함
 templates product
   @: $(first);
   $(first~..last)... -> @: $@ * $;
@@ -101,10 +101,10 @@ $odd-numbers(6..8) -> product -> !OUT::write
 '
 ' -> !OUT::write
 
-// Use processor objects to hold mutable state.
-// Note that the outer @ must be referred to by name in inner contexts
-// A sink templates gives no output and is called prefixed by !
-// A source templates takes no input and is called prefixed by $
+// 프로세서 객체를 사용하여 가변 상태 유지.
+// 외부 @는 내부 컨텍스트에서 이름으로 참조해야 합니다.
+// 싱크 템플릿은 출력이 없으며 접두사 !로 호출됩니다.
+// 소스 템플릿은 입력이 없으며 접두사 $로 호출됩니다.
 processor Product
   @: 1;
   sink accumulate
@@ -115,23 +115,23 @@ processor Product
   end result
 end Product
 
-// The processor is a constructor templates. This one called with $ (no input)
+// 프로세서는 생성자 템플릿입니다. 이것은 $(입력 없음)으로 호출됩니다.
 def multiplier: $Product;
 
-// Call object templates by sending messages with ::
+// ::로 메시지를 보내 객체 템플릿 호출
 1..7 -> !multiplier::accumulate
 -1 -> !multiplier::accumulate
 $multiplier::result -> 'The product is $;
 ' -> !OUT::write
 
-// Syntax sugar for a processor implementing the collector interface
+// 수집기 인터페이스를 구현하는 프로세서에 대한 구문 설탕
 1..7 -> ..=Product -> 'The collected product is $;$#10;' -> !OUT::write
 
-// Symbol sets (essentially enums) can be defined for finite sets of values
+// 유한한 값 집합에 대해 심볼 집합(본질적으로 열거형)을 정의할 수 있습니다.
 data colour #{green, red, blue, yellow}
 
-// Use processor typestates to model state cleanly.
-// The last named mutable state value set determines the typestate
+// 프로세서 타입 상태를 사용하여 상태를 깔끔하게 모델링합니다.
+// 마지막으로 명명된 가변 상태 값 집합이 타입 상태를 결정합니다.
 processor Lamp
   def colours: $;
   @Off: 0;
@@ -157,14 +157,14 @@ $myLamp::switchOn -> !OUT::write // Shining a blue light
 $myLamp::turnOff -> !OUT::write  // Lamp is off
 $myLamp::switchOn -> !OUT::write // Shining a green light
 
-// Use regular expressions to test strings
+// 정규식을 사용하여 문자열 테스트
 ['banana', 'apple', 'pear', 'cherry']... -> \(
   when <'.*a.*'> do '$; contains an ''a''' !
   otherwise '$; has no ''a''' !
 \) -> '$;
 ' -> !OUT::write
 
-// Use composers with regular expressions and defined rules to parse strings
+// 정규식과 정의된 규칙으로 작곡가를 사용하여 문자열 구문 분석
 composer parse-stock-line
   {inventory-id: <INT> (<WS>), name: <'\w+'> (<WS>), currency: <'.{3}'>,
     unit-price: <INT> (<WS>?) <parts>?}
@@ -178,17 +178,17 @@ end parse-stock-line
 '
 ' -> !OUT::write
 
-// Stream a string to split it into glyphs.
-// A list can be indexed/sliced by an array of indexes
-// Outputs ['h','e','l','l','o'], indexing arrays/lists starts at 1
+// 문자열을 스트리밍하여 글리프로 분할합니다.
+// 목록은 인덱스 배열로 인덱싱/슬라이스할 수 있습니다.
+// ['h','e','l','l','o']를 출력하고, 배열/목록 인덱싱은 1부터 시작합니다.
 ['abcdefghijklmnopqrstuvwxyz'...] -> $([8,5,12,12,15]) -> !OUT::write
 '
 ' -> !OUT::write
 
-// We have used only raw strings above.
-// Strings can have different types as determined by a tag.
-// Comparing different types is an error, unless a wider type bound is set
-// Type bound is given in ´´ and '' means any string value, tagged or raw
+// 위에서는 원시 문자열만 사용했습니다.
+// 문자열은 태그로 결정되는 다른 타입을 가질 수 있습니다.
+// 더 넓은 타입 경계가 설정되지 않은 한 다른 타입을 비교하는 것은 오류입니다.
+// 타입 경계는 ´´로 주어지며 ''는 태그가 있거나 원시인 모든 문자열 값을 의미합니다.
 templates get-string-type
   when <´''´ '.*'> do '$; is a raw string' !
   when <´''´ id´'\d+'> do '$; is a numeric id string' !
@@ -202,8 +202,8 @@ end get-string-type
 -> get-string-type -> '$;
 ' -> !OUT::write
 
-// Numbers can be raw, tagged or have a unit of measure
-// Type .. is any numeric value, tagged, measure or raw
+// 숫자는 원시, 태그 또는 측정 단위를 가질 수 있습니다.
+// 타입 ..은 태그, 측정 또는 원시인 모든 숫자 값입니다.
 templates get-number-type
   when <´..´ =inventory-id´86> do 'inventory-id 86 found' !
   when <´..´ inventory-id´100..> do '$; is an inventory-id >= 100' !
@@ -217,18 +217,18 @@ end get-number-type
 -> get-number-type -> '$;
 ' -> !OUT::write
 
-// Measures can be used in arithmetic, "1" is the scalar unit
-// When mixing measures you have to cast to the result measure
+// 측정 단위는 산술에 사용할 수 있으며, "1"은 스칼라 단위입니다.
+// 측정 단위를 혼합할 때는 결과 측정 단위로 캐스팅해야 합니다.
 4"m" + 6"m" * 3"1" -> ($ ~/ 2"s")"m/s" -> '$;
 ' -> !OUT::write
 
-// Tagged identifiers must be made into raw numbers when used in arithmetic
-// Then you can cast the result back to a tagged identifier if you like
+// 태그가 있는 식별자는 산술에 사용될 때 원시 숫자로 만들어야 합니다.
+// 그런 다음 원하는 경우 결과를 태그가 있는 식별자로 다시 캐스팅할 수 있습니다.
 inventory-id´300 -> inventory-id´($::raw + 1) -> get-number-type -> '$;
 ' -> !OUT::write
 
-// Fields get auto-typed, tagging raw strings or numbers by default
-// You cannot assign the wrong type to a field
+// 필드는 기본적으로 원시 문자열 또는 숫자를 태그하여 자동으로 타입을 지정합니다.
+// 필드에 잘못된 타입을 할당할 수 없습니다.
 def item: { inventory-id: 23, name: 'thingy', length: 12"m" };
 
 'Field inventory-id $item.inventory-id -> get-number-type;
@@ -238,8 +238,8 @@ def item: { inventory-id: 23, name: 'thingy', length: 12"m" };
 'Field length $item.length -> get-number-type;
 ' -> !OUT::write
 
-// You can define types and use as type-tests. This also defines a field.
-// It would be an error to assign a non-standard plate to a standard-plate field
+// 타입을 정의하고 타입 테스트로 사용할 수 있습니다. 이것은 또한 필드를 정의합니다.
+// 표준 플레이트 필드에 비표준 플레이트를 할당하는 것은 오류입니다.
 data standard-plate <'[A-Z]{3}[0-9]{3}'>
 
 [['Audi', 'XYZ345'], ['BMW', 'I O U']]... -> \(
@@ -248,30 +248,30 @@ data standard-plate <'[A-Z]{3}[0-9]{3}'>
 \) -> '$;
 ' -> !OUT::write
 
-// You can define union types
+// 유니온 타입을 정의할 수 있습니다.
 data age <"years"|"months">
 
 [ {name: 'Cesar', age: 20"years"},
   {name: 'Francesca', age: 19"years"},
   {name: 'Bobby', age: 11"months"}]...
 -> \(
-// Conditional tests on structures look a lot like literals, with field tests
+// 구조에 대한 조건부 테스트는 필드 테스트와 함께 리터럴처럼 보입니다.
   when <{age: <13"years"..19"years">}> do '$.name; is a teenager'!
   when <{age: <"months">}> do '$.name; is a baby'!
-// You don't need to handle all cases, 'Cesar' will just be ignored
+// 모든 경우를 처리할 필요는 없습니다. 'Cesar'는 그냥 무시됩니다.
 \) -> '$;
 ' -> !OUT::write
 
-// Array/list indexes start at 1 by default, but you can choose
-// Slices return whatever overlaps with the actual array
+// 배열/목록 인덱스는 기본적으로 1부터 시작하지만 선택할 수 있습니다.
+// 슬라이스는 실제 배열과 겹치는 부분을 반환합니다.
 [1..5] -> $(-2..2) -> '$;
-' -> !OUT::write // Outputs [1,2]
+' -> !OUT::write // [1,2] 출력
 0:[1..5] -> $(-2..2) -> '$;
-' -> !OUT::write // Outputs [1,2,3]
+' -> !OUT::write // [1,2,3] 출력
 -2:[1..5] -> $(-2..2) -> '$;
-' -> !OUT::write // Outputs [1,2,3,4,5]
+' -> !OUT::write // [1,2,3,4,5] 출력
 
-// Arrays can have indexes of measures or tagged identifiers
+// 배열은 측정 단위 또는 태그가 있는 식별자의 인덱스를 가질 수 있습니다.
 def game-map: 0"y":[
   1..5 -> 0"x":[
     1..5 -> level´1:[
@@ -284,12 +284,12 @@ def game-map: 0"y":[
   ]
 ];
 
-// Projections (indexing) can span several dimensions
+// 프로젝션(인덱싱)은 여러 차원에 걸쳐 있을 수 있습니다.
 $game-map(3"y"; 1"x"..3"x"; level´1; altitude:) -> '$;
-' -> !OUT::write // Gives a list of three altitude values
+' -> !OUT::write // 세 개의 고도 값 목록을 제공합니다.
 
-// Flatten and do a grouping projection to get stats
-// Count and Max are built-in collector processors
+// 통계를 얻기 위해 평탄화하고 그룹화 프로젝션을 수행합니다.
+// Count 및 Max는 내장된 수집기 프로세서입니다.
 [$game-map... ... ...] -> $(collect {
       occurences: Count,
       highest-on-level: Max&{by: :(altitude:), select: :(level:)}
@@ -298,22 +298,22 @@ $game-map(3"y"; 1"x"..3"x"; level´1; altitude:) -> '$;
 '
 ' -> !OUT::write
 
-// Relations are sets of structures/records.
-// Here we get all unique {level:, terrain-id:, altitude:} combinations
+// 관계는 구조/레코드의 집합입니다.
+// 여기서는 모든 고유한 {level:, terrain-id:, altitude:} 조합을 얻습니다.
 def location-types: {|$game-map... ... ...|};
 
-// Projections can re-map structures. Note § is the relative accessor
+// 프로젝션은 구조를 다시 매핑할 수 있습니다. §는 상대 접근자입니다.
 $location-types({terrain-id:, foo: §.level::raw * §.altitude})
 -> '$;
 ' -> !OUT::write
 
-// Relational algebra operators can be used on relations
+// 관계형 대수 연산자는 관계에 사용할 수 있습니다.
 ($location-types join {| {altitude: 3"m"} |})
 -> !OUT::write
 '
 ' -> !OUT::write
 
-// Define your own operators for binary operations
+// 이항 연산에 대한 자체 연산자 정의
 operator (left dot right)
   $left -> \[i]($ * $right($i)!\)... -> ..=Sum&{of: :()} !
 end dot
@@ -321,15 +321,15 @@ end dot
 ([1,2,3] dot [2,5,8]) -> 'dot product: $;
 ' -> !OUT::write
 
-// Supply parameters to vary templates behaviour
+// 템플릿 동작을 변경하기 위해 매개변수 제공
 templates die-rolls&{sides:}
   1..$ -> $sides::raw -> SYS::randomInt -> $ + 1 !
 end die-rolls
 
-[5 -> die-rolls&{sides:4}] -> '$;
+[5 -> die-rolls&{sides: 4}] -> '$;
 ' -> !OUT::write
 
-// Pass templates as parameters, maybe with some parameters pre-filled
+// 템플릿을 매개변수로 전달하고, 일부 매개변수를 미리 채울 수 있습니다.
 source damage-roll&{first:, second:, third:}
   (1 -> first) + (1 -> second) + (1 -> third) !
 end damage-roll
@@ -339,15 +339,15 @@ $damage-roll&{first: die-rolls&{sides:4},
 -> 'Damage done is $;
 ' -> !OUT::write
 
-// Write tests inline. Run by --test flag on command line
-// Note the ~ in the matcher means "not",
-// and the array content matcher matches elements < 1 and > 4
+// 인라인으로 테스트 작성. 명령줄에서 --test 플래그로 실행
+// 매처의 ~는 "not"을 의미하며,
+// 배열 내용 매처는 < 1 및 > 4인 요소를 일치시킵니다.
 test 'die-rolls'
   assert [100 -> die-rolls&{sides: 4}] <~[<..~1|4~..>]> 'all rolls 1..4'
 end 'die-rolls'
 
-// Provide modified modules to tests (aka test doubles or mocks)
-// IN is the standard input object and ::lines gets all lines
+// 테스트에 수정된 모듈 제공 (테스트 더블 또는 모의 객체라고도 함)
+// IN은 표준 입력 객체이고 ::lines는 모든 줄을 가져옵니다.
 source read-numbers
   $IN::lines -> #
   when <'\d+'> do $!
@@ -369,16 +369,16 @@ test 'read numbers from input'
   assert $read-numbers <=65> 'Only 65 is read'
 end 'read numbers from input'
 
-// You can work with byte arrays
+// 바이트 배열로 작업할 수 있습니다.
 composer hexToBytes
   <HEX>
 end hexToBytes
 
 '1a5c678d' -> hexToBytes -> ($ and [x 07 x]) -> $(last-1..last) -> '$;
-' -> !OUT::write // Outputs 0005
+' -> !OUT::write // 0005 출력
 ```
 
-## Further Reading
+## 더 읽을거리
 
-- [Main Tailspin site](https://github.com/tobega/tailspin-v0/)
-- [Tailspin language reference](https://github.com/tobega/tailspin-v0/blob/master/TailspinReference.md)
+- [Tailspin 메인 사이트](https://github.com/tobega/tailspin-v0/)
+- [Tailspin 언어 참조](https://github.com/tobega/tailspin-v0/blob/master/TailspinReference.md)

--- a/ko/tcsh.md
+++ b/ko/tcsh.md
@@ -7,253 +7,246 @@ contributors:
        - ["Nicholas Christopoulos", "https://github.com/nereusx"]
 ---
 
-tcsh ("tee-see-shell") is a Unix shell based on and compatible with the C shell (csh).
-It is essentially the C shell with programmable command-line completion, command-line editing,
-and a few other features.
-It is the native root shell for BSD-based systems such as FreeBSD.
+tcsh("tee-see-shell")는 C 셸(csh)을 기반으로 하고 호환되는 유닉스 셸입니다.
+본질적으로 프로그래밍 가능한 명령줄 완성, 명령줄 편집 및 몇 가지 다른 기능이 있는 C 셸입니다.
+FreeBSD와 같은 BSD 기반 시스템의 기본 루트 셸입니다.
 
-Almost all Linux distros and BSD today use tcsh instead of the original csh. In
-most cases csh is a symbolic link that points to tcsh.
-This is because tcsh is backward compatible with csh, and the last
-is not maintained anymore.
+오늘날 거의 모든 Linux 배포판과 BSD는 원래 csh 대신 tcsh를 사용합니다. 대부분의 경우 csh는 tcsh를 가리키는 심볼릭 링크입니다.
+이는 tcsh가 csh와 하위 호환되고 후자는 더 이상 유지 관리되지 않기 때문입니다.
 
-- [TCSH Home](http://www.tcsh.org/)
-- [TCSH Wikipedia](https://en.wikipedia.org/wiki/Tcsh)
-- [TCSH manual page](http://www.tcsh.org/tcsh.html/top.html)
-- [“An Introduction to the C shell”, William Joy](https://docs.freebsd.org/44doc/usd/04.csh/paper.html)
-- [TCSH Bug reports and/or features requests](https://bugs.gw.com/)
+- [TCSH 홈페이지](http://www.tcsh.org/)
+- [TCSH 위키백과](https://en.wikipedia.org/wiki/Tcsh)
+- [TCSH 매뉴얼 페이지](http://www.tcsh.org/tcsh.html/top.html)
+- ["C 셸 소개", William Joy](https://docs.freebsd.org/44doc/usd/04.csh/paper.html)
+- [TCSH 버그 리포트 및/또는 기능 요청](https://bugs.gw.com/)
 
-Some more files:
-[tcsh help command (for 132x35 terminal size)](https://github.com/nereusx/dotfiles/blob/master/csh-help),
-[my ~/.tcshrc](https://github.com/nereusx/dotfiles/blob/master/.tcshrc)
+추가 파일:
+[tcsh 도움말 명령어 (132x35 터미널 크기용)](https://github.com/nereusx/dotfiles/blob/master/csh-help),
+[나의 ~/.tcshrc](https://github.com/nereusx/dotfiles/blob/master/.tcshrc)
 
 ```tcsh
 #!/bin/tcsh
-# The first line of the script is a shebang which tells the system how to execute
-# the script: http://en.wikipedia.org/wiki/Shebang_(Unix)
-# TCSH emulates the shebang on systems that don't understand it.
+# 스크립트의 첫 번째 줄은 시스템에 스크립트 실행 방법을 알려주는 shebang입니다.
+# http://en.wikipedia.org/wiki/Shebang_(Unix)
+# TCSH는 shebang을 이해하지 못하는 시스템에서 이를 에뮬레이트합니다.
 
-# In most cases you'll use `#!/bin/tcsh -f`, because `-f` option does not load
-# any resource or start-up files, or perform any command hashing, and thus
-# starts faster.
+# 대부분의 경우 `#!/bin/tcsh -f`를 사용합니다. `-f` 옵션은
+# 리소스나 시작 파일을 로드하지 않고, 명령어 해싱을 수행하지 않으므로
+# 더 빨리 시작됩니다.
 
-# --- the echo command --------------------------------------------------------
-# The `echo` writes each word to the shell's standard output, separated by
-# spaces and terminated with a newline. The echo_style shell variable may be
-# set to emulate (or not) the flags and escape sequences.
+# --- echo 명령어 --------------------------------------------------------
+# `echo`는 각 단어를 셸의 표준 출력에 공백으로 구분하고
+# 줄 바꿈으로 종료하여 씁니다. echo_style 셸 변수는
+# 플래그와 이스케이프 시퀀스를 에뮬레이트(또는 에뮬레이트하지 않도록)하도록 설정할 수 있습니다.
 
-# Display the value of echo_style
+# echo_style 값 표시
 echo $echo_style
 
-# Enable `echo` to support backslashed characters and `-n` option (no new line)
-# This is the default for tcsh, but your distro may change it. Slackware has
-# done so.
+# `echo`가 백슬래시 문자와 `-n` 옵션(줄 바꿈 없음)을 지원하도록 활성화
+# 이것은 tcsh의 기본값이지만, 배포판에서 변경할 수 있습니다. Slackware는
+# 그렇게 했습니다.
 set echo_style = both
 
-# Prints "Hello world"
+# "Hello world" 출력
 echo Hello world
 echo "Hello world"
 echo 'Hello world'
 echo `echo Hello world`
 
-# This prints "twonlines" in one line
+# "twonlines"를 한 줄에 출력
 echo two\nlines
 
-# Prints the two lines
+# 두 줄 출력
 echo "two\nlines"
 echo 'two\nlines'
 
-# --- Basic Syntax ------------------------------------------------------------
+# --- 기본 구문 ------------------------------------------------------------
 
-# A special character (including a blank or tab) may be prevented from having
-# its special meaning by preceding it with a backslash `\`.
-# This will display the last history commands
+# 특수 문자(공백이나 탭 포함)는 앞에 백슬래시 `\`를 붙여
+# 특수 의미를 갖지 않도록 할 수 있습니다.
+# 마지막 히스토리 명령어를 표시합니다
 echo !!
-# This will not
+# 이것은 그렇지 않습니다
 echo \!\!
 
-# Single quotes prevent expanding special characters too, but some
-# characters like `!` and backslash have higher priority
-# `$` (variable value) will not expand
+# 작은따옴표도 특수 문자 확장을 방지하지만, `!`나 백슬래시 같은
+# 일부 문자는 우선순위가 더 높습니다
+# `$` (변수 값)는 확장되지 않습니다
 echo '$1 tip'
-# `!` (history) will expand
+# `!` (히스토리)는 확장됩니다
 echo '!!'
 
-# Strings enclosed by back-quotes will be executed and replaced by the result.
+# 백쿼트로 묶인 문자열은 실행되고 그 결과로 대체됩니다.
 echo `ls`
 
-# Semi-colon separate commands
+# 세미콜론은 명령어를 구분합니다
 echo 'first line'; echo 'second line'
 
-# There is also conditional execution
+# 조건부 실행도 있습니다
 echo "Always executed" || echo "Only executed if the first command fails"
 echo "Always executed" && echo "Only executed if the first command does NOT fail"
 
-# Parenthesised commands are always executed in a subshell,
+# 괄호로 묶인 명령어는 항상 서브셸에서 실행됩니다,
 
-# example: creates a project and then informs you that it finished while
-# it does the installation.
+# 예: 프로젝트를 생성하고 설치하는 동안 완료되었음을 알립니다.
 make && ( espeak "BOSS, compilation finished"; make install )
 
-# prints the home directory but leaves you where you were
+# 홈 디렉토리를 출력하지만 원래 있던 위치에 그대로 둡니다
 (cd; pwd); pwd
 
-# Read tcsh man-page documentation
+# tcsh 맨페이지 문서 읽기
 man tcsh
 
-# --- Variables ---------------------------------------------------------------
-# The shell maintains a list of variables, each of which has as value a list of
-# zero or more words. The values of shell variables can be displayed and
-# changed with the `set` and `unset` commands.
-# The system maintains its own list of "environment" variables.
-# These can be displayed and changed with `printenv`, `setenv`, and `unsetenv`.
-# The syntax of `setenv` is similar to POSIX sh.
+# --- 변수 ---------------------------------------------------------------
+# 셸은 변수 목록을 유지하며, 각 변수는 0개 이상의 단어로 구성된 목록을 값으로 가집니다.
+# 셸 변수의 값은 `set` 및 `unset` 명령어로 표시하고 변경할 수 있습니다.
+# 시스템은 자체 "환경" 변수 목록을 유지합니다.
+# 이는 `printenv`, `setenv`, `unsetenv`로 표시하고 변경할 수 있습니다.
+# `setenv`의 구문은 POSIX sh와 유사합니다.
 
-# Assign a value or nothing will create a variable
-# Assign nothing
+# 값을 할당하거나 아무것도 할당하지 않으면 변수가 생성됩니다
+# 아무것도 할당하지 않음
 set var
-# Assign a numeric value
-# the '@' denotes the expression is arithmetic; it works similar to 'set' but
-# the right value can be a numeric expression.
+# 숫자 값 할당
+# '@'는 표현식이 산술임을 나타냅니다. 'set'과 유사하게 작동하지만
+# 오른쪽 값은 숫자 표현식이 될 수 있습니다.
 @ var = 1 + 2
-# Assign a string value
+# 문자열 값 할당
 set var = "Hello, I am the contents of 'var' variable"
-# Assign the output of a program
+# 프로그램 출력 할당
 set var = `ls`
 
-# Remove a variable
+# 변수 제거
 unset var
-# Prints 1 (true) if the variable `var` exists otherwise prints 0 (false)
+# 변수 `var`가 존재하면 1(참)을 출력하고, 그렇지 않으면 0(거짓)을 출력합니다
 echo $?var
-# Print all variables and their values
+# 모든 변수와 그 값을 출력합니다
 set
 
-# Prints the contents of 'var'
+# 'var'의 내용을 출력합니다
 echo $var;
 echo "$var";
-# Prints the string `$var`
+# 문자열 `$var`를 출력합니다
 echo \$var
 echo '$var'
-# Braces can be used to separate variables from the rest when it is needed
+# 필요할 때 변수를 나머지 부분과 분리하기 위해 중괄호를 사용할 수 있습니다
 set num = 12; echo "There ${num}th element"
 
-# Prints the number of characters of the value: 6
+# 값의 문자 수를 출력합니다: 6
 set var = '123456'; echo $%var
 
-### LISTs
-# Assign a list of values
+### 리스트
+# 값 목록 할당
 set var = ( one two three four five )
-# Print all the elements: one two three four five
+# 모든 요소 출력: one two three four five
 echo $var
 echo $var[*]
-# Print the count of elements: 5
+# 요소 개수 출력: 5
 echo $#var
-# Print the indexed element; This prints the second element: two
+# 인덱싱된 요소 출력; 두 번째 요소 출력: two
 echo $var[2]
-# Print range of elements; prints 2nd up to 3rd: two, three
+# 요소 범위 출력; 2번째부터 3번째까지 출력: two, three
 echo $var[2-3]
-# Prints all elements starting from the 3rd: three four five
+# 3번째부터 모든 요소 출력: three four five
 echo $var[3-]
-# Prints print all up to 3rd element: one two three
+# 3번째 요소까지 모두 출력: one two three
 echo $var[-3]
 
-### Special Variables
-# $argv         list of command-line arguments
-# $argv[0]      this file-name (the file of the script file)
-# $# $0, $n, $* are the same as $#argv, $argv[0], $argv[n], $argv[*]
-# $status, $?   the exit code of the last command that executed
-# $_            the previous command line
-# $!            the PID of the last background process started by this shell
-# $$            script's PID
+### 특수 변수
+# $argv         명령줄 인수 목록
+# $argv[0]      이 파일 이름 (스크립트 파일의 파일)
+# $# $0, $n, $*는 $#argv, $argv[0], $argv[n], $argv[*]와 동일합니다
+# $status, $?   마지막으로 실행된 명령어의 종료 코드
+# $_            이전 명령줄
+# $!            이 셸에서 시작된 마지막 백그라운드 프로세스의 PID
+# $$            스크립트의 PID
 
-# $path, $PATH  the list of directories that will search for an executable to run
-# $home, $HOME  user's home directory, also the `~` can be used instead
-# $uid          user's login ID
-# $user         user's login name
-# $gid          the user's group ID
-# $group        the user's group-name
-# $cwd, $PWD    the Current/Print Working Directory
-# $owd          the previous working directory
-# $tcsh         tcsh version
-# $tty          the current tty; ttyN for Linux console, pts/N for terminal
-#               emulators under X
-# $term         the terminal type
-# $verbose      if set, causes the words of each command to be printed.
-#               can be set by the `-v` command line option too.
-# $loginsh      if set, it is a login shell
+# $path, $PATH  실행 파일을 찾을 디렉토리 목록
+# $home, $HOME  사용자의 홈 디렉토리, `~`를 대신 사용할 수도 있습니다
+# $uid          사용자 로그인 ID
+# $user         사용자 로그인 이름
+# $gid          사용자 그룹 ID
+# $group        사용자 그룹 이름
+# $cwd, $PWD    현재/작업 디렉토리 출력
+# $owd          이전 작업 디렉토리
+# $tcsh         tcsh 버전
+# $tty          현재 tty; Linux 콘솔의 경우 ttyN, X의 터미널 에뮬레이터의 경우 pts/N
+# $term         터미널 유형
+# $verbose      설정되면 각 명령어의 단어를 출력합니다.
+#               `-v` 명령줄 옵션으로도 설정할 수 있습니다.
+# $loginsh      설정되면 로그인 셸입니다
 
-# TIP: $?0 is always false in interactive shells
-# TIP: $?prompt is always false in non-interactive shells
-# TIP: if `$?tcsh` is unset; you run the original `csh` or something else;
-#      try `echo $shell`
-# TIP: `$verbose` is useful for debugging scripts
-# NOTE: `$PWD` and `$PATH` are synchronised with `$cwd` and `$pwd` automatically.
+# 팁: $?0은 대화형 셸에서 항상 거짓입니다
+# 팁: $?prompt는 비대화형 셸에서 항상 거짓입니다
+# 팁: `$?tcsh`가 설정되지 않았다면, 원래 `csh`나 다른 것을 실행하고 있는 것입니다;
+#      `echo $shell`을 시도해보세요
+# 팁: `$verbose`는 스크립트 디버깅에 유용합니다
+# 참고: `$PWD`와 `$PATH`는 `$cwd`와 `$pwd`와 자동으로 동기화됩니다.
 
-# --- Variable modifiers ------------------------------------------------------
-# Syntax: ${var}:m[:mN]
-# Where <m> is:
-# h : the directory  t : the filename  r : remove extension   e : the extension
-# u : uppercase the first lowercase letter
-# l : lowercase the first uppercase letter
-# p : print but do not execute it (hist)
-# q : quote the substituted words, preventing further substitutions
-# x : like q, but break into words at white spaces
-# g : apply the following modifier once to each word
-# a  : apply the following modifier as many times as possible to single word
-# s/l/r/ : search for `l` and replace with `r`, not regex; the `&` in the `r` is
-# replaced by `l`
-# & : Repeat the previous substitution
+# --- 변수 수정자 ------------------------------------------------------
+# 구문: ${var}:m[:mN]
+# 여기서 <m>은 다음과 같습니다:
+# h : 디렉토리  t : 파일 이름  r : 확장자 제거   e : 확장자
+# u : 첫 소문자를 대문자로
+# l : 첫 대문자를 소문자로
+# p : 출력하지만 실행하지는 않음 (hist)
+# q : 대체된 단어를 인용하여 추가 대체를 방지
+# x : q와 같지만 공백에서 단어로 나눔
+# g : 다음 수정자를 각 단어에 한 번 적용
+# a  : 다음 수정자를 단일 단어에 가능한 한 많이 적용
+# s/l/r/ : `l`을 찾아 `r`로 바꿈, 정규식 아님; `r`의 `&`는 `l`로 대체됨
+# & : 이전 대체 반복
 
-# start with this file
+# 이 파일로 시작
 set f = ~/Documents/Alpha/beta.txt
-# prints ~/Documents/Alpha/beta
+# ~/Documents/Alpha/beta 출력
 echo $f:r
-# prints ~/Documents/Alpha
+# ~/Documents/Alpha 출력
 echo $f:h
-# prints beta.txt
+# beta.txt 출력
 echo $f:t
-# prints txt
+# txt 출력
 echo $f:e
-# prints beta
+# beta 출력
 echo $f:t:r
-# prints Beta
+# Beta 출력
 echo $f:t:r:u
-# prints Biota
+# Biota 출력
 echo $f:t:r:u:s/eta/iota/
 
-# --- Redirection -------------------------------------------------------------
+# --- 리다이렉션 -------------------------------------------------------------
 
-# Create file.txt and write the standard output to it
+# file.txt를 만들고 표준 출력을 씁니다
 echo 'this string' > file.txt
-# Create file.txt and write the standard output and standard error to it
+# file.txt를 만들고 표준 출력과 표준 에러를 씁니다
 echo 'this string' >& file.txt
-# Append the standard output to file.txt
+# 표준 출력을 file.txt에 추가합니다
 echo 'this string' >> file.txt
-# Append the standard output and standard error to file.txt
+# 표준 출력과 표준 에러를 file.txt에 추가합니다
 echo 'this string' >>& file.txt
-# Redirect the standard input from file.txt
+# file.txt에서 표준 입력을 리다이렉션합니다
 cat < file.txt
-# Input from keyboard; this stores the input line to variable `x`
+# 키보드 입력; 입력 줄을 변수 `x`에 저장합니다
 set x = $<
-# Document here;
+# 여기에 문서;
 cat << LABEL
 ...text here...
 LABEL
 
-# TIP: this is how to get standard error separated:
+# 팁: 표준 에러를 분리하는 방법은 다음과 같습니다:
 (grep 'AGP' /usr/src/linux/Documentation/* > output-file.txt) >& error-file.txt
 
-# example: read a name from standard input and display a greetings message
+# 예: 표준 입력에서 이름을 읽고 인사 메시지를 표시합니다
 echo -n "Enter your name: "
 set name = $<
 echo "Greetings $name"
 
-# --- Expressions ------------------------------------------------------------
+# --- 표현식 ------------------------------------------------------------
 
-# Operators:
-# ==  equal         !=  not equal    !  not
-#  >  greater than   <  less than   >=  greater or equal  <= less or equal
-# &&  logical AND   ||  logical OR
+# 연산자:
+# ==  같음         !=  같지 않음    !  부정
+#  >  보다 큼   <  보다 작음   >=  크거나 같음  <= 작거나 같음
+# &&  논리 AND   ||  논리 OR
 
 if ( $name != $user ) then
     echo "Your name isn't your username"
@@ -261,24 +254,24 @@ else
     echo "Your name is your username"
 endif
 
-# single-line form
+# 한 줄 형식
 if ( $name != $user ) echo "Your name isn't your username"
 
-# NOTE: if $name is empty, tcsh sees the above condition as:
+# 참고: $name이 비어 있으면 tcsh는 위 조건을 다음과 같이 봅니다:
 # if ( != $user ) ...
-# which is invalid syntax
-# The "safe" way to use potentially empty variables in tcsh is:
+# 이것은 잘못된 구문입니다
+# tcsh에서 잠재적으로 비어 있는 변수를 사용하는 "안전한" 방법은 다음과 같습니다:
 # if ( "$name" != $user ) ...
-# which, when $name is empty, is seen by tcsh as:
+# $name이 비어 있을 때 tcsh는 이것을 다음과 같이 봅니다:
 # if ( "" != $user ) ...
-# which works as expected
+# 이것은 예상대로 작동합니다
 
-# There is also conditional execution
+# 조건부 실행도 있습니다
 echo "Always executed" || echo "Only executed if the first command fails"
 echo "Always executed" && echo "Only executed if the first command does NOT fail"
 
-# To use && and || with if statements, you don't need multiple pairs of
-# square brackets:
+# if 문에서 &&와 ||를 사용하려면 여러 쌍의
+# 대괄호가 필요하지 않습니다:
 if ( "$name" == "Steve" && "$age" == 15 ) then
     echo "This will run if $name is Steve AND $age is 15."
 endif
@@ -287,180 +280,179 @@ if ( "$name" == "Daniya" || "$name" == "Zach" ) then
     echo "This will run if $name is Daniya OR Zach."
 endif
 
-# String matching operators ( `=~` and `!~` )
-# The ‘==’ ‘!=’ ‘=~’ and ‘!~’ operators compare their arguments as strings;
-# all others operate on numbers. The operators ‘=~’ and ‘!~’ are like ‘!=’
-# and ‘==’ except that the right hand side is a glob-pattern against which
-# the left-hand operand is matched.
+# 문자열 일치 연산자 ( `=~` 및 `!~` )
+# '==' '!=' '=~' 및 '!~' 연산자는 인수를 문자열로 비교합니다;
+# 다른 모든 연산자는 숫자에 대해 작동합니다. '=~' 및 '!~' 연산자는 '!='
+# 및 '=='와 같지만 오른쪽이 왼쪽 피연산자와 일치하는
+# glob-패턴이라는 점이 다릅니다.
 
 if ( $user =~ ni[ck]* ) echo "Greetings Mr. Nicholas."
 if ( $user !~ ni[ck]* ) echo "Hey, get out of Nicholas' PC."
 
-# Arithmetic expressions are denoted with the following format:
+# 산술 표현식은 다음 형식으로 표시됩니다:
 @ result = 10 + 5
 echo $result
 
-# Arithmetic Operators
+# 산술 연산자
 # +, -, *, /, %
 #
-# Arithmetic Operators which must be parenthesized
+# 괄호로 묶어야 하는 산술 연산자
 # !, ~, |, &, ^, ~, <<, >>,
-# Compare and logical operators
+# 비교 및 논리 연산자
 #
-# All operators are the same as in C.
+# 모든 연산자는 C와 동일합니다.
 
-# It is non so well documented that numeric expressions require spaces
-# in-between; Also, `@` has its own parser, it seems that it works well when
-# the expression is parenthesized, otherwise the primary parser seems to be
-# active. Parentheses require spaces around, this is documented.
+# 숫자 표현식에 공백이 필요하다는 것은 잘 문서화되어 있지 않습니다;
+# 또한, `@`에는 자체 파서가 있으며, 표현식이 괄호로 묶여 있을 때 잘 작동하는 것 같습니다.
+# 그렇지 않으면 기본 파서가 활성 상태인 것 같습니다.
+# 괄호는 주위에 공백이 필요하며, 이것은 문서화되어 있습니다.
 
-# wrong
+# 잘못됨
 @ x = $y+1
 @ x = 0644 & 022;      echo $x
 @ x = (0644 & 022) +1; echo $x
 @ x = (0644 & 022)+ 1; echo $x
 @ x = ( ~077 );        echo $x
 
-# correct
+# 올바름
 @ x = $y + 1
 @ x = ( 0644 & 022 ) + 1; echo $x
 @ x = ( ~ 077 );          echo $x
 @ x = ( ~ 077 | 022 );    echo $x
 @ x = ( ! 0 );            echo $x
 
-# C's operators ++ and -- are supported if there is not assignment
+# C의 연산자 ++ 및 --는 할당이 없는 경우 지원됩니다
 @ result ++
 
-# No shell was created to do mathematics;
-# Except for the basic operations, use an external command with backslashes.
+# 수학을 하기 위해 만들어진 셸은 없습니다;
+# 기본 연산을 제외하고 백슬래시와 함께 외부 명령어를 사용하십시오.
 #
-# I suggest the calc as the best option.
+# 저는 calc를 최상의 옵션으로 제안합니다.
 # (http://www.isthe.com/chongo/tech/comp/calc/)
 #
-# The standard Unix's bc as the second option
+# 두 번째 옵션으로 표준 Unix의 bc
 # (https://www.gnu.org/software/bc/manual/html_mono/bc.html)
 #
-# The standard Unix's AWK as the third option
+# 세 번째 옵션으로 표준 Unix의 AWK
 # (https://www.gnu.org/software/gawk/manual/gawk.html)
 
-# You can also use `Perl`, `PHP`, `python`, or even several BASICs, but prefer
-# the above utilities for faster load-and-run results.
+# `Perl`, `PHP`, `python` 또는 여러 BASIC을 사용할 수도 있지만,
+# 더 빠른 로드 및 실행 결과를 위해 위 유틸리티를 선호하십시오.
 
-# real example: (that I answer in StackExchange)
-# REQ: x := 1001b OR 0110b
+# 실제 예: (StackExchange에서 답변한 내용)
+# 요구사항: x := 1001b OR 0110b
 
-# in `tcsh` expression (by using octal)
+# `tcsh` 표현식에서 (8진수 사용)
 @ x = ( 011 | 06 ); echo $x
 
-# the same by using `calc` (and using binary as the original req)
+# `calc`를 사용하여 동일하게 (원래 요구사항대로 이진수 사용)
 set x = `calc '0b1001 | 0b110'`; echo $x
 
-# --- File Inquiry Operators --------------------------------------------------
-# NOTE: The built-in `filetest` command does the same thing.
+# --- 파일 조회 연산자 --------------------------------------------------
+# 참고: 내장 `filetest` 명령어는 동일한 작업을 수행합니다.
 
-#### Boolean operators
-# -r  read access    -w  write access    -x  execute access    -e  existence
-# -f  plain file     -d  directory       -l  symbolic link     -p  named pipe
-# -S  socket file
-# -o  ownership      -z  zero size       -s  non-zero size
-# -u  SUID is set    -g  SGID is set     -k  sticky is set
-# -b  block device   -c  char device
-# -t  file (digit) is an open file descriptor for a terminal device
+#### 불리언 연산자
+# -r  읽기 접근    -w  쓰기 접근    -x  실행 접근    -e  존재
+# -f  일반 파일     -d  디렉토리       -l  심볼릭 링크     -p  명명된 파이프
+# -S  소켓 파일
+# -o  소유권      -z  크기 0       -s  크기 0 아님
+# -u  SUID 설정됨    -g  SGID 설정됨     -k  스티키 비트 설정됨
+# -b  블록 장치   -c  문자 장치
+# -t  파일(숫자)이 터미널 장치에 대한 열린 파일 디스크립터임
 
-# If the file `README` exists, display a message
+# `README` 파일이 존재하면 메시지를 표시합니다
 if ( -e README ) echo "I have already README file"
 
-# If the `less` program is installed, use it instead of `more`
+# `less` 프로그램이 설치되어 있으면 `more` 대신 사용합니다
 if ( -e `where less` ) then
     alias more 'less'
 endif
 
-#### Non-boolean operators
-# -Z  returns the file size in bytes
-# -M  returns the modification time (mtime)    -M: returns mtime string
-# -A  returns the last access time (atime)     -A: returns atime string
-# -U  returns the owner's user ID              -U: returns the owner's user name
-# -G  returns the owner's group ID             -G: returns the owner's group name
-# -P  returns the permissions as octal number  -Pmode returns perm. AND mode
+#### 비-불리언 연산자
+# -Z  파일 크기를 바이트 단위로 반환
+# -M  수정 시간(mtime) 반환    -M: mtime 문자열 반환
+# -A  마지막 접근 시간(atime) 반환     -A: atime 문자열 반환
+# -U  소유자 사용자 ID 반환              -U: 소유자 사용자 이름 반환
+# -G  소유자 그룹 ID 반환             -G: 소유자 그룹 이름 반환
+# -P  권한을 8진수로 반환  -Pmode는 권한과 모드의 AND 결과 반환
 
-# this will display the date as a Unix-time integer: 1498511486
+# 이것은 날짜를 유닉스 시간 정수로 표시합니다: 1498511486
 filetest -M README.md
 
-# This will display "Tue Jun 27 00:11:26 2017"
+# 이것은 "Tue Jun 27 00:11:26 2017"을 표시합니다
 filetest -M: README.md
 
-# --- Basic Commands ----------------------------------------------------------
+# --- 기본 명령어 ----------------------------------------------------------
 
-# Navigate through the filesystem with `chdir` (cd)
-cd path # change working directory
-cd      # change to the home directory
-cd -    # change to the previous directory
-cd ..   # go up one directory
+# `chdir` (cd)로 파일 시스템 탐색
+cd path # 작업 디렉토리 변경
+cd      # 홈 디렉토리로 변경
+cd -    # 이전 디렉토리로 변경
+cd ..   # 한 디렉토리 위로 이동
 
-# Examples:
-cd ~/Downloads # go to my `Downloads` directory
+# 예:
+cd ~/Downloads # 나의 `Downloads` 디렉토리로 이동
 
-# Use `mkdir` to create new directories.
+# `mkdir`를 사용하여 새 디렉토리 생성.
 mkdir newdir
-# The `-p` flag causes new intermediate directories to be created as necessary.
+# `-p` 플래그는 필요에 따라 새 중간 디렉토리를 생성합니다.
 mkdir -p ~/.backup/saves
 
 # which & where
-# find if csh points to tcsh
+# csh가 tcsh를 가리키는지 찾기
 ls -lha `which csh`
-# find if csh is installed on more than one directory
+# csh가 둘 이상의 디렉토리에 설치되어 있는지 찾기
 where csh
 
-# --- Pipe-lines --------------------------------------------------------------
-# A pipeline is a sequence of processes chained together by their standard
-# streams, so that the output of each process (stdout) feeds directly as input
-# (stdin) to the next one. These `pipes` are created with the `|` special
-# character and it is one of the most powerful characteristics of Unix.
+# --- 파이프라인 --------------------------------------------------------------
+# 파이프라인은 각 프로세스의 출력(stdout)이 다음 프로세스의 입력(stdin)으로
+# 직접 공급되도록 표준 스트림으로 함께 연결된 프로세스 시퀀스입니다.
+# 이러한 `파이프`는 `|` 특수 문자로 생성되며 유닉스의 가장 강력한
+# 특징 중 하나입니다.
 
-# example:
+# 예:
 ls -l | grep key | less
-# "ls -l" produces a process, the output (stdout) of which is piped to the
-# input (stdin) of the process for "grep key"; and likewise for the process
-# for "less".
+# "ls -l"은 프로세스를 생성하고, 그 출력(stdout)은 "grep key" 프로세스의
+# 입력(stdin)으로 파이프됩니다. "less" 프로세스도 마찬가지입니다.
 
-# the `ls`, the `grep`, and the `less` are Unix programs and they have their
-# own man-page. The `pipe` mechanism is part of the kernel but the syntax
-# and the control is the shell's job, the tcsh in our case.
+# `ls`, `grep`, `less`는 유닉스 프로그램이며 자체 맨페이지가 있습니다.
+# `파이프` 메커니즘은 커널의 일부이지만 구문과 제어는
+# 셸의 역할이며, 이 경우 tcsh입니다.
 
-# NOTE: Windows has the `pipe` mechanism too, but it is buggy and I signed it
-# for all versions until Windows XP SP3 API32 which was the last one that I
-# worked on. Microsoft denied it, but it is a well-known bug since it is a
-# common method for inter-process communication. For small I/O it will work well.
-# tcsh, along with grep, GCC, and Perl is one of the first Unix programs that
-# ported to DOS (with EMX DOS extender) and later to Windows (1998).
+# 참고: Windows에도 `파이프` 메커니즘이 있지만 버그가 있으며, 제가 마지막으로
+# 작업했던 Windows XP SP3 API32까지 모든 버전에 대해 서명했습니다.
+# Microsoft는 이를 부인했지만, 프로세스 간 통신에 일반적인 방법이기 때문에
+# 잘 알려진 버그입니다. 작은 I/O의 경우 잘 작동합니다.
+# tcsh는 grep, GCC, Perl과 함께 DOS(EMX DOS 확장기 사용) 및
+# 나중에 Windows(1998)로 포팅된 최초의 유닉스 프로그램 중 하나입니다.
 
-# example: this will convert tcsh to PostScript and will show it with Okular
+# 예: 이것은 tcsh를 PostScript로 변환하고 Okular로 보여줍니다
 zcat /usr/man/man1/tcsh.1.gz | groff -Tps -man | okular -
 
-# a better version
+# 더 나은 버전
 zcat `locate -b -n 1 '\tcsh.1.gz'` | groff -Tps -man | okular -
 
-# even better
+# 훨씬 더 나은 버전
 set page = tcsh; set loc = (locate -b -n 1 "\\\\"${page}".1.gz");
  zcat `eval $loc` | groff -Tps -man | okular -
 
-# the same, modified to create man page pdf
+# 동일, 맨페이지 pdf를 생성하도록 수정
 set page = tcsh; set loc = (locate -b -n 1 "\\\\"${page}".1.gz");
  zcat `eval $loc` | groff -Tps -man | ps2pdf - ${page}.pdf
 
-# the same, but now shows the ${page}.pdf too
+# 동일, 이제 ${page}.pdf도 표시
 set page = tcsh; set loc = (locate -b -n 1 "\\\\"${page}".1.gz");
  zcat `eval $loc` | groff -Tps -man | ps2pdf - ${page}.pdf && okular tcsh.pdf
 
-# NOTE: `okular` is the default application of the KDE environment and it shows
-# postcript and pdf files. You can replace it with your lovely PDF viewer.
-# `zcat`, `locate`, `groff`, are common programs in all Unixes. The `ps2pdf`
-# program is part of the `ghostscript` package that is widely used.
+# 참고: `okular`는 KDE 환경의 기본 응용 프로그램이며 포스트스크립트 및
+# pdf 파일을 표시합니다. 좋아하는 PDF 뷰어로 교체할 수 있습니다.
+# `zcat`, `locate`, `groff`는 모든 유닉스에서 일반적인 프로그램입니다. `ps2pdf`
+# 프로그램은 널리 사용되는 `ghostscript` 패키지의 일부입니다.
 
-# --- Control Flow ------------------------------------------------------------
+# --- 제어 흐름 ------------------------------------------------------------
 
 #### IF-THEN-ELSE-ENDIF
-# Syntax:
+# 구문:
 # if ( expr ) then
 #    ...
 # [else if ( expr2 ) then
@@ -469,37 +461,35 @@ set page = tcsh; set loc = (locate -b -n 1 "\\\\"${page}".1.gz");
 #    ...]
 # endif
 #
-# If the specified `expr` is true then the commands to the first else are
-# executed; otherwise if `expr2` is true then the commands to the second else
-# are executed, etc.
-# Any number of else-if pairs are possible; only one endif is needed.
+# 지정된 `expr`이 참이면 첫 번째 else까지의 명령어가 실행됩니다;
+# 그렇지 않고 `expr2`가 참이면 두 번째 else까지의 명령어가 실행되는 식입니다.
+# else-if 쌍은 얼마든지 가능하며, endif는 하나만 필요합니다.
 #
-# Single-line form:
+# 한 줄 형식:
 #
 # if ( expr ) command
 #
-# If `expr` evaluates to true, then the command is executed.
-# `command` must be a simple command, not an alias, a pipeline, a command list
-#, or a parenthesized command list. With a few words, avoid using it.
+# `expr`이 참으로 평가되면 명령어가 실행됩니다.
+# `command`는 단순 명령어여야 하며, 별칭, 파이프라인, 명령어 목록
+#, 또는 괄호로 묶인 명령어 목록이 아니어야 합니다. 간단히 말해 사용을 피하십시오.
 #
-# BUG: Input/output redirection occurs even if expr is false and the command
-# is thus not executed.
+# 버그: expr이 거짓이고 명령어가 실행되지 않더라도 입/출력 리다이렉션이 발생합니다.
 #
 
-# check if we are in a non-interactive shell and quit if true
+# 비대화형 셸인지 확인하고 참이면 종료
 if ( $?USER == 0 || $?prompt == 0 ) exit
 
-# check if we are a login shell
+# 로그인 셸인지 확인
 if ( $?loginsh ) then
-    # check if you are on linux console (not X's terminal)
+    # 리눅스 콘솔에 있는지 확인 (X의 터미널 아님)
     if ( $tty =~ tty* ) then
-        # enable keypad application keys (man console_codes)
+        # 키패드 응용 프로그램 키 활성화 (man console_codes)
         echo '\033='
     endif
 endif
 
 #### SWITCH-ENDSW
-# Syntax:
+# 구문:
 # switch ( expr )
 # case pattern:
 #     ...
@@ -508,13 +498,13 @@ endif
 #     ...]
 # endsw
 #
-# tcsh uses a case statement that works similarly to switch in C.
-# Each case label is successively matched, against the specified string which
-# is first command and filename expanded. The file metacharacters `*`, `?`
-# and `[...]` may be used in the case labels. If none of the labels match the
-# execution begins after the default label if it's defined.
-# The command `breaksw` causes execution to continue after the endsw. Otherwise,
-# control may fall through case labels and default labels as in C.
+# tcsh는 C의 switch와 유사하게 작동하는 case 문을 사용합니다.
+# 각 case 레이블은 먼저 명령어와 파일 이름이 확장된 지정된 문자열과
+# 순차적으로 일치합니다. 파일 메타문자 `*`, `?`, `[...]`를 case 레이블에
+# 사용할 수 있습니다. 레이블이 일치하지 않으면 정의된 경우 기본 레이블
+# 다음에 실행이 시작됩니다.
+# `breaksw` 명령어는 endsw 다음에 실행을 계속하도록 합니다. 그렇지 않으면
+# C에서처럼 제어가 case 레이블과 기본 레이블을 통과할 수 있습니다.
 
 switch ( $var )
 case *.[1-9]:
@@ -529,30 +519,30 @@ default:
 endsw
 
 #### FOREACH-END
-# Syntax:
+# 구문:
 # foreach name ( wordlist )
 #    ...
 #   [break | continue]
 # end
 #
-# Successively sets the variable `name` to each member of `wordlist` and
-# executes the sequence of commands between this command and the matching
-# `end` keyword. The `continue` keyword jumps to the next element back to
-# top, and the `break` keyword terminates the loop.
+# 변수 `name`을 `wordlist`의 각 멤버로 순차적으로 설정하고
+# 이 명령어와 일치하는 `end` 키워드 사이의 명령어 시퀀스를 실행합니다.
+# `continue` 키워드는 맨 위로 돌아가 다음 요소로 점프하고, `break` 키워드는
+# 루프를 종료합니다.
 #
-# BUG: `foreach` doesn't ignore here documents when looking for its end.
+# 버그: `foreach`는 끝을 찾을 때 here document를 무시하지 않습니다.
 
-# example: counting 1 to 10
+# 예: 1에서 10까지 세기
 foreach i ( `seq 1 10` )
     echo $i
 end
 
-# example: type all files in the list
+# 예: 목록의 모든 파일 유형
 foreach f ( a.txt b.txt c.txt )
     cat $f
 end
 
-# example: convert wma to ogg
+# 예: wma를 ogg로 변환
 foreach f ( *.wma )
     ffmpeg -i "$f" "$f:r".ogg
 end
@@ -563,25 +553,25 @@ end
 #     [break | continue]
 # end
 #
-# Executes the commands between the `while` and the matching `end` while `expr`
-# evaluates non-zero. `break` and `continue` may be used to terminate or
-# continue the loop prematurely.
+# `expr`이 0이 아닌 값으로 평가되는 동안 `while`과 일치하는 `end` 사이의
+# 명령어를 실행합니다. `break`와 `continue`를 사용하여 루프를 조기에
+# 종료하거나 계속할 수 있습니다.
 
-# count from 1 to 10
+# 1에서 10까지 세기
 set num = 1
 while ( $num <= 10 )
     echo $num
     @ num ++
 end
 
-# print all directories of CWD
+# CWD의 모든 디렉토리 출력
 set lst = ( * )
 while ( $#lst )
     if ( -d $lst[1] ) echo $lst[1] is directory
     shift lst
 end
 
-# separate command-line arguments to options or parameters
+# 명령줄 인수를 옵션 또는 매개변수로 분리
 set options
 set params
 set lst = ( $* )
@@ -597,44 +587,42 @@ echo 'options =' $options
 echo 'parameters =' $params
 
 #### REPEAT
-# Syntax: repeat count command
+# 구문: repeat count command
 #
-# The specified command, which is subject to the same restrictions as the
-# command in the one line `if` statement above, is executed count times.
-# I/O redirections occur exactly once, even if `count` is 0.
+# 위 한 줄 `if` 문의 명령어와 동일한 제한을 받는 지정된 명령어가
+# count 횟수만큼 실행됩니다.
+# `count`가 0이더라도 I/O 리다이렉션은 정확히 한 번 발생합니다.
 #
-# TIP: in most cases prefer `while`
+# 팁: 대부분의 경우 `while`을 선호하십시오
 
 repeat 3 echo "ding dong"
 
-# --- Functions ---------------------------------------------------------------
-# tcsh has no functions but its expression syntax is advanced enough to use
-# `alias` as functions. Another method is recursion
+# --- 함수 ---------------------------------------------------------------
+# tcsh에는 함수가 없지만 표현식 구문이 `alias`를 함수로 사용할 만큼
+# 충분히 발전했습니다. 다른 방법은 재귀입니다
 
-# Alias argument selectors; the ability to define an alias to take arguments
-# supplied to it and apply them to the commands that it refers to.
-# Tcsh is the only shell that provides this feature.
+# 별칭 인수 선택자; 별칭에 제공된 인수를 가져와 참조하는 명령어에
+# 적용하는 기능을 정의하는 기능입니다.
+# Tcsh는 이 기능을 제공하는 유일한 셸입니다.
 #
-# \!#   argument selector for all arguments, including the alias/command
-#       itself; arguments need not be supplied.
-# \!*   argument selector for all arguments, excluding the alias/command;
-#       arguments need not be supplied.
-# \!$   argument selector for the last argument; argument need not be supplied,
-#       but if none is supplied, the alias name is considered to be the
-#       last argument.
-# \!^   argument selector for first argument; argument MUST be supplied.
-# \!:n  argument selector for the nth argument; argument MUST be supplied;
-#       n=0 refers to the alias/command name.
-# \!:m-n   argument selector for the arguments from the mth to the nth;
-#       arguments MUST be supplied.
-# \!:n-$   argument selector for the arguments from the nth to the last;
-#       at least argument n MUST be supplied.
+# \!#   별칭/명령어 자체를 포함한 모든 인수에 대한 인수 선택자;
+#       인수를 제공할 필요는 없습니다.
+# \!*   별칭/명령어를 제외한 모든 인수에 대한 인수 선택자;
+#       인수를 제공할 필요는 없습니다.
+# \!$   마지막 인수에 대한 인수 선택자; 인수를 제공할 필요는 없지만,
+#       아무것도 제공되지 않으면 별칭 이름이 마지막 인수로 간주됩니다.
+# \!^   첫 번째 인수에 대한 인수 선택자; 인수를 반드시 제공해야 합니다.
+# \!:n  n번째 인수에 대한 인수 선택자; 인수를 반드시 제공해야 합니다;
+#       n=0은 별칭/명령어 이름을 나타냅니다.
+# \!:m-n   m번째부터 n번째까지의 인수에 대한 인수 선택자;
+#       인수를 반드시 제공해야 합니다.
+# \!:n-$   n번째부터 마지막까지의 인수에 대한 인수 선택자;
+#       적어도 n번째 인수는 반드시 제공해야 합니다.
 
-# Alias the cd command so that when you change directories, the contents
-# are immediately displayed.
+# 디렉토리를 변경할 때 내용이 즉시 표시되도록 cd 명령어에 별칭을 지정합니다.
 alias cd 'cd \!* && ls'
 
-# --- Recursion method --- begin ---
+# --- 재귀 방식 --- 시작 ---
 #!/bin/tcsh -f
 set todo = option1
 if ( $#argv > 0 ) then
@@ -658,36 +646,36 @@ default:
     echo "Unknown option: $todo"
 #    exit 0
 endsw
-# --- Recursion method --- end ---
+# --- 재귀 방식 --- 끝 ---
 
-# --- examples ----------------------------------------------------------------
+# --- 예제 ----------------------------------------------------------------
 
-# this script prints available power-states if no argument is set;
-# otherwise it sets the state of the $argv[1]
-# --- power-state script --- begin --------------------------------------------
+# 이 스크립트는 인수가 설정되지 않은 경우 사용 가능한 전원 상태를 출력합니다;
+# 그렇지 않으면 $argv[1]의 상태를 설정합니다
+# --- 전원 상태 스크립트 --- 시작 --------------------------------------------
 #!/bin/tcsh -f
-# get parameter ("help" for none)
+# 매개변수 가져오기 (없으면 "help")
 set todo = help
 if ( $#argv > 0 ) then
     set todo = $argv[1]
 endif
-# available options
+# 사용 가능한 옵션
 set opts = `cat /sys/power/state`
-# is known?
+# 알려져 있습니까?
 foreach o ( $opts )
     if ( $todo == $o ) then
-        # found; execute it
+        # 찾음; 실행
         echo -n $todo > /sys/power/state
         break
     endif
 end
-# print help and exit
+# 도움말 출력 및 종료
 echo "usage: $0 [option]"
 echo "available options on kernel: $opts"
-# --- power-state script --- end ----------------------------------------------
+# --- 전원 상태 스크립트 --- 끝 ----------------------------------------------
 
-# Guess the secret number game
-# --- secretnum.csh --- begin -------------------------------------------------
+# 비밀 숫자 맞추기 게임
+# --- secretnum.csh --- 시작 -------------------------------------------------
 #!/bin/tcsh -f
 set secret=`shuf -i1-100 -n1`
 echo "I have a secret number from 1 up to 100"
@@ -706,52 +694,51 @@ while ( 1 )
         endif
     endif
 end
-# --- secretnum.csh --- end ---------------------------------------------------
+# --- secretnum.csh --- 끝 ---------------------------------------------------
 
 # -----------------------------------------------------------------------------
-# Appendices
+# 부록
 
-#### About [T]CSH:
-# * CSH is notorious for its bugs;
-# * It is also famous for its advanced interactive mode.
-# * TCSH is famous for having the most advanced completion subsystem.
-# * TCSH is famous for having the most advanced aliases subsystem; aliases
-#   can take parameters and often be used as functions!
-# * TCSH is well known and preferred by people (me too) because of better
-#   syntax. All shells are using Thomson's syntax with the exception of
-#   [t]csh, fish, and plan9's shells (rc, ex).
-# * It is smaller and consumes far less memory than bash, zsh, and even mksh!
-#   (memusage reports)
-# * TCSH still has bugs; fewer, but it does; if you write readable clean code
-#   you'll find none; well almost none... This has to do with the implementation
-#   of csh; that doesn't mean the other shells have a good implementation.
-# * no well-known shell is capable of regular programming; if your script
-#   is getting big, use a programming language, like Python, PHP, or Perl (good
-#   scripting languages).
+#### [T]CSH에 대하여:
+# * CSH는 버그로 악명이 높습니다;
+# * 또한 고급 대화형 모드로도 유명합니다.
+# * TCSH는 가장 진보된 완성 하위 시스템을 갖춘 것으로 유명합니다.
+# * TCSH는 가장 진보된 별칭 하위 시스템을 갖춘 것으로 유명합니다; 별칭은
+#   매개변수를 사용할 수 있으며 종종 함수로 사용될 수 있습니다!
+# * TCSH는 더 나은 구문 때문에 사람들에게 잘 알려져 있고 선호됩니다 (저도 마찬가지).
+#   모든 셸은 [t]csh, fish, plan9의 셸(rc, ex)을 제외하고 Thomson의 구문을 사용합니다.
+# * bash, zsh, 심지어 mksh보다 작고 메모리를 훨씬 적게 소비합니다!
+#   (memusage 보고서)
+# * TCSH에는 여전히 버그가 있습니다. 더 적지만 있습니다. 읽기 쉬운 깨끗한 코드를 작성하면
+#   아무것도 찾을 수 없을 것입니다. 글쎄, 거의 없을 것입니다... 이것은 csh의 구현과
+#   관련이 있습니다. 다른 셸의 구현이 좋다는 의미는 아닙니다.
+# * 잘 알려진 셸 중 정규 프로그래밍이 가능한 셸은 없습니다. 스크립트가
+#   커지면 Python, PHP 또는 Perl과 같은 프로그래밍 언어를 사용하십시오 (좋은
+#   스크립팅 언어).
 #
-# Advice:
-# 1. Do not use redirection in single-line IFs (it is well documented bug)
-#    In most cases avoid using single-line IFs.
-# 2. Do not mess up with other shells' code, c-shell is not compatible with
-#    other shells and has different abilities and priorities.
-# 3. Use spaces as you'll use them to write readable code in any language.
-#    A bug of csh was `set x=1` and `set x = 1` worked, but `set x =1` did not!
-# 4. It is well documented that numeric expressions require spaces in between;
-#    also parenthesize all bit-wise and unary operators.
-# 5. Do not write a huge weird expression with several quotes, backslashes, etc
-#    It is bad practice for generic programming, it is dangerous in any shell.
-# 6. Help tcsh, report the bug here <https://bugs.gw.com/>
-# 7. Read the man page, `tcsh` has a huge number of options and variables.
+# 조언:
+# 1. 한 줄 IF에서 리다이렉션을 사용하지 마십시오 (잘 알려진 버그입니다)
+#    대부분의 경우 한 줄 IF 사용을 피하십시오.
+# 2. 다른 셸의 코드를 망치지 마십시오. c-shell은 다른 셸과 호환되지 않으며
+#    다른 기능과 우선순위를 가지고 있습니다.
+# 3. 어떤 언어로든 읽기 쉬운 코드를 작성하는 것처럼 공백을 사용하십시오.
+#    csh의 버그는 `set x=1`과 `set x = 1`은 작동했지만 `set x =1`은 작동하지 않았습니다!
+# 4. 숫자 표현식 사이에 공백이 필요하다는 것은 잘 문서화되어 있습니다;
+#    또한 모든 비트 및 단항 연산자를 괄호로 묶으십시오.
+# 5. 여러 따옴표, 백슬래시 등으로 거대하고 이상한 표현식을 작성하지 마십시오.
+#    일반 프로그래밍에 좋지 않은 습관이며 어떤 셸에서든 위험합니다.
+# 6. tcsh를 도와주세요, 여기에 버그를 보고하세요 <https://bugs.gw.com/>
+# 7. 맨페이지를 읽으십시오. `tcsh`에는 엄청난 수의 옵션과 변수가 있습니다.
 #
-#    I suggest the following options enabled by default
+#    기본적으로 다음 옵션을 활성화하는 것이 좋습니다
 #    --------------------------------------------------
-# Even in non-interactive shells
+# 비대화형 셸에서도
 #    set echo_style=both
 #    set backslash_quote
 #    set parseoctal
 #    unset noclobber
 #
-# Whatever...
+# 무엇이든...
 #    set inputmode=insert
 #    set autolist
 #    set listjobs
@@ -771,22 +758,22 @@ end
 #    unset time
 #    unset tperiod
 #
-# NOTE: If the `backslash_quote` is set, it may create compatibility issues
-# with other tcsh scripts that were written without it.
+# 참고: `backslash_quote`가 설정되면, 그것 없이 작성된 다른 tcsh 스크립트와
+# 호환성 문제가 발생할 수 있습니다.
 #
-# NOTE: The same for `parseoctal`, but it is better to fix the problematic
-# scripts.
+# 참고: `parseoctal`도 마찬가지이지만, 문제가 있는 스크립트를 수정하는 것이
+# 더 좋습니다.
 #
-# NOTE: **for beginners only**
-# This enables automatic rescanning of `path` directories if needed. (like bash)
+# 참고: **초보자 전용**
+# 필요한 경우 `path` 디렉토리를 자동으로 다시 스캔할 수 있습니다. (bash처럼)
 #    set autorehash
 
-#### common aliases
+#### 일반적인 별칭
 #    alias hist  'history 20'
 #    alias ll    'ls --color -lha'
 #    alias today "date '+%d%h%y'
 #    alias ff    'find . -name '
 
-#### a nice prompt
+#### 멋진 프롬프트
 #    set prompt = "%B%{\033[35m%}%t %{\033[32m%}%n@%m%b %C4 %# "
 ```

--- a/ko/textile.md
+++ b/ko/textile.md
@@ -8,495 +8,487 @@ filename: learn-textile.textile
 ---
 
 
-Textile is a lightweight markup language that uses a text formatting syntax to
-convert plain text into structured HTML markup. The syntax is a shorthand
-version of HTML that is designed to be easy to read and write. Textile is used
-for writing articles, forum posts, readme documentation, and any other type of
-written content published online.
+Textile은 텍스트 서식 구문을 사용하여 일반 텍스트를 구조화된 HTML 마크업으로 변환하는 경량 마크업 언어입니다. 구문은 읽고 쓰기 쉽도록 설계된 HTML의 약식 버전입니다. Textile은 기사, 포럼 게시물, readme 문서 및 온라인에 게시되는 기타 모든 유형의 서면 콘텐츠를 작성하는 데 사용됩니다.
 
-- [Comments](#comments)
-- [Paragraphs](#paragraphs)
-- [Headings](#headings)
-- [Simple Text Styles](#simple-text-styles)
-- [Lists](#lists)
-- [Code blocks](#code-blocks)
-- [Horizontal rule](#horizontal-rule)
-- [Links](#links)
-- [Images](#images)
-- [Footnotes and Endnotes](#footnotes-and-endnotes)
-- [Tables](#tables)
-- [Character Conversions](#character-conversions)
+- [주석](#comments)
+- [단락](#paragraphs)
+- [제목](#headings)
+- [간단한 텍스트 스타일](#simple-text-styles)
+- [목록](#lists)
+- [코드 블록](#code-blocks)
+- [가로줄](#horizontal-rule)
+- [링크](#links)
+- [이미지](#images)
+- [각주 및 미주](#footnotes-and-endnotes)
+- [표](#tables)
+- [문자 변환](#character-conversions)
 - [CSS](#css)
-- [Spans and Divs](#spans-and-divs)
-- [Additional Info](#additional-info)
+- [스팬 및 Div](#spans-and-divs)
+- [추가 정보](#additional-info)
 
-## Comments
+## 주석
 
 ```
-###. Comments begin with three (3) '#' signs followed by a full-stop period '.'.
-Comments can span multiple lines until a blank line is reached.
+###. 주석은 세(3) 개의 '#' 기호와 마침표 '.'로 시작합니다.
+주석은 빈 줄이 나올 때까지 여러 줄에 걸쳐 있을 수 있습니다.
 
 ###..
-Multi-line comments (including blank lines) are indicated by three (3) '#'
-signs followed by two (2) full-stop periods '..'.
+여러 줄 주석(빈 줄 포함)은 세(3) 개의 '#'
+기호와 두(2) 개의 마침표 '..'로 표시됩니다.
 
-This line is also part of the above comment.
+이 줄도 위 주석의 일부입니다.
 
-The comment continues until the next block element is reached
+주석은 다음 블록 요소가 나올 때까지 계속됩니다
 
-p. This line is not commented
+p. 이 줄은 주석 처리되지 않았습니다
 
-<!-- HTML comments are also…
+<!-- HTML 주석도…
 
-respected -->
+존중됩니다 -->
 ```
 
-## Paragraphs
+## 단락
 
 ```
-###. Paragraphs are a one or multiple adjacent lines of text separated by one or
-multiple blank lines. They can also be indicated explicitly with a 'p. '
+###. 단락은 하나 이상의 빈 줄로 구분된 하나 또는 여러 개의 인접한 텍스트 줄입니다. 'p. '로 명시적으로 표시할 수도 있습니다.
 
-This is a paragraph. I'm typing in a paragraph isn't this fun?
+이것은 단락입니다. 단락에 입력하는 것이 재미있지 않나요?
 
-Now I'm in paragraph 2.
-I'm still in paragraph 2 too!
-Line breaks without blank spaces are equivalent to a <br /> in XHTML.
+이제 단락 2에 있습니다.
+저도 아직 단락 2에 있습니다!
+빈 공간이 없는 줄 바꿈은 XHTML의 <br />과 동일합니다.
 
-p. I'm an explicitly defined paragraph
+p. 저는 명시적으로 정의된 단락입니다
 
- Lines starting with a blank space are not wrapped in <p>..</p> tags.
+ 빈 공간으로 시작하는 줄은 <p>..</p> 태그로 래핑되지 않습니다.
 
-###. Paragraphs (and all block elements) can be aligned using shorthand:
+###. 단락(및 모든 블록 요소)은 약식으로 정렬할 수 있습니다:
 
-p<. Left aligned paragraph (default).
+p<. 왼쪽 정렬 단락(기본값).
 
-p>. Right aligned paragraph.
+p>. 오른쪽 정렬 단락.
 
-p=. Centered paragraph.
+p=. 가운데 정렬 단락.
 
-p<>. Justified paragraph.
+p<>. 양쪽 정렬 단락.
 
-h3>. Right aligned <h3>
-
-
-###. Paragraphs can be indented using a parentheses for each em
-Indentation utilizes padding-[left/right] css styles.
-
-p(. Left indent 1em.
-
-p((. Left indent 2em.
-
-p))). Right indent 3em.
-
-h2). This is equivalent to <h2 style="padding-right: 1em;">..</h2>
+h3>. 오른쪽 정렬 <h3>
 
 
-###. Block quotes use the tag 'bq.'
+###. 단락은 각 em에 대해 괄호를 사용하여 들여쓸 수 있습니다.
+들여쓰기는 padding-[left/right] css 스타일을 사용합니다.
 
-bq. This is a block quote.
+p(. 왼쪽 1em 들여쓰기.
 
-bq.:http://someurl.com You can include a citation URL immediately after the '.'
+p((. 왼쪽 2em 들여쓰기.
 
-bq.. Multi-line blockquotes containing
+p))). 오른쪽 3em 들여쓰기.
 
-blank lines are indicated using two periods
-
-p. Multi-line blockquotes continue until a new block element is reached.
-
-bq. You can add a footer to a blockquote using html:
-<footer>citation text</footer>
+h2). 이것은 <h2 style="padding-right: 1em;">..</h2>와 동일합니다.
 
 
-###. Preformatted text blocks:
+###. 블록 인용은 'bq.' 태그를 사용합니다.
 
-pre. This text is preformatted.  <= those two spaces will carry through.
+bq. 이것은 블록 인용입니다.
 
-pre.. This is a multi-line preformatted…
+bq.:http://someurl.com '.' 바로 뒤에 인용 URL을 포함할 수 있습니다.
 
-…text block that includes blank lines
+bq.. 빈 줄을 포함하는 여러 줄 블록 인용은
+두 개의 마침표를 사용하여 표시됩니다
 
-p. End a multi-line preformatted text block with a new block element.
+p. 여러 줄 블록 인용은 새 블록 요소가 나올 때까지 계속됩니다.
+
+bq. html을 사용하여 블록 인용에 바닥글을 추가할 수 있습니다:
+<footer>인용 텍스트</footer>
+
+
+###. 서식이 미리 지정된 텍스트 블록:
+
+pre. 이 텍스트는 서식이 미리 지정되었습니다.  <= 저 두 개의 공백은 그대로 유지됩니다.
+
+pre.. 이것은 여러 줄로 된 서식이 미리 지정된...
+
+…빈 줄을 포함하는 텍스트 블록입니다
+
+p. 여러 줄로 된 서식이 미리 지정된 텍스트 블록을 새 블록 요소로 끝냅니다.
 ```
 
-## Headings
+## 제목
 
-You can create HTML elements `<h1>` through `<h6>` easily by prepending the
-text you want to be in that element by 'h#.' where # is the level 1-6.
-A blank line is required after headings.
+<h1>부터 <h6>까지의 HTML 요소를 해당 요소에 넣고 싶은 텍스트 앞에 'h#.'을 붙여 쉽게 만들 수 있습니다. 여기서 #은 1-6 수준입니다.
+제목 뒤에는 빈 줄이 필요합니다.
 
 
 ```
-h1. This is an <h1>
+h1. 이것은 <h1>입니다
 
-h2. This is an <h2>
+h2. 이것은 <h2>입니다
 
-h3. This is an <h3>
+h3. 이것은 <h3>입니다
 
-h4. This is an <h4>
+h4. 이것은 <h4>입니다
 
-h5. This is an <h5>
+h5. 이것은 <h5>입니다
 
-h6. This is an <h6>
+h6. 이것은 <h6>입니다
 ```
 
 
-## Simple text styles
+## 간단한 텍스트 스타일
 
 ```
-###. Bold and strong text are indicated using asterisks:
+###. 굵은 텍스트와 강조 텍스트는 별표를 사용하여 표시됩니다:
 
-*This is strong text*
-**This is bold text**
-This is [*B*]old text within a word.
+*이것은 강조 텍스트입니다*
+**이것은 굵은 텍스트입니다**
+이것은 단어 안의 [*굵은*] 텍스트입니다.
 
-*Strong* and **Bold** usually display the same in browsers
-but they use different HTML markup, thus the distinction.
+*강조*와 **굵게**는 일반적으로 브라우저에서 동일하게 표시되지만
+다른 HTML 마크업을 사용하므로 구별됩니다.
 
-###. Italics and emphasized text are indicated using underscores.
+###. 이탤릭체 및 강조 텍스트는 밑줄을 사용하여 표시됩니다.
 
-_This is Emphasized text_
-__This is Italics text__
-This is It[_al_]ics within a word.
+_이것은 강조된 텍스트입니다_
+__이것은 이탤릭체 텍스트입니다__
+이것은 단어 안의 이탤[_릭_]체입니다.
 
-_Emphasized_ and __Italics__ text typically display the same in browsers,
-but again, they use different HTML markup and thus the distinction.
+_강조된_ 텍스트와 __이탤릭체__ 텍스트는 일반적으로 브라우저에서 동일하게 표시되지만,
+다시 말하지만, 다른 HTML 마크업을 사용하므로 구별됩니다.
 
-###. Superscripts and Subscripts use carats and tildes:
+###. 위 첨자와 아래 첨자는 캐럿과 물결표를 사용합니다:
 
-Superscripts are 2 ^and^ to none, but subscripts are CO ~2~ L too.
-Note the spaces around the superscripts and subscripts.
+위 첨자는 2^와^ 같고, 아래 첨자는 CO~2~L입니다.
+위 첨자와 아래 첨자 주위의 공백에 유의하십시오.
 
-To avoid the spaces, add square brackets around them:
-2[^and^] and CO[~2~]L
+공백을 피하려면 대괄호를 사용하십시오:
+2[^and^] 및 CO[~2~]L
 
-###. Insertions and deletions are indicated using -/+ symbols:
-This is -deleted- text and this is +inserted+ text.
+###. 삽입 및 삭제는 -/+ 기호로 표시됩니다:
+이것은 -삭제된- 텍스트이고 이것은 +삽입된+ 텍스트입니다.
 
-###. Citations are indicated using double '?':
+###. 인용은 이중 '?'로 표시됩니다:
 
-??This is a cool citation??
+??이것은 멋진 인용입니다??
 ```
 
-## Lists
+## 목록
 
 ```
-###. Unordered lists can be made using asterisks '*' to indicate levels:
+###. 순서 없는 목록은 별표 '*'를 사용하여 수준을 나타낼 수 있습니다:
 
-* Item
-** Sub-Item
-* Another item
-** Another sub-item
-** Yet another sub-item
-*** Three levels deep
+* 항목
+** 하위 항목
+* 다른 항목
+** 다른 하위 항목
+** 또 다른 하위 항목
+*** 3단계 깊이
 
-###. Ordered lists are done with a pound sign '#':
+###. 순서 있는 목록은 파운드 기호 '#'로 수행됩니다:
 
-# Item one
-# Item two
-## Item two-a
-## Item two-b
-# Item three
-** Mixed unordered list within ordered list
+# 항목 1
+# 항목 2
+## 항목 2-a
+## 항목 2-b
+# 항목 3
+** 순서 있는 목록 내의 혼합된 순서 없는 목록
 
-###. Ordered lists can start above 1 and can continue after another block:
+###. 순서 있는 목록은 1 이상에서 시작할 수 있으며 다른 블록 뒤에 계속될 수 있습니다:
 
-#5 Item 5
-# Item 6
+#5 항목 5
+# 항목 6
 
-additional paragraph
+추가 단락
 
-#_ Item 7 continued from above
-# Item 8
+#_ 위에서 계속되는 항목 7
+# 항목 8
 
-###. Definition lists are indicated with a dash and assignment:
+###. 정의 목록은 대시와 할당으로 표시됩니다:
 
-- First item := first item definition
-- Second := second def.
-- Multi-line :=
-Multi-line
-definition =:
+- 첫 번째 항목 := 첫 번째 항목 정의
+- 두 번째 := 두 번째 정의
+- 여러 줄 :=
+여러 줄
+정의 =:
 ```
 
-## Code blocks
+## 코드 블록
 
 ```
-Code blocks use the 'bc.' shorthand:
+코드 블록은 'bc.' 약식을 사용합니다:
 
-bc. This is code
-    So is this
+bc. 이것은 코드입니다
+    이것도 마찬가지입니다
 
-This is outside of the code block
+이것은 코드 블록 밖에 있습니다
 
-bc.. This is a multi-line code block
+bc.. 이것은 여러 줄 코드 블록입니다
 
-Blank lines are included in the multi-line code block
+빈 줄은 여러 줄 코드 블록에 포함됩니다
 
-p. End a multi-line code block with any block element
+p. 여러 줄 코드 블록을 모든 블록 요소로 끝냅니다
 
-p. Indicate @inline code@ using the '@' symbol.
+p. '@' 기호를 사용하여 @인라인 코드@를 표시합니다.
 ```
 
-## Horizontal rule
+## 가로줄
 
-Horizontal rules (`<hr/>`) are easily added with two hyphens
+가로줄(`<hr/>`)은 두 개의 하이픈으로 쉽게 추가할 수 있습니다.
 
 ```
 --
 ```
 
-## Links
+## 링크
 
 ```
-###. Link text is in quotes, followed by a colon and the URL:
+###. 링크 텍스트는 따옴표 안에 있고, 그 뒤에 콜론과 URL이 옵니다:
 
-"Link text":http://linkurl.com/ plain text.
+"링크 텍스트":http://linkurl.com/ 일반 텍스트.
 
-"Titles go in parentheses at the end of the link text"(mytitle):http://url.com
-###. produces <a href... title="mytitle">...</a>
+"제목은 링크 텍스트 끝에 괄호 안에 들어갑니다"(mytitle):http://url.com
+###. <a href... title="mytitle">...</a>를 생성합니다
 
-###. Use square brackets when the link text or URL might be ambiguous:
-["Textile on Wikipedia":http://en.wikipedia.org/wiki/Textile_(markup_language)]
+###. 링크 텍스트나 URL이 모호할 수 있을 때 대괄호를 사용하십시오:
+["위키백과의 Textile":http://en.wikipedia.org/wiki/Textile_(markup_language)]
 
-###. Named links are useful if the same URL is referenced multiple times.
-Multiple "references":txstyle to the "txstyle":txstyle website.
+###. 동일한 URL이 여러 번 참조될 경우 명명된 링크가 유용합니다.
+"txstyle":txstyle 웹사이트에 대한 여러 "참조":txstyle.
 
 [txstyle]https://txstyle.org/
 ```
 
-## Images
+## 이미지
 
 ```
-###. Images can be included by surrounding its URL with exclamation marks (!)
-Alt text is included in parenthesis after the URL, and they can be linked too:
+###. 이미지는 URL을 느낌표(!)로 둘러싸서 포함할 수 있습니다.
+대체 텍스트는 URL 뒤에 괄호 안에 포함되며 링크할 수도 있습니다:
 
 !http://imageurl.com!
 
-!http://imageurl.com(image alt-text)!
+!http://imageurl.com(이미지 대체 텍스트)!
 
-!http://imageurl.com(alt-text)!:http://image-link-url.com
+!http://imageurl.com(대체 텍스트)!:http://image-link-url.com
 ```
 
-## Footnotes and Endnotes
+## 각주 및 미주
 
 ```
-A footnote is indicated with the reference id in square brackets.[1]
+각주는 대괄호 안에 참조 ID로 표시됩니다.[1]
 
-fn1. Footnote text with a "link":http://link.com.
+fn1. "링크":http://link.com가 있는 각주 텍스트.
 
-A footnote without a link.[2!]
+링크가 없는 각주.[2!]
 
-fn2. The corresponding unlinked footnote.
+fn2. 해당 링크 없는 각주.
 
-A footnote with a backlink from the footnote back to the text.[3]
+각주에서 텍스트로 다시 연결되는 백링크가 있는 각주.[3]
 
-fn3^. This footnote links back to the in-text citation.
+fn3^. 이 각주는 텍스트 내 인용으로 다시 연결됩니다.
 
 
-Endnotes are automatically numbered[#first] and are indicated using square[#second]
-brackets and a key value[#first]. They can also be unlinked[#unlinkednote!]
+미주는 자동으로 번호가 매겨지고[#first] 대괄호와 키 값[#second]으로 표시됩니다[#first]. 링크되지 않을 수도 있습니다[#unlinkednote!]
 
-###. Give the endnotes text:
+###. 미주 텍스트 제공:
 
-note#first. This is the first endnote text.
+note#first. 이것은 첫 번째 미주 텍스트입니다.
 
-note#second. This is the second text.
+note#second. 이것은 두 번째 텍스트입니다.
 
-note#unlinkednote. This one isn't linked from the text.
+note#unlinkednote. 이것은 텍스트에서 링크되지 않았습니다.
 
-### Use the notelist block to place the list of notes in the text:
-This list will start with #1. Can also use alpha or Greeks.
-notelist:1. ###. start at 1 (then 2, 3, 4...)
-notelist:c. ###. start at c (then d, e, f...)
-notelist:α. ###. start at α (then β, γ, δ...)
+### notelist 블록을 사용하여 텍스트에 노트 목록을 배치합니다:
+이 목록은 #1부터 시작합니다. 알파벳이나 그리스 문자를 사용할 수도 있습니다.
+notelist:1. ###. 1에서 시작 (그런 다음 2, 3, 4...)
+notelist:c. ###. c에서 시작 (그런 다음 d, e, f...)
+notelist:α. ###. α에서 시작 (그런 다음 β, γ, δ...)
 
-###. The notelist syntax is as follows:
+###. notelist 구문은 다음과 같습니다:
 
-notelist.    Notes with backlinks to every citation made to them.
-notelist+.   Notes with backlinks to every citation made to them,
-               followed by the unreferenced notes.
-notelist^.   Notes with one backlink to the first citation made to each note.
-notelist^+.  Notes with one backlink to the first citation made to each note,
-               followed by unreferenced notes.
-notelist!.   Notes with no backlinks to the citations.
-notelist!+.  Notes with no backlinks to the citations, followed by
-               unreferenced notes.
+notelist.    모든 인용에 대한 백링크가 있는 노트.
+notelist+.   모든 인용에 대한 백링크가 있는 노트,
+               그 뒤에 참조되지 않은 노트가 옵니다.
+notelist^.   각 노트에 대한 첫 번째 인용에 대한 백링크가 하나 있는 노트.
+notelist^+.  각 노트에 대한 첫 번째 인용에 대한 백링크가 하나 있는 노트,
+               그 뒤에 참조되지 않은 노트가 옵니다.
+notelist!.   인용에 대한 백링크가 없는 노트.
+notelist!+.  인용에 대한 백링크가 없는 노트, 그 뒤에
+               참조되지 않은 노트가 옵니다.
 ```
 
-## Tables
+## 표
 
 
 ```
-###. Tables are simple to define using the pipe '|' symbol
+###. 표는 파이프 '|' 기호를 사용하여 간단하게 정의됩니다.
 
-| A | simple | table | row |
-| And | another | table | row |
-| With an | | empty | cell |
+| A | 간단한 | 표 | 행 |
+| 그리고 | 다른 | 표 | 행 |
+| 빈 | | 셀 | 이 있는 |
 
-###. Headers are preceded by '|_.'
-|_. First Header |_. Second Header |
-| Content Cell | Content Cell |
+###. 헤더는 '|_. '가 앞에 옵니다.
+|_. 첫 번째 헤더 |_. 두 번째 헤더 |
+| 내용 셀 | 내용 셀 |
 
-###. The <thead> tag is added when |^. above and |-. below the heading are used.
+###. <thead> 태그는 제목 위 |^.와 아래 |-.가 사용될 때 추가됩니다.
 
 |^.
-|_. First Header |_. Second Header |
+|_. 첫 번째 헤더 |_. 두 번째 헤더 |
 |-.
-| Content Cell | Content Cell |
-| Content Cell | Content Cell |
+| 내용 셀 | 내용 셀 |
+| 내용 셀 | 내용 셀 |
 
-###. The <tfoot> tag is added when |~. above and |-. below the footer are used.
+###. <tfoot> 태그는 바닥글 위 |~.와 아래 |-.가 사용될 때 추가됩니다.
 
 |~.
-|\2=. A footer, centered & across two columns |
+|\2=. 두 열에 걸쳐 가운데 정렬된 바닥글 |
 |-.
-| Content Cell | Content Cell |
-| Content Cell | Content Cell |
+| 내용 셀 | 내용 셀 |
+| 내용 셀 | 내용 셀 |
 
-###. Attributes are be applied either to individual cells, rows, or to
-the entire table. Cell attributes are placed within each cell:
+###. 속성은 개별 셀, 행 또는 전체 표에 적용할 수 있습니다.
+셀 속성은 각 셀 안에 배치됩니다:
 
-|a|{color:red}. styled|cell|
+|a|{color:red}. 스타일이 적용된|셀|
 
-###. Row attributes are placed at the beginning of a row,
-followed by a dot and a space:
+###. 행 속성은 행 시작 부분에 배치되고,
+그 뒤에 점과 공백이 옵니다:
 
 (rowclass). |a|classy|row|
 
-###. Table attributes are specified by placing the special 'table.' block
-modifier immediately before the table:
+###. 표 속성은 표 바로 앞에 특수 'table.' 블록
+수정자를 배치하여 지정됩니다:
 
 table(tableclass).
 |a|classy|table|
 |a|classy|table|
 
-###. Spanning rows and columns:
-A backslash \ is used for a column span:
+###. 행과 열 병합:
+백슬래시 \는 열 병합에 사용됩니다:
 
-|\2. spans two cols |
-| col 1 | col 2 |
+|\2. 두 열 병합 |
+| 열 1 | 열 2 |
 
-###. A forward slash / is used for a row span:
+###. 슬래시 /는 행 병합에 사용됩니다:
 
-|/3. spans 3 rows | row a |
-| row b |
-| row c |
+|/3. 3개 행 병합 | 행 a |
+| 행 b |
+| 행 c |
 
-###. Vertical alignments within a table cell:
+###. 표 셀 내의 수직 정렬:
 
-|^. top alignment|
-|-. middle alignment|
-|~. bottom alignment|
+|^. 위쪽 정렬|
+|-. 가운데 정렬|
+|~. 아래쪽 정렬|
 
-###. Horizontal alignments within a table cell
+###. 표 셀 내의 수평 정렬
 
 |:\1. |400|
-|=. center alignment |
-| no alignment |
-|>. right alignment |
+|=. 가운데 정렬 |
+| 정렬 없음 |
+|>. 오른쪽 정렬 |
 ```
 
-or, for the same results
+또는 동일한 결과에 대해
 
 ```
-Col 1 | Col2 | Col3
+열 1 | 열 2 | 열 3
 :-- | :-: | --:
-Ugh this is so ugly | make it | stop
+으악 너무 못생겼어 | 멈춰 | 줘
 ```
 
 
-## Character Conversions
+## 문자 변환
 
-### Registered, Trademark, Copyright Symbols
-
-```
-RegisteredTrademark(r), Trademark(tm), Copyright (c)
-```
-
-### Acronyms
+### 등록 상표, 상표, 저작권 기호
 
 ```
-###. Acronym definitions can be provided in parentheses:
-
-EPA(Environmental Protection Agency) and CDC(Center for Disease Control)
+등록 상표(r), 상표(tm), 저작권 (c)
 ```
 
-### Angle Brackets and Ampersand
+### 약어
 
 ```
-### Angled brackets < and > and ampersands & are automatically escaped:
+###. 약어 정의는 괄호 안에 제공될 수 있습니다:
+
+EPA(환경 보호국) 및 CDC(질병 통제 예방 센터)
+```
+
+### 꺾쇠괄호 및 앰퍼샌드
+
+```
+### 꺾쇠괄호 < 및 >와 앰퍼샌드 &는 자동으로 이스케이프됩니다:
 < => &lt;
 > => &gt;
 & => &amp;
 ```
 
-### Ellipses
+### 생략 부호
 
 ```
-p. Three consecutive periods are translated into ellipses...automatically
+p. 세 개의 연속된 마침표는 생략 부호로 자동 변환됩니다...
 ```
 
-### Em and En dashes
+### Em 및 En 대시
 
 ```
-###. En dashes (short) is a hyphen surrounded by spaces:
+###. En 대시(짧음)는 공백으로 둘러싸인 하이픈입니다:
 
-This line uses an en dash to separate Oct - Nov 2018.
+이 줄은 2018년 10월 - 11월을 구분하기 위해 en 대시를 사용합니다.
 
-###. Em dashes (long) are two hyphens with or without spaces:
+###. Em 대시(길음)는 공백이 있거나 없는 두 개의 하이픈입니다:
 
-This is an em dash--used to separate clauses.
-But we can also use it with spaces -- which is a less-used convention.
-That last hyphen between 'less' and 'used' is not converted between words.
+이것은 절을 구분하는 데 사용되는 em 대시입니다--.
+그러나 공백과 함께 사용할 수도 있습니다 -- 덜 사용되는 관례입니다.
+'less'와 'used' 사이의 마지막 하이픈은 단어 사이에서 변환되지 않습니다.
 ```
 
-## Fractions and other Math Symbols
+## 분수 및 기타 수학 기호
 
 ```
-One quarter: (1/4) => ¼
-One half: (1/2) => ½
-Three quarters: (3/4) => ¾
-Degree: (o) => °
-Plus/minus: (+/-) => ±
+4분의 1: (1/4) => ¼
+2분의 1: (1/2) => ½
+4분의 3: (3/4) => ¾
+도: (o) => °
+플러스/마이너스: (+/-) => ±
 ```
 
-### Multiplication/Dimension
+### 곱셈/치수
 
 ```
-p. Numbers separated by the letter 'x' translate to the multiplication
-or dimension symbol '×':
+p. 문자 'x'로 구분된 숫자는 곱셈
+또는 치수 기호 '×'로 변환됩니다:
 3 x 5 => 3 × 5
 ```
 
-### Quotes and Apostrophes
+### 따옴표 및 아포스트로피
 
 ```
-###. Straight quotes and apostrophes are automatically converted to
-their curly equivalents:
+###. 직선 따옴표와 아포스트로피는 자동으로
+해당하는 곱슬 형태로 변환됩니다:
 
-"these", 'these', and this'n are converted to their HTML entity equivalents.
-Leave them straight using '==' around the text: =="straight quotes"==.
+"이것들", '이것들', 그리고 this'n은 해당 HTML 엔티티로 변환됩니다.
+텍스트 주위에 '=='를 사용하여 직선으로 유지하십시오: =="직선 따옴표"==.
 ```
 
 ## CSS
 
 ```
-p{color:blue}. CSS Styles are enclosed in curly braces '{}'
-p(my-class). Classes are enclosed in parenthesis
-p(#my-id). IDs are enclosed in parentheses and prefaced with a pound '#'.
+p{color:blue}. CSS 스타일은 중괄호 '{}'로 묶습니다.
+p(my-class). 클래스는 괄호로 묶습니다.
+p(#my-id). ID는 괄호로 묶고 파운드 '#' 기호를 앞에 붙입니다.
 ```
 
-## Spans and Divs
+## 스팬 및 Div
 
 ```
-%spans% are enclosed in percent symbols
-div. Divs are indicated by the 'div.' shorthand
+%스팬%은 퍼센트 기호로 묶습니다.
+div. Div는 'div.' 약식으로 표시됩니다.
 ```
 
 ---
 
-## For More Info
+## 추가 정보
 
-* TxStyle Textile Documentation: [https://txstyle.org/](https://txstyle.org/)
-* promptworks Textile Reference Manual: [https://www.promptworks.com/textile](https://www.promptworks.com/textile)
-* Redmine Textile Formatting: [http://www.redmine.org/projects/redmine/wiki/RedmineTextFormattingTextile](http://www.redmine.org/projects/redmine/wiki/RedmineTextFormattingTextile)
+* TxStyle Textile 문서: [https://txstyle.org/](https://txstyle.org/)
+* promptworks Textile 참조 매뉴얼: [https://www.promptworks.com/textile](https://www.promptworks.com/textile)
+* Redmine Textile 서식: [http://www.redmine.org/projects/redmine/wiki/RedmineTextFormattingTextile](http://www.redmine.org/projects/redmine/wiki/RedmineTextFormattingTextile)

--- a/ko/tmux.md
+++ b/ko/tmux.md
@@ -9,197 +9,196 @@ filename: LearnTmux.txt
 ---
 
 
-[tmux](http://tmux.github.io)
-is a terminal multiplexer: it enables a number of terminals
-to be created, accessed, and controlled from a single screen. tmux
-may be detached from a screen and continue running in the background
-then later reattached.
+[tmux](http://tmux.github.io)는 터미널 멀티플렉서입니다: 여러 터미널을
+하나의 화면에서 생성, 액세스 및 제어할 수 있습니다. tmux는
+화면에서 분리되어 백그라운드에서 계속 실행될 수 있으며,
+나중에 다시 연결할 수 있습니다.
 
 
 ```
-  tmux [command]     # Run a command
-                     # 'tmux' with no commands will create a new session
+  tmux [command]     # 명령어 실행
+                     # 명령어가 없는 'tmux'는 새 세션을 생성합니다.
 
-    new              # Create a new session
-     -s "Session"    # Create named session
-     -n "Window"     # Create named Window
-     -c "/dir"       # Start in target directory
+    new              # 새 세션 생성
+     -s "Session"    # 명명된 세션 생성
+     -n "Window"     # 명명된 창 생성
+     -c "/dir"       # 대상 디렉토리에서 시작
 
-    attach           # Attach last/available session
-     -t "#"          # Attach target session
-     -d              # Detach the session from other instances
+    attach           # 마지막/사용 가능한 세션에 연결
+     -t "#"          # 대상 세션에 연결
+     -d              # 다른 인스턴스에서 세션 분리
 
-    ls               # List open sessions
-     -a              # List all open sessions
+    ls               # 열린 세션 목록
+     -a              # 모든 열린 세션 목록
 
-    lsw              # List windows
-     -a              # List all windows
-     -s              # List all windows in session
+    lsw              # 창 목록
+     -a              # 모든 창 목록
+     -s              # 세션의 모든 창 목록
 
-    lsp              # List panes
-     -a              # List all panes
-     -s              # List all panes in session
-     -t              # List all panes in target
+    lsp              # 창 목록
+     -a              # 모든 창 목록
+     -s              # 세션의 모든 창 목록
+     -t              # 대상의 모든 창 목록
 
-    kill-window      # Kill current window
-     -t "#"          # Kill target window
-     -a              # Kill all windows
-     -a -t "#"       # Kill all windows but the target
+    kill-window      # 현재 창 종료
+     -t "#"          # 대상 창 종료
+     -a              # 모든 창 종료
+     -a -t "#"       # 대상을 제외한 모든 창 종료
 
-    kill-session     # Kill current session
-     -t "#"          # Kill target session
-     -a              # Kill all sessions
-     -a -t "#"       # Kill all sessions but the target
+    kill-session     # 현재 세션 종료
+     -t "#"          # 대상 세션 종료
+     -a              # 모든 세션 종료
+     -a -t "#"       # 대상을 제외한 모든 세션 종료
 ```
 
 
-### Key Bindings
+### 키 바인딩
 
-The method of controlling an attached tmux session is via key
-combinations called 'Prefix' keys.
+연결된 tmux 세션을 제어하는 방법은 '접두사' 키라고 하는
+키 조합을 통하는 것입니다.
 
 ```
 ----------------------------------------------------------------------
-  (C-b) = Ctrl + b    # 'Prefix' combination required to use keybinds
+  (C-b) = Ctrl + b    # 키 바인딩을 사용하려면 '접두사' 조합이 필요합니다.
 
-  (M-1) = Meta + 1 -or- Alt + 1
+  (M-1) = Meta + 1 -또는- Alt + 1
 ----------------------------------------------------------------------
 
-  ?                  # List all key bindings
-  :                  # Enter the tmux command prompt
-  r                  # Force redraw of the attached client
-  c                  # Create a new window
+  ?                  # 모든 키 바인딩 목록
+  :                  # tmux 명령어 프롬프트 입력
+  r                  # 연결된 클라이언트 강제 다시 그리기
+  c                  # 새 창 생성
 
-  !                  # Break the current pane out of the window.
-  %                  # Split the current pane into two, left and right
-  "                  # Split the current pane into two, top and bottom
+  !                  # 현재 창을 창에서 분리합니다.
+  %                  # 현재 창을 좌우로 분할합니다.
+  "                  # 현재 창을 위아래로 분할합니다.
 
-  n                  # Change to the next window
-  p                  # Change to the previous window
-  {                  # Swap the current pane with the previous pane
-  }                  # Swap the current pane with the next pane
-  [                  # Enter Copy Mode to copy text or view history.
+  n                  # 다음 창으로 변경
+  p                  # 이전 창으로 변경
+  {                  # 현재 창을 이전 창과 교체
+  }                  # 현재 창을 다음 창과 교체
+  [                  # 텍스트 복사 또는 기록 보기를 위해 복사 모드로 들어갑니다.
 
-  s                  # Select a new session for the attached client
-                     interactively
-  w                  # Choose the current window interactively
-  0 to 9             # Select windows 0 to 9
+  s                  # 연결된 클라이언트에 대한 새 세션을 대화식으로
+                     # 선택합니다.
+  w                  # 현재 창을 대화식으로 선택
+  0 to 9             # 창 0에서 9까지 선택
 
-  d                  # Detach the current client
-  D                  # Choose a client to detach
+  d                  # 현재 클라이언트 분리
+  D                  # 분리할 클라이언트 선택
 
-  &                  # Kill the current window
-  x                  # Kill the current pane
+  &                  # 현재 창 종료
+  x                  # 현재 창 종료
 
-  Up, Down           # Change to the pane above, below, left, or right
+  Up, Down           # 위, 아래, 왼쪽 또는 오른쪽 창으로 변경
   Left, Right
 
-  M-1 to M-5         # Arrange panes:
-                       # 1) even-horizontal
-                       # 2) even-vertical
-                       # 3) main-horizontal
-                       # 4) main-vertical
-                       # 5) tiled
+  M-1 to M-5         # 창 정렬:
+                       # 1) 수평으로 균등하게
+                       # 2) 수직으로 균등하게
+                       # 3) 주 수평
+                       # 4) 주 수직
+                       # 5) 타일형
 
-  C-Up, C-Down       # Resize the current pane in steps of one cell
+  C-Up, C-Down       # 현재 창 크기를 한 셀 단위로 조정
   C-Left, C-Right
 
-  M-Up, M-Down       # Resize the current pane in steps of five cells
+  M-Up, M-Down       # 현재 창 크기를 다섯 셀 단위로 조정
   M-Left, M-Right
 ```
 
 
-### Configuring ~/.tmux.conf
+### ~/.tmux.conf 구성
 
-tmux.conf can be used to set options automatically on start up, much
-like how .vimrc or init.el are used.
+tmux.conf는 .vimrc나 init.el이 사용되는 것처럼 시작 시
+옵션을 자동으로 설정하는 데 사용할 수 있습니다.
 
 ```
-# Example tmux.conf
+# 예제 tmux.conf
 # 2015.12
 
 
-### General
+### 일반
 ###########################################################################
 
-# Scrollback/History limit
+# 스크롤백/기록 제한
 set -g history-limit 2048
 
-# Index Start
+# 인덱스 시작
 set -g base-index 1
 
-# Mouse
+# 마우스
 set-option -g -q mouse on
 
-# Force reload of config file
+# 구성 파일 강제 다시 로드
 unbind r
 bind r source-file ~/.tmux.conf
 
 
-### Keybinds
+### 키 바인딩
 ###########################################################################
 
-# Unbind C-b as the default prefix
+# 기본 접두사로 C-b 바인딩 해제
 unbind C-b
 
-# Set new default prefix
+# 새 기본 접두사 설정
 set-option -g prefix `
 
-# Return to previous window when prefix is pressed twice
+# 접두사를 두 번 누를 때 이전 창으로 돌아가기
 bind C-a last-window
 bind ` last-window
 
-# Allow swapping C-a and ` using F11/F12
+# F11/F12를 사용하여 C-a와 ` 교체 허용
 bind F11 set-option -g prefix C-a
 bind F12 set-option -g prefix `
 
-# Keybind preference
+# 키 바인딩 기본 설정
 setw -g mode-keys vi
 set-option -g status-keys vi
 
-# Moving between panes with vim movement keys
+# vim 이동 키로 창 간 이동
 bind h select-pane -L
 bind j select-pane -D
 bind k select-pane -U
 bind l select-pane -R
 
-# Window Cycle/Swap
+# 창 순환/교체
 bind e previous-window
 bind f next-window
 bind E swap-window -t -1
 bind F swap-window -t +1
 
-# Easy split pane commands
+# 쉬운 창 분할 명령어
 bind = split-window -h
 bind - split-window -v
 unbind '"'
 unbind %
 
-# Activate inner-most session (when nesting tmux) to send commands
+# 명령을 보내기 위해 가장 안쪽 세션 활성화 (tmux 중첩 시)
 bind a send-prefix
 
 
-### Theme
+### 테마
 ###########################################################################
 
-# Statusbar Color Palette
+# 상태 표시줄 색상 팔레트
 set-option -g status-justify left
 set-option -g status-bg black
 set-option -g status-fg white
 set-option -g status-left-length 40
 set-option -g status-right-length 80
 
-# Pane Border Color Palette
+# 창 테두리 색상 팔레트
 set-option -g pane-active-border-fg green
 set-option -g pane-active-border-bg black
 set-option -g pane-border-fg white
 set-option -g pane-border-bg black
 
-# Message Color Palette
+# 메시지 색상 팔레트
 set-option -g message-fg black
 set-option -g message-bg green
 
-# Window Status Color Palette
+# 창 상태 색상 팔레트
 setw -g window-status-bg black
 setw -g window-status-current-fg green
 setw -g window-status-bell-attr default
@@ -211,36 +210,36 @@ setw -g window-status-activity-fg yellow
 ### UI
 ###########################################################################
 
-# Notification
+# 알림
 setw -g monitor-activity on
 set -g visual-activity on
 set-option -g bell-action any
 set-option -g visual-bell off
 
-# Automatically set window titles
+# 창 제목 자동 설정
 set-option -g set-titles on
-set-option -g set-titles-string '#H:#S.#I.#P #W #T' # window number,program name,active (or not)
+set-option -g set-titles-string '#H:#S.#I.#P #W #T' # 창 번호, 프로그램 이름, 활성(또는 비활성)
 
-# Statusbar Adjustments
+# 상태 표시줄 조정
 set -g status-left "#[fg=red] #H#[fg=green]:#[fg=white]#S#[fg=green] |#[default]"
 
-# Show performance counters in statusbar
-# Requires https://github.com/thewtex/tmux-mem-cpu-load/
+# 상태 표시줄에 성능 카운터 표시
+# https://github.com/thewtex/tmux-mem-cpu-load/ 필요
 set -g status-interval 4
 set -g status-right "#[fg=green] | #[fg=white]#(tmux-mem-cpu-load)#[fg=green] | #[fg=cyan]%H:%M #[default]"
 ```
 
 
-### References
+### 참고 자료
 
-[Tmux | Home](http://tmux.github.io)
+[Tmux | 홈페이지](http://tmux.github.io)
 
-[Tmux Manual page](http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man1/tmux.1?query=tmux)
+[Tmux 매뉴얼 페이지](http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man1/tmux.1?query=tmux)
 
-[Gentoo Wiki](http://wiki.gentoo.org/wiki/Tmux)
+[Gentoo 위키](http://wiki.gentoo.org/wiki/Tmux)
 
-[Archlinux Wiki](https://wiki.archlinux.org/index.php/Tmux)
+[Archlinux 위키](https://wiki.archlinux.org/index.php/Tmux)
 
-[Display CPU/MEM % in statusbar](https://stackoverflow.com/questions/11558907/is-there-a-better-way-to-display-cpu-usage-in-tmux)
+[상태 표시줄에 CPU/MEM % 표시](https://stackoverflow.com/questions/11558907/is-there-a-better-way-to-display-cpu-usage-in-tmux)
 
-[tmuxinator - Manage complex tmux sessions](https://github.com/tmuxinator/tmuxinator)
+[tmuxinator - 복잡한 tmux 세션 관리](https://github.com/tmuxinator/tmuxinator)

--- a/ko/v.md
+++ b/ko/v.md
@@ -7,30 +7,27 @@ contributors:
     - ["Maou Shimazu", "https://github.com/Maou-Shimazu"]
 ---
 
-V is a statically typed compiled programming language
-designed for building maintainable software.
+V는 유지보수 가능한 소프트웨어를 구축하기 위해 설계된 정적 타입 컴파일 프로그래밍 언어입니다.
 
-It's similar to Go and its design has also been influenced by
-Oberon, Rust, Swift, Kotlin, and Python.
+Go와 유사하며 Oberon, Rust, Swift, Kotlin, Python의 영향도 받았습니다.
 
-The language promotes writing
-simple and clear code with minimal abstraction.
+이 언어는 최소한의 추상화로 간단하고 명확한 코드를 작성하도록 권장합니다.
 
-Despite being simple, V gives the developer a lot of power.
-Anything you can do in other languages, you can do in V.
+단순함에도 불구하고 V는 개발자에게 많은 강력한 기능을 제공합니다.
+다른 언어에서 할 수 있는 모든 것을 V에서도 할 수 있습니다.
 
 ```v
-// Single Line Comment.
+// 한 줄 주석.
 /*
-    Multi Line Comment
+    여러 줄 주석
 */
 
-struct User { // Cannot be defined in main, explained later.
+struct User { // main 함수 내부에 정의할 수 없으며, 나중에 설명합니다.
 	age  int
 	name string
-	pos int = -1 // custom default value
+	pos int = -1 // 사용자 정의 기본값
 }
-// struct method
+// 구조체 메서드
 fn (u User) can_register() bool {
 	return u.age > 16
 }
@@ -39,7 +36,7 @@ struct Parser {
 	token Token
 }
 
-// c like enums
+// c와 유사한 열거형
 enum Token {
 	plus
 	minus
@@ -47,18 +44,18 @@ enum Token {
 	mult
 }
 
-// 1. functions
-// language does not use semi colons
+// 1. 함수
+// 언어는 세미콜론을 사용하지 않습니다
 fn add(x int, y int) int {
 	return x + y
 }
-// can return multiple values
+// 여러 값을 반환할 수 있습니다
 fn foo() (int, int) {
 	return 2, 3
 }
 
-// function visibility
-pub fn public_function() { // pub can only be used from a named module.
+// 함수 가시성
+pub fn public_function() { // pub는 명명된 모듈에서만 사용할 수 있습니다.
 }
 
 fn private_function() {
@@ -66,68 +63,68 @@ fn private_function() {
 
 
 
-// Main function
+// 메인 함수
 fn main() {
-	// Anonymous functions can be declared inside other functions:
+	// 익명 함수는 다른 함수 내부에 선언할 수 있습니다:
 	double_fn := fn (n int) int {
 		return n + n
 	}
-	// 2. Variables: they are immutable by default
-	// implicitly typed
+	// 2. 변수: 기본적으로 불변입니다
+	// 암시적 타입
 	x := 1
-	// x = 2 // error
+	// x = 2 // 오류
 	mut y := 2
 	y = 4
 	name := "John"
 	large_number := i64(9999999999999)
     println("$x, $y, $name, $large_number") // 1, 4, John, 9999999999999
 
-	// unpacking values from functions.
+	// 함수에서 값 언패킹.
 	a, b := foo()
 	println("$a, $b") // 2, 3
-	c, _ := foo() // ignore values using `_`
+	c, _ := foo() // `_`를 사용하여 값 무시
 	println("$c") // 2
 
-	// Numbers
+	// 숫자
 	u := u16(12)
-	v := 13 + u    // v is of type `u16`
+	v := 13 + u    // v는 `u16` 타입입니다
 	r := f32(45.6)
-	q := r + 3.14  // x is of type `f32`
-	s := 75        // a is of type `int`
-	l := 14.7      // b is of type `f64`
-	e := u + s     // c is of type `int`
-	d := l + r     // d is of type `f64`
+	q := r + 3.14  // x는 `f32` 타입입니다
+	s := 75        // a는 `int` 타입입니다
+	l := 14.7      // b는 `f64` 타입입니다
+	e := u + s     // c는 `int` 타입입니다
+	d := l + r     // d는 `f64` 타입입니다
 
-	// Strings
+	// 문자열
 	mut bob := 'Bob'
-	assert bob[0] == u8(66) // indexing gives a byte, u8(66) == `B`
-	assert bob[1..3] == 'ob'  // slicing gives a string 'ob'
-	bobby := bob + 'by' // + is used to concatenate strings
+	assert bob[0] == u8(66) // 인덱싱은 바이트를 반환, u8(66) == `B`
+	assert bob[1..3] == 'ob'  // 슬라이싱은 문자열 'ob'를 반환
+	bobby := bob + 'by' // +는 문자열을 연결하는 데 사용됩니다
 	println(bobby) // "Bobby"
-	bob += "by2" // += is used to append to strings
+	bob += "by2" // +=는 문자열에 추가하는 데 사용됩니다
 	println(bob) // "Bobby2"
 
-	//String values are immutable. You cannot mutate elements:
+	//문자열 값은 불변입니다. 요소를 변경할 수 없습니다:
 	//mut s := 'hello 🌎'
-	//s[0] = `H` // not allowed
+	//s[0] = `H` // 허용되지 않음
 
-	//For raw strings, prepend r. Escape handling is not done for raw strings:
-	rstring := r'hello\nworld' // the `\n` will be preserved as two characters
+	//원시 문자열의 경우 r을 앞에 붙입니다. 원시 문자열에 대해서는 이스케이프 처리가 수행되지 않습니다:
+	rstring := r'hello\nworld' // `\n`은 두 문자로 유지됩니다
 	println(rstring) // "hello\nworld"
 
-	// string interpolation
+	// 문자열 보간
 	println('Hello, $bob!') // Hello, Bob!
 	println('Bob length + 10: ${bob.len + 10}!') // Bob length + 10: 13!
 
-	// 3. Arrays
+	// 3. 배열
 	mut numbers := [1, 2, 3]
 	println(numbers) // `[1, 2, 3]`
-	numbers << 4 // append elements with <<
+	numbers << 4 // <<로 요소 추가
 	println(numbers[3]) // `4`
 	numbers[1] = 5
 	println(numbers) // `[1, 5, 3]`
-	// numbers << "John" // error: `numbers` is an array of numbers
-	numbers = [] // array is now empty
+	// numbers << "John" // 오류: `numbers`는 숫자 배열입니다
+	numbers = [] // 배열이 이제 비어 있습니다
 	arr := []int{len: 5, init: -1}
 	// `arr == [-1, -1, -1, -1, -1]`, arr.cap == 5
 
@@ -136,11 +133,11 @@ fn main() {
 	println(number_slices[..4]) // [0, 10, 20, 30]
 	println(number_slices[1..]) // [10, 20, 30, 40]
 
-	// 4. structs and enums
+	// 4. 구조체 및 열거형
 	// struct User {
 	// 	age  int
 	// 	name string
-	//  pos int = -1 // custom default value
+	//  pos int = -1 // 사용자 정의 기본값
 	// }
 	mut users := User{21, 'Bob', 0}
 	println(users.age) // 21
@@ -162,21 +159,21 @@ fn main() {
 	}
 
 
-	// 5. Maps
+	// 5. 맵
 	number_map := {
 		'one': 1
 		'two': 2
 	}
 	println(number_map) // {'one': 1, 'two': 2}
 	println(number_map["one"]) // 1
-	mut m := map[string]int{} // a map with `string` keys and `int` values
+	mut m := map[string]int{} // `string` 키와 `int` 값을 갖는 맵
 	m['one'] = 1
 	m['two'] = 2
 	println(m['one']) // "1"
 	println(m['bad_key']) // "0"
 	m.delete('two')
 
-	// 6. Conditionals
+	// 6. 조건문
 	a_number := 10
 	b_number := 20
 	if a_number < b {
@@ -196,7 +193,7 @@ fn main() {
 		else { println('unknown') }
 	}
 
-	// 7. Loops
+	// 7. 루프
 	loops := [1, 2, 3, 4, 5]
 	for lp in loops {
 		println(lp)
@@ -204,11 +201,11 @@ fn main() {
 	loop_names := ['Sam', 'Peter']
 	for i, lname in loop_names {
 		println('$i) $lname')
-		// Output: 0) Sam
+		// 출력: 0) Sam
 		//         1) Peter
 	}
-	// You can also use break and continue followed by a
-	// label name to refer to an outer for loop:
+	// break 및 continue 다음에 레이블 이름을 사용하여
+	// 외부 for 루프를 참조할 수도 있습니다:
 	outer: for i := 4; true; i++ {
 		println(i)
 		for {
@@ -222,10 +219,8 @@ fn main() {
 }
 ```
 
-## Further reading
+## 더 읽을거리
 
-There are more complex concepts to be learnt in V which are available at the
-official [V documentation](https://github.com/vlang/v/blob/master/doc/docs.md).
+V에는 공식 [V 문서](https://github.com/vlang/v/blob/master/doc/docs.md)에서 배울 수 있는 더 복잡한 개념이 있습니다.
 
-You can also find more information about the V language at the [official website](https://vlang.io/)
-or check it out at the [v playground](https://v-wasm.vercel.app/).
+V 언어에 대한 자세한 정보는 [공식 웹사이트](https://vlang.io/)에서 찾거나 [v 플레이그라운드](https://v-wasm.vercel.app/)에서 확인할 수 있습니다.

--- a/ko/vimscript.md
+++ b/ko/vimscript.md
@@ -9,44 +9,29 @@ contributors:
 
 ```vim
 " ##############
-"  Introduction
+"  소개
 " ##############
 "
-" Vim script (also called VimL) is the subset of Vim's ex-commands which
-" supplies a number of features one would expect from a scripting language,
-" such as values, variables, functions or loops. Always keep in the back of
-" your mind that a Vim script file is just a sequence of ex-commands. It is
-" very common for a script to mix programming-language features and raw
-" ex-commands.
+" Vim 스크립트(VimL이라고도 함)는 값, 변수, 함수 또는 루프와 같이 스크립팅 언어에서 기대할 수 있는 여러 기능을 제공하는 Vim의 ex-명령어 하위 집합입니다.
+" Vim 스크립트 파일은 단지 ex-명령어의 시퀀스라는 것을 항상 염두에 두십시오. 스크립트가 프로그래밍 언어 기능과 원시 ex-명령어를 혼합하는 것은 매우 일반적입니다.
 "
-" You can run Vim script directly by entering the commands in command-line mode
-" (press `:` to enter command-line mode), or you can write them to a file
-" (without the leading `:`) and source it in a running Vim instance (`:source
-" path/to/file`). Some files are sourced automatically as part of your
-" configuration (see |startup|). This guide assumes that you are familiar
-" with ex-commands and will only cover the scripting. Help topics to the
-" relevant manual sections are included.
+" 명령줄 모드에서 명령을 직접 입력하여 Vim 스크립트를 실행하거나(명령줄 모드로 들어가려면 `:` 누름) 파일에 작성(선행 `:` 없이)하고 실행 중인 Vim 인스턴스에서 소싱할 수 있습니다(`:source path/to/file`).
+" 일부 파일은 구성의 일부로 자동으로 소싱됩니다(|startup| 참조). 이 가이드는 ex-명령어에 익숙하고 스크립팅만 다룰 것이라고 가정합니다. 관련 매뉴얼 섹션에 대한 도움말 항목이 포함되어 있습니다.
 "
-" See |usr_41.txt| for the official introduction to Vim script. A comment is
-" anything following an unmatched `"` until the end of the line, and `|`
-" separates instructions (what `;` does in most other languages). References to
-" the manual as surrounded with `|`, such as |help.txt|.
+" Vim 스크립트에 대한 공식 소개는 |usr_41.txt|를 참조하십시오. 주석은 일치하지 않는 `"` 다음에 오는 모든 것이 줄 끝까지이며, `|`는 지침을 구분합니다(대부분의 다른 언어에서 `;`가 하는 역할). |help.txt|와 같이 `|`로 둘러싸인 매뉴얼에 대한 참조.
 
-" This is a comment
+" 이것은 주석입니다
 
-" The vertical line '|' (pipe) separates commands
+" 세로줄 '|' (파이프)는 명령을 구분합니다
 echo 'Hello' | echo 'world!'
 
-" Putting a comment after a command usually works
-pwd                   " Displays the current working directory
+" 명령어 뒤에 주석을 다는 것은 보통 작동합니다
+pwd                   " 현재 작업 디렉토리를 표시합니다
 
-" Except for some commands it does not; use the command delimiter before the
-" comment (echo assumes that the quotation mark begins a string)
-echo 'Hello world!'  | " Displays a message
+" 일부 명령어를 제외하고는 그렇지 않습니다. 주석 앞에 명령어 구분 기호를 사용하십시오(echo는 따옴표가 문자열을 시작한다고 가정합니다)
+echo 'Hello world!'  | " 메시지를 표시합니다
 
-" Line breaks can be escaped by placing a backslash as the first non-whitespace
-" character on the *following* line. Only works in script files, not on the
-" command line
+" 줄 바꿈은 다음 줄의 첫 번째 비공백 문자로 백슬래시를 배치하여 이스케이프할 수 있습니다. 스크립트 파일에서만 작동하며 명령줄에서는 작동하지 않습니다
 echo " Hello
     \ world "
 
@@ -60,275 +45,259 @@ echo {
 
 
 " #######
-"  Types
+"  타입
 " #######
 "
-" For an overview of types see |E712|. For an overview of operators see
-" |expression-syntax|
+" 타입에 대한 개요는 |E712|를 참조하십시오. 연산자에 대한 개요는 |expression-syntax|를 참조하십시오.
 
-" Numbers (|expr-number|)
+" 숫자 (|expr-number|)
 " #######
 
-echo  123         | " Decimal
-echo  0b1111011   | " Binary
-echo  0173        | " Octal
-echo  0x7B        | " Hexadecimal
-echo  123.0       | " Floating-point
-echo  1.23e2      | " Floating-point (scientific notation)
+echo  123         | " 십진수
+echo  0b1111011   | " 이진수
+echo  0173        | " 8진수
+echo  0x7B        | " 16진수
+echo  123.0       | " 부동 소수점
+echo  1.23e2      | " 부동 소수점 (과학적 표기법)
 
-" Note that an *integer* number with a leading `0` is in octal notation. The
-" usual arithmetic operations are supported.
+" 선행 `0`이 있는 *정수*는 8진수 표기법입니다.
+" 일반적인 산술 연산이 지원됩니다.
 
-echo  1 + 2       | " Addition
-echo  1 - 2       | " Subtraction
-echo  - 1         | " Negation (unary minus)
-echo  + 1         | " Unary plus (does nothing really, but still legal)
-echo  1 * 2       | " Multiplication
-echo  1 / 2       | " Division
-echo  1 % 2       | " Modulo (remainder)
+echo  1 + 2       | " 덧셈
+echo  1 - 2       | " 뺄셈
+echo  - 1         | " 부정 (단항 빼기)
+echo  + 1         | " 단항 더하기 (실제로는 아무것도 하지 않지만 여전히 합법적)
+echo  1 * 2       | " 곱셈
+echo  1 / 2       | " 나눗셈
+echo  1 % 2       | " 나머지 (나머지)
 
-" Booleans (|Boolean|)
+" 불리언 (|Boolean|)
 " ########
 "
-" The number 0 is false, every other number is true. Strings are implicitly
-" converted to numbers (see below). There are two pre-defined semantic
-" constants.
+" 숫자 0은 거짓이고 다른 모든 숫자는 참입니다. 문자열은 암시적으로 숫자로 변환됩니다(아래 참조).
+" 두 개의 미리 정의된 의미 상수.
 
-echo  v:true      | " Evaluates to 1 or the string 'v:true'
-echo  v:false     | " Evaluates to 0 or the string 'v:false'
+echo  v:true      | " 1 또는 문자열 'v:true'로 평가됩니다
+echo  v:false     | " 0 또는 문자열 'v:false'로 평가됩니다
 
-" Boolean values can result from comparison of two objects.
+" 불리언 값은 두 객체의 비교 결과일 수 있습니다.
 
-echo  x == y             | " Equality by value
-echo  x != y             | " Inequality
-echo  x >  y             | " Greater than
-echo  x >= y             | " Greater than or equal
-echo  x <  y             | " Smaller than
-echo  x <= y             | " Smaller than or equal
-echo  x is y             | " Instance identity (lists and dictionaries)
-echo  x isnot y          | " Instance non-identity (lists and dictionaries)
+echo  x == y             | " 값에 의한 동등성
+echo  x != y             | " 불일치
+echo  x >  y             | " 보다 큼
+echo  x >= y             | " 크거나 같음
+echo  x <  y             | " 보다 작음
+echo  x <= y             | " 작거나 같음
+echo  x is y             | " 인스턴스 ID (리스트 및 딕셔너리)
+echo  x isnot y          | " 인스턴스 비 ID (리스트 및 딕셔너리)
 
-" Strings are compared based on their alphanumerical ordering
-" echo 'a' < 'b'. Case sensitivity depends on the setting of 'ignorecase'
+" 문자열은 영숫자 순서에 따라 비교됩니다
+" echo 'a' < 'b'. 대소문자 구분은 'ignorecase' 설정에 따라 다릅니다.
 "
-" Explicit case-sensitivity is specified by appending '#' (match case) or '?'
-" (ignore case) to the operator. Prefer explicitly case sensitivity when writing
-" portable scripts.
+" 명시적인 대소문자 구분은 연산자에 '#' (대소문자 일치) 또는 '?' (대소문자 무시)를 추가하여 지정됩니다.
+" 이식 가능한 스크립트를 작성할 때 명시적으로 대소문자 구분을 선호하십시오.
 
-echo  'a' <  'B'         | " True or false depending on 'ignorecase'
-echo  'a' <? 'B'         | " True
-echo  'a' <# 'B'         | " False
+echo  'a' <  'B'         | " 'ignorecase'에 따라 참 또는 거짓
+echo  'a' <? 'B'         | " 참
+echo  'a' <# 'B'         | " 거짓
 
-" Regular expression matching
-echo  "hi" =~  "hello"    | " Regular expression match, uses 'ignorecase'
-echo  "hi" =~# "hello"    | " Regular expression match, case sensitive
-echo  "hi" =~? "hello"    | " Regular expression match, case insensitive
-echo  "hi" !~  "hello"    | " Regular expression unmatch, use 'ignorecase'
-echo  "hi" !~# "hello"    | " Regular expression unmatch, case sensitive
-echo  "hi" !~? "hello"    | " Regular expression unmatch, case insensitive
+" 정규식 일치
+echo  "hi" =~  "hello"    | " 정규식 일치, 'ignorecase' 사용
+echo  "hi" =~# "hello"    | " 정규식 일치, 대소문자 구분
+echo  "hi" =~? "hello"    | " 정규식 일치, 대소문자 무시
+echo  "hi" !~  "hello"    | " 정규식 불일치, 'ignorecase' 사용
+echo  "hi" !~# "hello"    | " 정규식 불일치, 대소문자 구분
+echo  "hi" !~? "hello"    | " 정규식 불일치, 대소문자 무시
 
-" Boolean operations are possible.
+" 불리언 연산이 가능합니다.
 
-echo  v:true && v:false       | " Logical AND
-echo  v:true || v:false       | " Logical OR
-echo  ! v:true                | " Logical NOT
-echo  v:true ? 'yes' : 'no'   | " Ternary operator
+echo  v:true && v:false       | " 논리 AND
+echo  v:true || v:false       | " 논리 OR
+echo  ! v:true                | " 논리 NOT
+echo  v:true ? 'yes' : 'no'   | " 삼항 연산자
 
 
-" Strings (|String|)
+" 문자열 (|String|)
 " #######
 "
-" An ordered zero-indexed sequence of bytes. The encoding of text into bytes
-" depends on the option |'encoding'|.
+" 정렬된 0-인덱스 바이트 시퀀스입니다. 텍스트를 바이트로 인코딩하는 것은 |'encoding'| 옵션에 따라 다릅니다.
 
-" Literal constructors
-echo  "Hello world\n"   | " The last two characters stand for newline
-echo  'Hello world\n'   | " The last two characters are literal
-echo  'Let''s go!'      | " Two single quotes become one quote character
+" 리터럴 생성자
+echo  "Hello world\n"   | " 마지막 두 문자는 줄 바꿈을 나타냅니다
+echo  'Hello world\n'   | " 마지막 두 문자는 리터럴입니다
+echo  'Let''s go!'      | " 두 개의 작은따옴표는 하나의 따옴표 문자가 됩니다
 
-" Single-quote strings take all characters are literal, except two single
-" quotes, which are taken to be a single quote in the string itself. See
-" |expr-quote| for all possible escape sequences.
+" 작은따옴표 문자열은 모든 문자를 리터럴로 사용하지만, 두 개의 작은따옴표는 문자열 자체에서 하나의 작은따옴표로 간주됩니다.
+" 가능한 모든 이스케이프 시퀀스는 |expr-quote|를 참조하십시오.
 
-" String concatenation
-" The .. operator is preferred, but only supported in since Vim 8.1.1114
-echo  'Hello ' .  'world'  | " String concatenation
-echo  'Hello ' .. 'world'  | " String concatenation (new variant)
+" 문자열 연결
+" .. 연산자가 선호되지만 Vim 8.1.1114 이후에만 지원됩니다
+echo  'Hello ' .  'world'  | " 문자열 연결
+echo  'Hello ' .. 'world'  | " 문자열 연결 (새 변형)
 
-" String indexing
-echo  'Hello'[0]           | " First byte
-echo  'Hello'[1]           | " Second byte
-echo  'Hellö'[4]           | " Returns a byte, not the character 'ö'
+" 문자열 인덱싱
+echo  'Hello'[0]           | " 첫 번째 바이트
+echo  'Hello'[1]           | " 두 번째 바이트
+echo  'Hellö'[4]           | " 문자 'ö'가 아닌 바이트를 반환합니다
 
-" Substrings (second index is inclusive)
-echo  'Hello'[:]           | " Copy of entire string
-echo  'Hello'[1:3]         | " Substring, second to fourth byte
-echo  'Hello'[1:-2]        | " Substring until second to last byte
-echo  'Hello'[1:]          | " Substring with starting index
-echo  'Hello'[:2]          | " Substring with ending index
-echo  'Hello'[-2:]         | " Substring relative to end of string
+" 부분 문자열 (두 번째 인덱스는 포함)
+echo  'Hello'[:]           | " 전체 문자열 복사
+echo  'Hello'[1:3]         | " 부분 문자열, 두 번째에서 네 번째 바이트
+echo  'Hello'[1:-2]        | " 부분 문자열, 끝에서 두 번째 바이트까지
+echo  'Hello'[1:]          | " 시작 인덱스가 있는 부분 문자열
+echo  'Hello'[:2]          | " 끝 인덱스가 있는 부분 문자열
+echo  'Hello'[-2:]         | " 문자열 끝을 기준으로 한 부분 문자열
 
-" A negative index is relative to the end of the string. See
-" |string-functions| for all string-related functions.
+" 음수 인덱스는 문자열 끝을 기준으로 합니다.
+" 모든 문자열 관련 함수는 |string-functions|를 참조하십시오.
 
-" Lists (|List|)
+" 리스트 (|List|)
 " #####
 "
-" An ordered zero-indexed heterogeneous sequence of arbitrary Vim script
-" objects.
+" 임의의 Vim 스크립트 객체의 정렬된 0-인덱스 이기종 시퀀스입니다.
 
-" Literal constructor
-echo  []                   | " Empty list
-echo  [1, 2, 'Hello']      | " List with elements
-echo  [1, 2, 'Hello', ]    | " Trailing comma permitted
-echo  [[1, 2], 'Hello']    | " Lists can be nested arbitrarily
+" 리터럴 생성자
+echo  []                   | " 빈 리스트
+echo  [1, 2, 'Hello']      | " 요소가 있는 리스트
+echo  [1, 2, 'Hello', ]    | " 후행 쉼표 허용
+echo  [[1, 2], 'Hello']    | " 리스트는 임의로 중첩될 수 있습니다
 
-" List concatenation
-echo  [1, 2] + [3, 4]      | " Creates a new list
+" 리스트 연결
+echo  [1, 2] + [3, 4]      | " 새 리스트 생성
 
-" List indexing, negative is relative to end of list (|list-index|)
-echo  [1, 2, 3, 4][2]      | " Third element
-echo  [1, 2, 3, 4][-1]     | " Last element
+" 리스트 인덱싱, 음수는 리스트 끝을 기준으로 합니다 (|list-index|)
+echo  [1, 2, 3, 4][2]      | " 세 번째 요소
+echo  [1, 2, 3, 4][-1]     | " 마지막 요소
 
-" List slicing (|sublist|)
-echo  [1, 2, 3, 4][:]      | " Shallow copy of entire list
-echo  [1, 2, 3, 4][:2]     | " Sublist until third item (inclusive)
-echo  [1, 2, 3, 4][2:]     | " Sublist from third item (inclusive)
-echo  [1, 2, 3, 4][:-2]    | " Sublist until second-to-last item (inclusive)
+" 리스트 슬라이싱 (|sublist|)
+echo  [1, 2, 3, 4][:]      | " 전체 리스트의 얕은 복사
+echo  [1, 2, 3, 4][:2]     | " 세 번째 항목까지의 하위 리스트 (포함)
+echo  [1, 2, 3, 4][2:]     | " 세 번째 항목부터의 하위 리스트 (포함)
+echo  [1, 2, 3, 4][:-2]    | " 끝에서 두 번째 항목까지의 하위 리스트 (포함)
 
-" All slicing operations create new lists. To modify a list in-place use list
-" functions (|list-functions|) or assign directly to an item (see below about
-" variables).
+" 모든 슬라이싱 작업은 새 리스트를 생성합니다. 리스트를 제자리에서 수정하려면 리스트 함수(|list-functions|)를 사용하거나 항목에 직접 할당하십시오(아래 변수 참조).
 
 
-" Dictionaries (|Dictionary|)
+" 딕셔너리 (|Dictionary|)
 " ############
 "
-" An unordered sequence of key-value pairs, keys are always strings (numbers
-" are implicitly converted to strings).
+" 키-값 쌍의 정렬되지 않은 시퀀스이며, 키는 항상 문자열입니다(숫자는 암시적으로 문자열로 변환됨).
 
-" Dictionary literal
-echo  {}                       | " Empty dictionary
-echo  {'a': 1, 'b': 2}         | " Dictionary literal
-echo  {'a': 1, 'b': 2, }       | " Trailing comma permitted
-echo  {'x': {'a': 1, 'b': 2}}  | " Nested dictionary
+" 딕셔너리 리터럴
+echo  {}                       | " 빈 딕셔너리
+echo  {'a': 1, 'b': 2}         | " 딕셔너리 리터럴
+echo  {'a': 1, 'b': 2, }       | " 후행 쉼표 허용
+echo  {'x': {'a': 1, 'b': 2}}  | " 중첩된 딕셔너리
 
-" Indexing a dictionary
-echo  {'a': 1, 'b': 2}['a']    | " Literal index
-echo  {'a': 1, 'b': 2}.a       | " Syntactic sugar for simple keys
+" 딕셔너리 인덱싱
+echo  {'a': 1, 'b': 2}['a']    | " 리터럴 인덱스
+echo  {'a': 1, 'b': 2}.a       | " 간단한 키에 대한 구문 설탕
 
-" See |dict-functions| for dictionary manipulation functions.
+" 딕셔너리 조작 함수는 |dict-functions|를 참조하십시오.
 
 
-" Funcref (|Funcref|)
+" 함수 참조 (|Funcref|)
 " #######
 "
-" Reference to a function, uses the function name as a string for construction.
-" When stored in a variable the name of the variable has the same restrictions
-" as a function name (see below).
+" 함수에 대한 참조이며, 생성에 함수 이름을 문자열로 사용합니다.
+" 변수에 저장될 때 변수 이름은 함수 이름과 동일한 제한을 가집니다(아래 참조).
 
-echo  function('type')                   | " Reference to function type()
-" Note that `funcref('type')` will throw an error because the argument must be
-" a user-defined function; see further below for defining your own functions.
-echo  funcref('type')                    | " Reference by identity, not name
-" A lambda (|lambda|) is an anonymous function; it can only contain one
-" expression in its body, which is also its implicit return value.
-echo  {x -> x * x}                       | " Anonymous function
-echo  function('substitute', ['hello'])  | " Partial function
+echo  function('type')                   | " 함수 type()에 대한 참조
+" `funcref('type')`는 인수가 사용자 정의 함수여야 하므로 오류를 발생시킵니다.
+" 사용자 정의 함수 정의에 대해서는 아래를 참조하십시오.
+echo  funcref('type')                    | " 이름이 아닌 ID별 참조
+" 람다(|lambda|)는 익명 함수입니다. 본문에 하나의 표현식만 포함할 수 있으며, 이것이 암시적인 반환값이기도 합니다.
+echo  {x -> x * x}                       | " 익명 함수
+echo  function('substitute', ['hello'])  | " 부분 함수
 
 
-" Regular expression (|regular-expression|)
+" 정규식 (|regular-expression|)
 " ##################
 "
-" A regular expression pattern is generally a string, but in some cases you can
-" also use a regular expression between a pair of delimiters (usually `/`, but
-" you can choose anything).
+" 정규식 패턴은 일반적으로 문자열이지만, 경우에 따라 구분 기호 쌍(보통 `/`이지만 원하는 것을 선택할 수 있음) 사이에 정규식을 사용할 수도 있습니다.
 
-" Substitute 'hello' for 'Hello'
+" 'hello'를 'Hello'로 대체
 substitute/hello/Hello/
 
 
 " ###########################
-"  Implicit type conversions
+"  암시적 타입 변환
 " ###########################
 "
-" Strings are converted to numbers, and numbers to strings when necessary. A
-" number becomes its decimal notation as a string. A string becomes its
-" numerical value if it can be parsed to a number, otherwise it becomes zero.
+" 문자열은 숫자로, 숫자는 필요할 때 문자열로 변환됩니다.
+" 숫자는 10진수 표기법으로 문자열이 됩니다. 문자열은 숫자로 구문 분석할 수 있으면 숫자 값이 되고, 그렇지 않으면 0이 됩니다.
 
-echo  "1" + 1         | " Number
-echo  "1" .. 1        | " String
-echo  "0xA" + 1       | " Number
+echo  "1" + 1         | " 숫자
+echo  "1" .. 1        | " 문자열
+echo  "0xA" + 1       | " 숫자
 
-" Strings are treated like numbers when used as booleans
-echo "true" ? 1 : 0   | " This string is parsed to 0, which is false
+" 문자열은 불리언으로 사용될 때 숫자처럼 취급됩니다
+echo "true" ? 1 : 0   | " 이 문자열은 0으로 구문 분석되어 거짓입니다
 
 " ###########
-"  Variables
+"  변수
 " ###########
 "
-" Variables are bound within a scope; if no scope is provided a default is
-" chosen by Vim. Use `:let` and `:const` to bind a value and `:unlet` to unbind
-" it.
+" 변수는 범위 내에 바인딩됩니다. 범위가 제공되지 않으면 Vim에서 기본값을 선택합니다.
+" 값을 바인딩하려면 `:let` 및 `:const`를 사용하고, 바인딩을 해제하려면 `:unlet`을 사용하십시오.
 
-let b:my_var = 1        | " Local to current buffer
-let w:my_var = 1        | " Local to current window
-let t:my_var = 1        | " Local to current tab page
-let g:my_var = 1        | " Global variable
-let l:my_var = 1        | " Local to current function (see functions below)
-let s:my_var = 1        | " Local to current script file
-let a:my_arg = 1        | " Function argument (see functions below)
+let b:my_var = 1        | " 현재 버퍼에 로컬
+let w:my_var = 1        | " 현재 창에 로컬
+let t:my_var = 1        | " 현재 탭 페이지에 로컬
+let g:my_var = 1        | " 전역 변수
+let l:my_var = 1        | " 현재 함수에 로컬 (아래 함수 참조)
+let s:my_var = 1        | " 현재 스크립트 파일에 로컬
+let a:my_arg = 1        | " 함수 인수 (아래 함수 참조)
 
-" The Vim scope is read-only
-echo  v:true            | " Special built-in Vim variables (|v:var|)
+" Vim 범위는 읽기 전용입니다
+echo  v:true            | " 특수 내장 Vim 변수 (|v:var|)
 
-" Access special Vim memory like variables
-let @a = 'Hello'        | " Register
-let $PATH=''            | " Environment variable
-let &textwidth = 79     | " Option
-let &l:textwidth = 79   | " Local option
-let &g:textwidth = 79   | " Global option
+" 변수와 같은 특수 Vim 메모리 액세스
+let @a = 'Hello'        | " 레지스터
+let $PATH=''            | " 환경 변수
+let &textwidth = 79     | " 옵션
+let &l:textwidth = 79   | " 로컬 옵션
+let &g:textwidth = 79   | " 전역 옵션
 
-" Access scopes as dictionaries (can be modified like all dictionaries)
-" See the |dict-functions|, especially |get()|, for access and manipulation
-echo  b:                | " All buffer variables
-echo  w:                | " All window variables
-echo  t:                | " All tab page variables
-echo  g:                | " All global variables
-echo  l:                | " All local variables
-echo  s:                | " All script variables
-echo  a:                | " All function arguments
-echo  v:                | " All Vim variables
+" 딕셔너리로 범위 액세스 (모든 딕셔너리처럼 수정 가능)
+" 액세스 및 조작에 대해서는 |dict-functions|, 특히 |get()|을 참조하십시오.
+echo  b:                | " 모든 버퍼 변수
+echo  w:                | " 모든 창 변수
+echo  t:                | " 모든 탭 페이지 변수
+echo  g:                | " 모든 전역 변수
+echo  l:                | " 모든 로컬 변수
+echo  s:                | " 모든 스크립트 변수
+echo  a:                | " 모든 함수 인수
+echo  v:                | " 모든 Vim 변수
 
-" Constant variables
-const x = 10            | " See |:const|, |:lockvar|
+" 상수 변수
+const x = 10            | " |:const|, |:lockvar| 참조
 
-" Function reference variables have the same restrictions as function names
-let IsString = {x -> type(x) == type('')}    | " Global: capital letter
-let s:isNumber = {x -> type(x) == type(0)}   | " Local: any name allowed
+" 함수 참조 변수는 함수 이름과 동일한 제한을 가집니다
+let IsString = {x -> type(x) == type('')}    | " 전역: 대문자
+let s:isNumber = {x -> type(x) == type(0)}   | " 로컬: 모든 이름 허용
 
-" When omitted the scope `g:` is implied, except in functions, there `l:` is
-" implied.
+" 생략하면 `g:` 범위가 암시되지만, 함수에서는 `l:`이 암시됩니다.
 
 
-" Multiple value binding (list unpacking)
+" 다중 값 바인딩 (리스트 언패킹)
 " #######################################
 "
-" Assign values of list to multiple variables (number of items must match)
+" 리스트 값을 여러 변수에 할당 (항목 수가 일치해야 함)
 let [x, y] = [1, 2]
 
-" Assign the remainder to a rest variable (note the semicolon)
+" 나머지를 나머지 변수에 할당 (세미콜론 참고)
 let [mother, father; children] = ['Alice', 'Bob', 'Carol', 'Dennis', 'Emily']
 
 
 " ##############
-"  Flow control
+"  제어 흐름
 " ##############
 
-" Conditional (|:if|, |:elseif|, |:else|, |:endif|)
+" 조건문 (|:if|, |:elseif|, |:else|, |:endif|)
 " ###########
 "
-" Conditions are set between `if` and `endif`. They can be nested.
+" 조건은 `if`와 `endif` 사이에 설정됩니다. 중첩될 수 있습니다.
 
 let condition = v:true
 
@@ -340,49 +309,47 @@ else
     echo 'Fail'
 endif
 
-" Loops (|:for|, |:endfor|, |:while|, |:endwhile|, |:break|, |:continue|)
+" 루프 (|:for|, |:endfor|, |:while|, |:endwhile|, |:break|, |:continue|)
 " #####
 "
-" Two types of loops: `:for` and `:while`. Use `:continue` to skip to the next
-" iteration, `:break` to break out of the loop.
+" 두 가지 유형의 루프: `:for` 및 `:while`. 다음 반복으로 건너뛰려면 `:continue`를 사용하고, 루프를 빠져나가려면 `:break`를 사용하십시오.
 
-" For-loop (|:for|, |:endfor|)
+" For-루프 (|:for|, |:endfor|)
 " ========
 "
-" For-loops iterate over lists and nothing else. If you want to iterate over
-" another sequence you need to use a function which will create a list.
+" For-루프는 리스트만 반복합니다. 다른 시퀀스를 반복하려면 리스트를 생성하는 함수를 사용해야 합니다.
 
-" Iterate over a list
+" 리스트 반복
 for person in ['Alice', 'Bob', 'Carol', 'Dennis', 'Emily']
     echo 'Hello ' .. person
 endfor
 
-" Iterate over a nested list by unpacking it
+" 중첩된 리스트를 언패킹하여 반복
 for [x, y] in [[1, 0], [0, 1], [-1, 0], [0, -1]]
     echo 'Position: x ='  .. x .. ', y = ' .. y
 endfor
 
-" Iterate over a range of numbers
-for i in range(10, 0, -1)  " Count down from 10
+" 숫자 범위 반복
+for i in range(10, 0, -1)  " 10부터 카운트다운
     echo 'T minus'  .. i
 endfor
 
-" Iterate over the keys of a dictionary
+" 딕셔너리 키 반복
 for symbol in keys({'π': 3.14, 'e': 2.71})
     echo 'The constant ' .. symbol .. ' is a transcendent number'
 endfor
 
-" Iterate over the values of a dictionary
+" 딕셔너리 값 반복
 for value in values({'π': 3.14, 'e': 2.71})
     echo 'The value ' .. value .. ' approximates a transcendent number'
 endfor
 
-" Iterate over the keys and values of a dictionary
+" 딕셔너리 키와 값 반복
 for [symbol, value] in items({'π': 3.14, 'e': 2.71})
     echo 'The number ' .. symbol .. ' is approximately ' .. value
 endfor
 
-" While-loops (|:while|, |:endwhile|)
+" While-루프 (|:while|, |:endwhile|)
 
 let there_yet = v:true
 while !there_yet
@@ -390,16 +357,15 @@ while !there_yet
 endwhile
 
 
-" Exception handling (|exception-handling|)
+" 예외 처리 (|exception-handling|)
 " ##################
 "
-" Throw new exceptions as strings, catch them by pattern-matching a regular
-" expression against the string
+" 새 예외를 문자열로 throw하고, 문자열에 대한 정규식 패턴 일치로 catch합니다.
 
-" Throw new exception
+" 새 예외 throw
 throw "Wrong arguments"
 
-" Guard against an exception (the second catch matches any exception)
+" 예외로부터 보호 (두 번째 catch는 모든 예외와 일치)
 try
     source path/to/file
 catch /Cannot open/
@@ -412,49 +378,45 @@ endtry
 
 
 " ##########
-"  Functions
+"  함수
 " ##########
 
-" Defining functions (|:function|, |:endfunction|)
+" 함수 정의 (|:function|, |:endfunction|)
 " ##################
 
-" Unscoped function names have to start with a capital letter
+" 범위가 없는 함수 이름은 대문자로 시작해야 합니다
 function! AddNumbersLoudly(x, y)
-    " Use a: scope to access arguments
-    echo 'Adding'  .. a:x ..  'and'  .. a:y   | " A side effect
-    return a:x + a:y                          | " A return value
+    " a: 범위를 사용하여 인수에 액세스
+    echo 'Adding'  .. a:x ..  'and'  .. a:y   | " 부작용
+    return a:x + a:y                          | " 반환 값
 endfunction
 
-" Scoped function names may start with a lower-case letter
+" 범위가 있는 함수 이름은 소문자로 시작할 수 있습니다
 function! s:addNumbersLoudly(x, y)
     echo 'Adding'  .. a:x ..  'and'  .. a:y
     return a:x + a:y
 endfunction
 
-" Without the exclamation mark it would be an error to re-define a function,
-" with the exclamation mark the new definition can replace the old one. Since
-" Vim script files can be reloaded several times over the course of a session
-" it is best to use the exclamation mark unless you really know what you are
-" doing.
+" 느낌표가 없으면 함수를 다시 정의하는 것이 오류가 되지만, 느낌표가 있으면 새 정의가 이전 정의를 대체할 수 있습니다.
+" Vim 스크립트 파일은 세션 동안 여러 번 다시 로드될 수 있으므로, 무엇을 하는지 정말로 알지 못하는 한 느낌표를 사용하는 것이 가장 좋습니다.
 
-" Function definitions can have special qualifiers following the argument list.
+" 함수 정의에는 인수 목록 뒤에 특수 한정자가 있을 수 있습니다.
 
-" Range functions define two implicit arguments, which will be set to the range
-" of the ex-command
+" 범위 함수는 두 개의 암시적 인수를 정의하며, ex-명령어의 범위로 설정됩니다
 function! FirstAndLastLine() range
     echo [a:firstline, a:lastline]
 endfunction
 
-" Prints the first and last line that match a pattern (|cmdline-ranges|)
+" 패턴과 일치하는 첫 번째 및 마지막 줄을 인쇄합니다 (|cmdline-ranges|)
 /^#!/,/!#$/call FirstAndLastLine()
 
-" Aborting functions, abort once error occurs (|:func-abort|)
+" 함수 중단, 오류 발생 시 중단 (|:func-abort|)
 function! SourceMyFile() abort
-    source my-file.vim        | " Try sourcing non-existing file
+    source my-file.vim        | " 존재하지 않는 파일 소싱 시도
     echo 'This will never be printed'
 endfunction
 
-" Closures, functions carrying values from outer scope (|:func-closure|)
+" 클로저, 외부 범위에서 값을 전달하는 함수 (|:func-closure|)
 function! MakeAdder(x)
     function! Adder(n) closure
         return a:n + a:x
@@ -462,42 +424,40 @@ function! MakeAdder(x)
     return funcref('Adder')
 endfunction
 let AddFive = MakeAdder(5)
-echo AddFive(3)               | " Prints 8
+echo AddFive(3)               | " 8 인쇄
 
-" Dictionary functions, poor man's OOP methods (|Dictionary-function|)
+" 딕셔너리 함수, 가난한 사람의 OOP 메서드 (|Dictionary-function|)
 function! Mylen() dict
-    return len(self.data)     | " Implicit variable self
+    return len(self.data)     | " 암시적 변수 self
 endfunction
 let mydict = {'data': [0, 1, 2, 3], 'len': function("Mylen")}
 echo mydict.len()
 
-" Alternatively, more concise
+" 또는 더 간결하게
 let mydict = {'data': [0, 1, 2, 3]}
 function! mydict.len()
     return len(self.data)
 endfunction
 
-" Calling functions (|:call|)
+" 함수 호출 (|:call|)
 " #################
 
-" Call a function for its return value, and possibly for its side effects
+" 반환 값 및 부작용을 위해 함수 호출
 let animals = keys({'cow': 'moo', 'dog': 'woof', 'cat': 'meow'})
 
-" Call a function for its side effects only, ignore potential return value
+" 부작용만을 위해 함수 호출, 잠재적인 반환 값 무시
 call sign_undefine()
 
-" The call() function calls a function reference and passes parameters as a
-" list, and returns the function's result.
-echo  call(function('get'), [{'a': 1, 'b': 2}, 'c', 3])   | " Prints 3
+" call() 함수는 함수 참조를 호출하고 매개변수를 리스트로 전달하며, 함수의 결과를 반환합니다.
+echo  call(function('get'), [{'a': 1, 'b': 2}, 'c', 3])   | " 3 인쇄
 
-" Recall that Vim script is embedded within the ex-commands, that is why we
-" cannot just call a function directly, we have to use the `:call` ex-command.
+" Vim 스크립트는 ex-명령어 내에 포함되어 있으므로 함수를 직접 호출할 수 없고 `:call` ex-명령어를 사용해야 합니다.
 
-" Function namespaces (|write-library-script|, |autoload|)
+" 함수 네임스페이스 (|write-library-script|, |autoload|)
 " ###################
 
-" Must be defined in autoload/foo/bar.vim
-" Namspaced function names do not have to start with a capital letter
+" autoload/foo/bar.vim에 정의해야 합니다
+" 네임스페이스 함수 이름은 대문자로 시작할 필요가 없습니다
 function! foo#bar#log(value)
     echomsg value
 endfunction
@@ -506,155 +466,144 @@ call foo#bar#log('Hello')
 
 
 " #############################
-"  Frequently used ex-commands
+"  자주 사용되는 ex-명령어
 " #############################
 
 
-" Sourcing runtime files (|'runtimepath'|)
+" 런타임 파일 소싱 (|'runtimepath'|)
 " ######################
 
-" Source first match among runtime paths
+" 런타임 경로 중에서 첫 번째 일치 항목 소싱
 runtime plugin/my-plugin.vim
 
 
-" Defining new ex-commands (|40.2|, |:command|)
+" 새 ex-명령어 정의 (|40.2|, |:command|)
 " ########################
 
-" First argument here is the name of the command, rest is the command body
+" 첫 번째 인수는 명령어 이름, 나머지는 명령어 본문
 command! SwapAdjacentLines normal! ddp
 
-" The exclamation mark works the same as with `:function`. User-defined
-" commands must start with a capital letter. The `:command` command can take a
-" number of attributes (some of which have their own parameters with `=`), such
-" as `-nargs`, all of them start with a dash to set them apart from the command
-" name.
+" 느낌표는 `:function`과 동일하게 작동합니다. 사용자 정의 명령어는 대문자로 시작해야 합니다.
+" `:command` 명령어는 `-nargs`와 같이 여러 속성을 가질 수 있으며, 모두 대시로 시작하여 명령어 이름과 구분합니다.
 
 command! -nargs=1 Error echoerr <args>
 
 
-" Defining auto-commands (|40.3|, |autocmd|, |autocommand-events|)
+" 자동 명령어 정의 (|40.3|, |autocmd|, |autocommand-events|)
 " ######################
 
-" The arguments are "events", "patterns", rest is "commands"
+" 인수는 "이벤트", "패턴", 나머지는 "명령어"입니다
 autocmd BufWritePost $MYVIMRC source $MYVIMRC
 
-" Events and patterns are separated by commas with no space between. See
-" |autocmd-events| for standard events, |User| for custom events. Everything
-" else are the ex-commands which will be executed.
+" 이벤트와 패턴은 공백 없는 쉼표로 구분됩니다.
+" 표준 이벤트는 |autocmd-events|를 참조하고, 사용자 정의 이벤트는 |User|를 참조하십시오.
+" 나머지는 실행될 ex-명령어입니다.
 
-" Auto groups
+" 자동 그룹
 " ===========
 "
-" When a file is sourced multiple times the auto-commands are defined anew,
-" without deleting the old ones, causing auto-commands to pile up over time.
-" Use auto-groups and the following ritual to guard against this.
+" 파일이 여러 번 소싱될 때 자동 명령어가 새로 정의되어 이전 명령어를 삭제하지 않고 시간이 지남에 따라 자동 명령어가 쌓이게 됩니다.
+" 이를 방지하기 위해 자동 그룹과 다음 의식을 사용하십시오.
 
-augroup auto-source   | " The name of the group is arbitrary
-    autocmd!          | " Deletes all auto-commands in the current group
+augroup auto-source   | " 그룹 이름은 임의적입니다
+    autocmd!          | " 현재 그룹의 모든 자동 명령어 삭제
     autocmd BufWritePost $MYVIMRC source $MYVIMRC
-augroup END           | " Switch back to default auto-group
+augroup END           | " 기본 자동 그룹으로 다시 전환
 
-" It is also possible to assign a group directly. This is useful if the
-" definition of the group is in one script and the definition of the
-" auto-command is in another script.
+" 그룹을 직접 할당할 수도 있습니다.
+" 그룹 정의가 한 스크립트에 있고 자동 명령어 정의가 다른 스크립트에 있는 경우 유용합니다.
 
-" In one file
+" 한 파일에서
 augroup auto-source
     autocmd!
 augroup END
 
-" In another file
+" 다른 파일에서
 autocmd auto-source BufWritePost $MYVIMRC source $MYVIMRC
 
-" Executing (run-time macros of sorts)
+" 실행 (일종의 런타임 매크로)
 " ####################################
 
-" Sometimes we need to construct an ex-command where part of the command is not
-" known until runtime.
+" 때로는 명령어의 일부가 런타임까지 알려지지 않은 ex-명령어를 구성해야 합니다.
 
-let line = 3                | " Line number determined at runtime
-execute line .. 'delete'    | " Delete a line
+let line = 3                | " 런타임에 결정되는 줄 번호
+execute line .. 'delete'    | " 한 줄 삭제
 
-" Executing normal-mode commands
+" 일반 모드 명령어 실행
 " ##############################
 "
-" Use `:normal` to play back a sequence of normal mode commands from the
-" command-line. Add an exclamation mark to ignore user mappings.
+" `:normal`을 사용하여 명령줄에서 일반 모드 명령어 시퀀스를 재생합니다.
+" 사용자 매핑을 무시하려면 느낌표를 추가하십시오.
 
-normal! ggddGp             | " Transplant first line to end of buffer
+normal! ggddGp             | " 첫 번째 줄을 버퍼 끝으로 이식
 
-" Window commands can be used with :normal, or with :wincmd if :normal would
-" not work
-wincmd L                   | " Move current window all the way to the right
+" 창 명령어는 :normal과 함께 사용하거나, :normal이 작동하지 않을 경우 :wincmd와 함께 사용할 수 있습니다
+wincmd L                   | " 현재 창을 맨 오른쪽으로 이동
 
 
 " ###########################
-"  Frequently used functions
+"  자주 사용되는 함수
 " ###########################
 
-" Feature check
-echo  has('nvim')                  | " Running Neovim
-echo  has('python3')               | " Support for Python 3 plugins
-echo  has('unix')                  | " Running on a Unix system
-echo  has('win32')                 | " Running on a Windows system
+" 기능 확인
+echo  has('nvim')                  | " Neovim 실행 중
+echo  has('python3')               | " Python 3 플러그인 지원
+echo  has('unix')                  | " 유닉스 시스템에서 실행 중
+echo  has('win32')                 | " Windows 시스템에서 실행 중
 
 
-" Test if something exists
-echo  exists('&mouse')             | " Option (exists only)
-echo  exists('+mouse')             | " Option (exists and works)
-echo  exists('$HOSTNAME')          | " Environment variable
-echo  exists('*strftime')          | " Built-in function
-echo  exists('**s:MyFunc')         | " User-defined function
-echo  exists('bufcount')           | " Variable (scope optional)
-echo  exists('my_dict["foo"]')     | " Variable (dictionary entry)
-echo  exists('my_dict["foo"]')     | " Variable (dictionary entry)
-echo  exists(':Make')              | " Command
-echo  exists("#CursorHold")        | " Auto-command defined for event
-echo  exists("#BufReadPre#*.gz")   | " Event and pattern
-echo  exists("#filetypeindent")    | " Auto-command group
-echo  exists("##ColorScheme")      | " Auto-command supported for event
+" 무언가 존재하는지 테스트
+echo  exists('&mouse')             | " 옵션 (존재만 함)
+echo  exists('+mouse')             | " 옵션 (존재하고 작동함)
+echo  exists('$HOSTNAME')          | " 환경 변수
+echo  exists('*strftime')          | " 내장 함수
+echo  exists('**s:MyFunc')         | " 사용자 정의 함수
+echo  exists('bufcount')           | " 변수 (범위는 선택 사항)
+echo  exists('my_dict["foo"]')     | " 변수 (딕셔셔너리 항목)
+echo  exists('my_dict["foo"]')     | " 변수 (딕셔셔너리 항목)
+echo  exists(':Make')              | " 명령어
+echo  exists("#CursorHold")        | " 이벤트에 대해 정의된 자동 명령어
+echo  exists("#BufReadPre#*.gz")   | " 이벤트 및 패턴
+echo  exists("#filetypeindent")    | " 자동 명령어 그룹
+echo  exists("##ColorScheme")      | " 이벤트에 대해 지원되는 자동 명령어
 
-" Various dynamic values (see |expand()|)
-echo  expand('%')                  | " Current file name
-echo  expand('<cword>')            | " Current word under cursor
-echo  expand('%:p')                | " Modifier are possible
+" 다양한 동적 값 (|expand()| 참조)
+echo  expand('%')                  | " 현재 파일 이름
+echo  expand('<cword>')            | " 커서 아래 현재 단어
+echo  expand('%:p')                | " 수정자 가능
 
-" Type tests
-" There are unique constants defined for the following types. Older versions
-" of Vim lack the type variables, see the reference " documentation for a
-" workaround
-echo  type(my_var) == v:t_number      | " Number
-echo  type(my_var) == v:t_string      | " String
-echo  type(my_var) == v:t_func        | " Funcref
-echo  type(my_var) == v:t_list        | " List
-echo  type(my_var) == v:t_dict        | " Dictionary
-echo  type(my_var) == v:t_float       | " Float
-echo  type(my_var) == v:t_bool        | " Explicit Boolean
-" For the null object should compare it against itself
+" 타입 테스트
+" 다음 타입에 대해 고유한 상수가 정의되어 있습니다. 이전 버전의 Vim에는 타입 변수가 없으므로 해결 방법은 참조 문서를 참조하십시오.
+echo  type(my_var) == v:t_number      | " 숫자
+echo  type(my_var) == v:t_string      | " 문자열
+echo  type(my_var) == v:t_func        | " 함수 참조
+echo  type(my_var) == v:t_list        | " 리스트
+echo  type(my_var) == v:t_dict        | " 딕셔너리
+echo  type(my_var) == v:t_float       | " 부동 소수점
+echo  type(my_var) == v:t_bool        | " 명시적 불리언
+" null 객체의 경우 자체와 비교해야 합니다
 echo  my_var is v:null
 
-" Format strings
+" 문자열 서식 지정
 echo  printf('%d in hexadecimal is %X', 123, 123)
 
 
 " #####################
-"  Tricks of the trade
+"  업계의 비결
 " #####################
 
-" Source guard
+" 소스 가드
 " ############
 
-" Prevent a file from being sourced multiple times; users can set the variable
-" in their configuration to prevent the plugin from loading at all.
+" 파일이 여러 번 소싱되는 것을 방지합니다. 사용자는 구성에서 변수를 설정하여 플러그인이 전혀 로드되지 않도록 할 수 있습니다.
 if exists('g:loaded_my_plugin')
     finish
 endif
 let g:loaded_my_plugin = v:true
 
-" Default values
+" 기본값
 " ##############
 
-" Get a default value: if the user defines a variable use it, otherwise use a
-" hard-coded default. Uses the fact that a scope is also a dictionary.
+" 기본값을 가져옵니다. 사용자가 변수를 정의하면 해당 변수를 사용하고, 그렇지 않으면 하드코딩된 기본값을 사용합니다. 범위도 딕셔너리라는 사실을 이용합니다.
 let s:greeting = get(g:, 'my_plugin_greeting', 'Hello')
 ```


### PR DESCRIPTION
I have translated a number of markdown files in the `ko/` directory from English to Korean. The translation includes both the main content and the comments within code blocks.

As you requested, the YAML front matter of each file has been preserved.

- [ ] I solemnly swear that this is all original content of which I am the original author
- [ ] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [ ] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
