### PR TITLE
Translate several markdown files to Korean

### DIFF
--- a/ko/lean4.md
+++ b/ko/lean4.md
@@ -1,5 +1,3 @@
-# lean4.md (번역)
-
 ---
 name: "Lean 4"
 filename: learnlean4.lean
@@ -8,12 +6,11 @@ contributors:
     - ["Ferinko", "https://github.com/Ferinko"]
 ---
 
-[Lean 4](https://lean-lang.org/) is a dependently typed functional programming
-language and an interactive theorem prover.
+[Lean 4](https://lean-lang.org/)는 종속 타입 함수형 프로그래밍 언어이자 대화형 정리 증명기입니다.
 
 ```lean4
 /-
-An enumerated data type.
+열거형 데이터 타입입니다.
 -/
 inductive Grade where
   | A : Grade
@@ -22,7 +19,7 @@ inductive Grade where
 deriving Repr
 
 /-
-Functions.
+함수입니다.
 -/
 def grade (m : Nat) : Grade :=
   if 80 <= m then Grade.A
@@ -35,18 +32,17 @@ def lowMarks  := 25 + 25
 #eval grade lowMarks
 
 #check (0 : Nat)
-/- #check (0 : Grade) -/ /- This is an error. -/
+/- #check (0 : Grade) -/ /- 이것은 오류입니다. -/
 
 /-
-Types themselves are values.
+타입 자체도 값입니다.
 -/
 #check (Nat : Type)
 
 /-
-Mathematical propositions are values in Lean. `Prop` is the type of
-propositions.
+수학적 명제는 Lean에서 값입니다. `Prop`은 명제의 타입입니다.
 
-Here are some simple propositions.
+다음은 몇 가지 간단한 명제입니다.
 -/
 
 #check 0 = 1
@@ -54,40 +50,37 @@ Here are some simple propositions.
 #check 2^9 - 2^8 = 2^8
 
 /-
-Notice Lean displays `0 = 1 : Prop` to say:
+Lean은 `0 = 1 : Prop`을 표시하여 다음을 말합니다:
 
-  The statement "0 = 1" is a proposition.
+  "0 = 1" 문장은 명제입니다.
 
-We want to distinguish true propositions and false propositions. We do this via
-proofs.
+우리는 참인 명제와 거짓인 명제를 구별하고 싶습니다. 우리는 증명을 통해 이를 수행합니다.
 
-Each proposition is a type. `0 = 1` is a type, `1 = 1` is another type.
+각 명제는 타입입니다. `0 = 1`은 타입이고, `1 = 1`은 다른 타입입니다.
 
-A proposition is true iff there is a value of that type.
+명제는 해당 타입의 값이 있는 경우에만 참입니다.
 
-How do we construct a value of type `1 = 1`? We use a constructor that is
-defined for that type.
+`1 = 1` 타입의 값을 어떻게 생성할까요? 해당 타입에 대해 정의된 생성자를 사용합니다.
 
-  `Eq.refl a` constructs a value of type `a = a`. (reflexivity)
+  `Eq.refl a`는 `a = a` 타입의 값을 생성합니다. (반사성)
 
-Using this we can prove `1 = 1` as follows.
+이를 사용하여 다음과 같이 `1 = 1`을 증명할 수 있습니다.
 -/
 
 theorem one_eq_one : 1 = 1 := Eq.refl 1
 
 /-
-But there is no way to prove (construct a value of type) `0 = 1`.
+하지만 `0 = 1`을 증명할 (타입의 값을 생성할) 방법은 없습니다.
 
-The following will fail. As will `Eq.refl 1`
+다음은 실패합니다. `Eq.refl 1`도 마찬가지입니다.
 -/
 
 /- theorem zero_eq_one : 0 = 1 := Eq.refl 0 -/
 
 /-
-Let us prove an inequality involving variables.
+변수를 포함하는 부등식을 증명해 봅시다.
 
-The `calc` primitive allows us to prove equalities using stepwise
-calculations. Each step has to be justified by a proof.
+`calc` 프리미티브를 사용하면 단계별 계산을 통해 등식을 증명할 수 있습니다. 각 단계는 증명으로 정당화되어야 합니다.
 -/
 theorem plus_squared (a b : Nat) : (a+b)^2 = a^2 + 2*a*b + b^2 :=
   calc
@@ -102,37 +95,34 @@ theorem plus_squared (a b : Nat) : (a+b)^2 = a^2 + 2*a*b + b^2 :=
     _       = a^2 + 2*(a*b) + b^2     := by rw [← Nat.two_mul _]
     _       = a^2 + 2*a*b + b^2       := by rw [Nat.mul_assoc _ _ _]
 /-
-Underscores can be used when there is no ambiguity in what is to be matched.
+일치시킬 대상에 모호함이 없을 때 밑줄을 사용할 수 있습니다.
 
-For example, in the first step, we want to apply `Nat.pow_two (a+b)`. But,
-`(a+b)` is the only pattern here to apply `Nat.pow_two`. So we can omit it.
+예를 들어, 첫 번째 단계에서 `Nat.pow_two (a+b)`를 적용하려고 합니다. 하지만,
+`(a+b)`는 여기서 `Nat.pow_two`를 적용할 유일한 패턴입니다. 그래서 생략할 수 있습니다.
 -/
 
 /-
-Let us now prove more "realistic" theorems. Those involving logical connectives.
+이제 더 "현실적인" 정리, 즉 논리적 연결사를 포함하는 정리를 증명해 봅시다.
 
-First, we define even and odd numbers.
+먼저, 짝수와 홀수를 정의합니다.
 -/
 def Even (n : Nat) := ∃ k, n = 2*k
 def Odd  (n : Nat) := ∃ k, n = 2*k + 1
 
 /-
-To prove an existential, we can provide specific values if we know them.
+존재 증명을 하려면, 우리가 안다면 특정 값을 제공할 수 있습니다.
 -/
 theorem zero_even : Even 0 :=
   have h : 0 = 2 * 0 := Eq.symm (Nat.mul_zero 2)
   Exists.intro 0 h
 /-
-`Exists.intro v h` proves `∃ x, p x` by substituting `x` by `v` and using the
-proof `h` for `p v`.
+`Exists.intro v h`는 `x`를 `v`로 치환하고 `p v`에 대한 증명 `h`를 사용하여 `∃ x, p x`를 증명합니다.
 -/
 
 /-
-Now, we will see how to use hypothesis that are existentials to prove
-conclusions that are existentials.
+이제, 존재 가설을 사용하여 존재 결론을 증명하는 방법을 살펴보겠습니다.
 
-The curly braces around parameters `n` and `m` indicate that they are
-implicit. Here, Lean will infer them from `hn` and `hm`.
+매개변수 `n`과 `m` 주위의 중괄호는 그것들이 암시적임을 나타냅니다. 여기서 Lean은 `hn`과 `hm`에서 그것들을 추론할 것입니다.
 -/
 theorem even_mul_even_is_even' {n m : Nat} (hn : Even n) (hm : Even m) : Even (n*m) :=
   Exists.elim hn (fun k1 hk1 =>
@@ -146,10 +136,9 @@ theorem even_mul_even_is_even' {n m : Nat} (hn : Even n) (hm : Even m) : Even (n
   )
 
 /-
-Most proofs are written using *tactics*. These are commands to Lean that guide
-it to construct proofs by itself.
+대부분의 증명은 *전술(tactics)*을 사용하여 작성됩니다. 이것들은 Lean이 스스로 증명을 구성하도록 안내하는 명령어입니다.
 
-The same theorem, proved using tactics.
+전술을 사용하여 증명된 동일한 정리입니다.
 -/
 theorem even_mul_even_is_even {n m : Nat} (hn : Even n) (hm : Even m) : Even (n*m) := by
   have ⟨k1, hk1⟩ := hn
@@ -160,7 +149,7 @@ theorem even_mul_even_is_even {n m : Nat} (hn : Even n) (hm : Even m) : Even (n*
     _   = 2 * (k1 * (2 * k2)) := by rw [Nat.mul_assoc]
 
 /-
-Let us work with implications.
+함의(implications)를 다루어 봅시다.
 -/
 theorem succ_of_even_is_odd' {n : Nat} : Even n → Odd (n+1) :=
   fun hn =>
@@ -170,19 +159,15 @@ theorem succ_of_even_is_odd' {n : Nat} : Even n → Odd (n+1) :=
         n + 1 = 2 * k + 1 := by rw [hk]
     )
 /-
-To prove an implication `p → q`, you have to write a function that takes a proof
-of `p` and construct a proof of `q`.
+함의 `p → q`를 증명하려면 `p`의 증명을 받아 `q`의 증명을 구성하는 함수를 작성해야 합니다.
 
-Here, `pn` is proof of `Even n := ∃ k, n = 2 *k`. Eliminating the existential
-gets us `k` and a proof `hk` of `n = 2 * k`.
+여기서 `pn`은 `Even n := ∃ k, n = 2 *k`의 증명입니다. 존재 한정자를 제거하면 `k`와 `n = 2 * k`의 증명 `hk`를 얻습니다.
 
-Now, we have to introduce the existential `∃ k, n + 1 = 2 * k + 1`. This `k` is
-the same as `k` for `n`. And, the equation is proved by a simple calculation
-that substitutes `2 * k` for `n`, which is allowed by `hk`.
+이제 존재 한정자 `∃ k, n + 1 = 2 * k + 1`을 도입해야 합니다. 이 `k`는 `n`에 대한 `k`와 동일합니다. 그리고 방정식은 `hk`에 의해 허용되는 `n`을 `2 * k`로 치환하는 간단한 계산으로 증명됩니다.
 -/
 
 /-
-Same theorem, now using tactics.
+전술을 사용하여 동일한 정리입니다.
 -/
 theorem succ_of_even_is_odd {n : Nat} : Even n → Odd (n+1) := by
   intro hn
@@ -191,54 +176,47 @@ theorem succ_of_even_is_odd {n : Nat} : Even n → Odd (n+1) := by
   rw [hk]
 
 /-
-The following theorem can be proved similarly.
+다음 정리는 비슷하게 증명될 수 있습니다.
 
-We will use this theorem later.
+이 정리는 나중에 사용할 것입니다.
 
-A `sorry` proves any theorem. It should not be used in real proofs.
+`sorry`는 어떤 정리든 증명합니다. 실제 증명에서는 사용해서는 안 됩니다.
 -/
 theorem succ_of_odd_is_even {n : Nat} : Odd n → Even (n+1) := sorry
 
 /-
-We can use theorems by applying them.
+정리를 적용하여 사용할 수 있습니다.
 -/
 example : Odd 1 := by
   apply succ_of_even_is_odd
   exact zero_even
 /-
-The two new tactics are:
+두 가지 새로운 전술은 다음과 같습니다:
 
-  - `apply p` where `p` is an implication `q → r` and `r` is the goal rewrites
-  the goal to `q`. More generally, `apply t` will unify the current goal with
-  the conclusion of `t` and generate goals for each hypothesis of `t`.
-  - `exact h` solves the goal by stating that the goal is the same as `h`.
+  - `apply p`는 `p`가 함의 `q → r`이고 `r`이 목표일 때 목표를 `q`로 다시 씁니다. 더 일반적으로 `apply t`는 현재 목표를 `t`의 결론과 통합하고 `t`의 각 가설에 대한 목표를 생성합니다.
+  - `exact h`는 목표가 `h`와 동일하다고 명시하여 목표를 해결합니다.
 -/
 
 /-
-Let us see examples of disjunctions.
+선언(disjunctions)의 예를 살펴봅시다.
 -/
 example : Even 0 ∨ Odd 0 := Or.inl zero_even
 example : Even 0 ∨ Odd 1 := Or.inl zero_even
 example : Odd 1 ∨ Even 0 := Or.inr zero_even
 /-
-Here, we always know from `p ∨ q` which of `p` and/or `q` is correct. So we can
-introduce a proof of the correct side.
+여기서, 우리는 항상 `p ∨ q`에서 `p`와/또는 `q` 중 어느 것이 올바른지 알 수 있습니다. 그래서 우리는 올바른 쪽의 증명을 도입할 수 있습니다.
 -/
 
 /-
-Let us see a more "standard" disjunction.
+더 "표준적인" 선언을 살펴봅시다.
 
-Here, from the hypothesis that `n : Nat`, we cannot determine whether `n` is
-even or odd. So we cannot construct `Or` directly.
+여기서, `n : Nat`라는 가설에서 `n`이 짝수인지 홀수인지 결정할 수 없습니다. 그래서 우리는 `Or`를 직접 구성할 수 없습니다.
 
-But, for any specific `n`, we will know which one to construct.
+하지만, 어떤 특정한 `n`에 대해서는 어떤 것을 구성해야 할지 알게 될 것입니다.
 
-This is exactly what induction allows us to do. We introduce the `induction`
-tactic.
+이것이 바로 귀납법이 우리에게 허용하는 것입니다. `induction` 전술을 도입합니다.
 
-The inductive hypothesis is a disjunction. When disjunctions appear at the
-hypothesis, we use *proof by exhaustive cases*. This is done using the `cases`
-tactic.
+귀납적 가설은 선언입니다. 가설에 선언이 나타나면 *철저한 사례별 증명*을 사용합니다. 이것은 `cases` 전술을 사용하여 수행됩니다.
 -/
 theorem even_or_odd {n : Nat} : Even n ∨ Odd n := by
   induction n
@@ -248,12 +226,11 @@ theorem even_or_odd {n : Nat} : Even n ∨ Odd n := by
     | inl h => right ; apply (succ_of_even_is_odd h)
     | inr h => left  ; apply (succ_of_odd_is_even h)
 /-
-`induction` is not just for natural numbers. It is for any type, since all types
-in Lean are inductive.
+`induction`은 자연수만을 위한 것이 아닙니다. Lean의 모든 타입은 귀납적이므로 모든 타입에 대해 사용할 수 있습니다.
 -/
 
 /-
-We now state Collatz conjecture. The proof is left as an exercise to the reader.
+이제 콜라츠 추측을 기술합니다. 증명은 독자를 위한 연습 문제로 남겨둡니다.
 -/
 def collatz_next (n : Nat) : Nat :=
   if n % 2 = 0 then n / 2 else 3 * n + 1
@@ -266,53 +243,48 @@ def iter (k : Nat) (f : Nat → Nat) :=
 theorem collatz : ∀ n, n > 0 → ∃ k, iter k collatz_next n = 1 := sorry
 
 /-
-Now, some "corner cases" in logic.
+이제 논리학의 몇 가지 "코너 케이스"입니다.
 -/
 
 /-
-The proposition `True` is something that can be trivially proved.
+명제 `True`는 자명하게 증명될 수 있는 것입니다.
 
-`True.intro` is a constructor for proving `True`. Notice that it needs no
-inputs.
+`True.intro`는 `True`를 증명하기 위한 생성자입니다. 입력이 필요 없다는 점에 유의하십시오.
 -/
 theorem obvious : True := True.intro
 
 /-
-On the other hand, there is no constructor for `False`.
+반면에 `False`에 대한 생성자는 없습니다.
 
-We have to use `sorry`.
+`sorry`를 사용해야 합니다.
 -/
 theorem impossible : False := sorry
 
 /-
-Any `False` in the hypothesis allows us to conclude anything.
+가설에 있는 어떤 `False`라도 우리에게 무엇이든 결론 내리게 할 수 있습니다.
 
-Written in term style, we use the eliminator `False.elim`. It takes a proof of
-`False`, here `h`, and concludes whatever is the goal.
+항(term) 스타일로 작성할 때, 우리는 제거자 `False.elim`을 사용합니다. 이것은 `False`의 증명(여기서는 `h`)을 받아 목표가 무엇이든 결론을 내립니다.
 -/
 theorem nonsense (h : False) : 0 = 1 := False.elim h
 
 /-
-The `contradiction` tactic uses any `False` in the hypothesis to conclude the
-goal.
+`contradiction` 전술은 가설에 있는 어떤 `False`라도 사용하여 목표를 결론 내립니다.
 -/
 theorem more_nonsense (h : False) : 1 = 2 := by contradiction
 
 /-
-To illustrate constructive vs classical logic, we now prove the contrapositive
-theorem.
+구성주의 논리와 고전주의 논리의 차이를 설명하기 위해, 이제 대우(contrapositive) 정리를 증명합니다.
 
-The forward direction does not require classical logic.
+순방향은 고전주의 논리를 요구하지 않습니다.
 -/
 theorem contrapositive_forward' (p q : Prop) : (p → q) → (¬q → ¬p) :=
   fun pq => fun hqf => fun hp => hqf (pq hp)
 /-
-Use the definition `¬q := q → False`. Notice that we have to construct `p →
-False` given `p → q` and `q → False`. This is just function composition.
+정의 `¬q := q → False`를 사용하십시오. `p → q`와 `q → False`가 주어졌을 때 `p → False`를 구성해야 한다는 점에 유의하십시오. 이것은 단지 함수 합성일 뿐입니다.
 -/
 
 /-
-The above proof, using tactics.
+위 증명을 전술을 사용하여 다시 작성한 것입니다.
 -/
 theorem contrapositive_forward (p q : Prop) : (p → q) → (¬q → ¬p) := by
   intro hpq
@@ -322,14 +294,14 @@ theorem contrapositive_forward (p q : Prop) : (p → q) → (¬q → ¬p) := by
   contradiction
 
 /-
-The reverse requires classical logic.
+역방향은 고전주의 논리를 요구합니다.
 
-Here, we are required to construct a `q` given values of following types:
+여기서, 우리는 다음 타입의 값들이 주어졌을 때 `q`를 구성해야 합니다:
 
   - `(q → False) → (p → False)`.
   - `p`.
 
-This is impossible without using the law of excluded middle.
+이것은 배중률을 사용하지 않고는 불가능합니다.
 -/
 theorem contrapositive_reverse' (p q : Prop) : (¬q → ¬p) → (p → q) :=
   fun hnqnp =>
@@ -337,15 +309,11 @@ theorem contrapositive_reverse' (p q : Prop) : (¬q → ¬p) → (p → q) :=
     (fun hq  => fun  _ => hq)
     (fun hnq => fun hp => absurd hp (hnqnp hnq))
 /-
-Law of excluded middle tells us that we will have a `q` or a `q → False`. In the
-first case, it is trivial to construct a `q`, we already have it. In the second
-case, we give the `q → False` to obtain a `p → False`.  Then, we use the fact
-(in constructive logic) that given `p` and `p → False`, we can construct
-`False`. Once, we have `False`, we can construct anything, and specifically `q`.
+배중률은 우리에게 `q` 또는 `q → False`가 있을 것이라고 말해줍니다. 첫 번째 경우, `q`를 구성하는 것은 자명합니다. 우리는 이미 그것을 가지고 있습니다. 두 번째 경우, `p → False`를 얻기 위해 `q → False`를 제공합니다. 그런 다음, `p`와 `p → False`가 주어지면 `False`를 구성할 수 있다는 사실(구성주의 논리에서)을 사용합니다. 일단 `False`를 가지게 되면, 우리는 무엇이든 구성할 수 있으며, 구체적으로 `q`를 구성할 수 있습니다.
 -/
 
 /-
-Same proof, using tactics.
+전술을 사용한 동일한 증명입니다.
 -/
 theorem contrapositive_reverse (p q : Prop) : (¬q → ¬p) → (p → q) := by
   intro hnqnp
@@ -356,17 +324,15 @@ theorem contrapositive_reverse (p q : Prop) : (¬q → ¬p) → (p → q) := by
   case inr h => specialize hnqnp h ; contradiction
 
 /-
-To illustrate how we can define an work with axiomatic systems. Here is a
-definition of Groups and some proofs directly translated from "Topics in
-Algebra" by Herstein, Second edition.
+공리 체계를 정의하고 작업하는 방법을 설명하기 위해, Herstein의 "대수학의 주제들(Topics in Algebra)" 제2판에서 직접 번역한 군(Group)의 정의와 몇 가지 증명을 소개합니다.
 -/
 
 /-
-A `section` introduces a namespace.
+`section`은 네임스페이스를 도입합니다.
 -/
 section GroupTheory
 /-
-To define abstract objects like groups, we may use `class`.
+군과 같은 추상적인 객체를 정의하기 위해 `class`를 사용할 수 있습니다.
 -/
 class Group (G : Type u) where
   op : G → G → G
@@ -376,21 +342,20 @@ class Group (G : Type u) where
   inverse: ∀ a : G, ∃ b : G, op a b = e ∧ op b a = e
 
 /-
-Let us introduce some notation to make this convenient.
+이것을 편리하게 만들기 위해 몇 가지 표기법을 도입합시다.
 -/
 open Group
 infixl:70 " * " => op
 
 /-
-`G` will always stand for a group and variables `a b c` will be elements of that
-group in this `section`.
+이 `section`에서 `G`는 항상 군을 나타내고 변수 `a b c`는 해당 군의 원소가 될 것입니다.
 -/
 variable [Group G] {a b c : G}
 
 def is_identity (e' : G) := ∀ a : G, (a * e' = a ∧ e' * a = a)
 
 /-
-We prove that the identity element is unique.
+항등원이 유일함을 증명합니다.
 -/
 theorem identity_element_unique : ∀ e' : G, is_identity e' → e' = e := by
   intro e'
@@ -401,12 +366,11 @@ theorem identity_element_unique : ∀ e' : G, is_identity e' → e' = e := by
   have ⟨_, h2⟩ := h'
   exact Eq.trans (Eq.symm h2) h1
 /-
-Note that we used the `identity` axiom.
+`identity` 공리를 사용했음에 유의하십시오.
 -/
 
 /-
-Left cancellation. We have to use both `identity` and `inverse` axioms from
-`Group`.
+왼쪽 소거. `Group`의 `identity`와 `inverse` 공리를 모두 사용해야 합니다.
 -/
 theorem left_cancellation : ∀ x y : G, a * x = a * y → x = y := by
   have h1 := inverse a
@@ -423,12 +387,12 @@ theorem left_cancellation : ∀ x y : G, a * x = a * y → x = y := by
     _ = (e : G) * y  := by rw [h2]
     _ = y            := (identity y).right
 
-end GroupTheory /- Variables `G`, `a`, `b`, `c` are now not in scope. -/
+end GroupTheory /- 변수 `G`, `a`, `b`, `c`는 이제 범위에 없습니다. -/
 
 /-
-Let us see a mutually recursive definition.
+상호 재귀적인 정의를 살펴봅시다.
 
-The game of Nim with two heaps.
+두 개의 힙이 있는 님(Nim) 게임입니다.
 -/
 abbrev between (lower what upper : Nat) : Prop := lower ≤ what ∧ what ≤ upper
 
@@ -457,9 +421,7 @@ example : Bob 0 0 := by
     intro a ; have := a.right ; contradiction
 
 /-
-We have to convince Lean of termination when a function is defined using just a
-`def`. Here's a simple primality checking algorithm that tests all candidate
-divisors.
+단지 `def`를 사용하여 함수가 정의될 때, 우리는 Lean에게 종료를 확신시켜야 합니다. 다음은 모든 후보 약수를 테스트하는 간단한 소수 판별 알고리즘입니다.
 -/
 def prime' (n : Nat) : Bool :=
   if h : n < 2 then
@@ -468,7 +430,7 @@ def prime' (n : Nat) : Bool :=
     @go 2 n (by omega)
 where
   go (d : Nat) (n : Nat) {_ : n ≥ d} : Bool :=
-    if h : n = d then /- `h` needed for `omega` below. -/
+    if h : n = d then /- `omega`가 아래에서 필요로 하는 `h`. -/
       true
     else if n % d = 0 then
       false
@@ -476,22 +438,16 @@ where
       @go (Nat.succ d) n (by omega)
   termination_by (n - d)
 /-
-We have to specify that the recursive function `go` terminates because `n-k`
-decreases in each recursive call. This needs the hypothesis `n > k` at the
-recursive call site. But the function itself can only assume that `n ≥ k`. We
-label the test `n ≤ k` by `h` so that the falsification of this proposition can
-be used by `omega` later to conclude that `n > k`.
+재귀 함수 `go`가 각 재귀 호출에서 `n-k`가 감소하기 때문에 종료된다는 것을 명시해야 합니다. 이를 위해서는 재귀 호출 위치에 `n > k`라는 가설이 필요합니다. 하지만 함수 자체는 `n ≥ k`라고만 가정할 수 있습니다. 우리는 `n ≤ k` 테스트를 `h`로 레이블을 지정하여, 나중에 `omega`가 `n > k`라고 결론 내리는 데 이 명제의 반증을 사용할 수 있도록 합니다.
 
-The tactic `omega` can solve simple equalities and inequalities.
+`omega` 전술은 간단한 등식과 부등식을 풀 수 있습니다.
 -/
 /-
-You can also instruct Lean to not check for totality by prefixing `partial` to
-`def`.
+또한 `def` 앞에 `partial`을 붙여 Lean이 전체성(totality)을 확인하지 않도록 지시할 수 있습니다.
 -/
 
 /-
-Or, we can rewrite the function to test the divisors from largest to
-smallest. In this case, Lean easily verifies that the function is total.
+또는, 약수를 가장 큰 것부터 가장 작은 것 순으로 테스트하도록 함수를 다시 작성할 수 있습니다. 이 경우 Lean은 함수가 전체(total)임을 쉽게 확인합니다.
 -/
 def prime (n : Nat) : Bool :=
   if n < 2 then
@@ -507,14 +463,13 @@ where
     else
       go (d-1) n
 /-
-Now, to Lean, it is obvious that `go` will terminate because `d` decreases in
-each recursive call.
+이제 Lean에게는 각 재귀 호출에서 `d`가 감소하기 때문에 `go`가 종료될 것이라는 점이 명백합니다.
 -/
 #eval prime 57
 #eval prime 97
 ```
 
-For further learning, see:
+더 자세한 학습을 원하시면 다음을 참조하십시오:
 
 * [Functional Programming in Lean](https://lean-lang.org/functional_programming_in_lean/)
 * [Theorem Proving in Lean 4](https://lean-lang.org/theorem_proving_in_lean4/)

--- a/ko/lfe.md
+++ b/ko/lfe.md
@@ -1,5 +1,3 @@
-# lfe.md (번역)
-
 ---
 name: "Lisp Flavoured Erlang (LFE)"
 filename: lispflavourederlang.lfe
@@ -7,114 +5,112 @@ contributors:
   - ["Pratik Karki", "https://github.com/prertik"]
 ---
 
-Lisp Flavoured Erlang (LFE) is a functional, concurrent, general-purpose programming
-language and Lisp dialect (Lisp-2) built on top of Core Erlang and the Erlang Virtual Machine (BEAM).
+Lisp Flavoured Erlang(LFE)는 함수형, 동시성, 범용 프로그래밍 언어이자 코어 얼랭(Core Erlang) 및 얼랭 가상 머신(BEAM) 위에 구축된 리스프 방언(Lisp-2)입니다.
 
-LFE can be obtained from [LFE](https://github.com/rvirding/lfe).
-The classic starting point is the [LFE docs](http://docs.lfe.io).
+LFE는 [LFE](https://github.com/rvirding/lfe)에서 얻을 수 있습니다.
+고전적인 시작점은 [LFE 문서](http://docs.lfe.io)입니다.
 
 ```lisp
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 0. Syntax
+;;; 0. 구문
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;; General form.
+;;; 일반적인 형식.
 
-;; Lisp is comprised of two syntaxes, the ATOM and the S-expression.
-;; `forms` are known as grouped S-expressions.
+;; 리스프는 ATOM과 S-표현식이라는 두 가지 구문으로 구성됩니다.
+;; `form`은 그룹화된 S-표현식으로 알려져 있습니다.
 
-8  ; an atom; it evaluates to itself
+8  ; 아톰; 자기 자신으로 평가됩니다.
 
-:ERLANG ;Atom; evaluates to the symbol :ERLANG.
+:ERLANG ; 아톰; 심볼 :ERLANG으로 평가됩니다.
 
-t  ; another atom which denotes true.
+t  ; true를 나타내는 또 다른 아톰입니다.
 
-(* 2 21) ; an S- expression
+(* 2 21) ; S-표현식입니다.
 
-'(8 :foo t)  ;another one
+'(8 :foo t)  ; 또 다른 예시입니다.
 
 
-;;; Comments
+;;; 주석
 
-;; Single line comments start with a semicolon; use two for normal
-;; comments, three for section comments, and four fo file-level
-;; comments.
+;; 한 줄 주석은 세미콜론으로 시작합니다. 일반 주석에는 두 개,
+;; 섹션 주석에는 세 개, 파일 수준 주석에는 네 개를 사용하십시오.
 
-;; Block Comment
+;; 블록 주석
 
-   #| comment text |#
+   #| 주석 텍스트 |#
 
-;;; Environment
+;;; 환경
 
-;; LFE is the de-facto standard.
+;; LFE는 사실상의 표준입니다.
 
-;; Libraries can be used directly from the Erlang ecosystem. Rebar3 is the build tool.
+;; 라이브러리는 얼랭 생태계에서 직접 사용할 수 있습니다. Rebar3가 빌드 도구입니다.
 
-;; LFE is usually developed with a text editor(preferably Emacs) and a REPL
-;; (Read Evaluate Print Loop) running at the same time. The REPL
-;; allows for interactive exploration of the program as it is "live"
-;; in the system.
+;; LFE는 보통 텍스트 편집기(가급적 이맥스)와 REPL(Read Evaluate Print Loop)을
+;; 동시에 실행하여 개발합니다. REPL을 사용하면 시스템에서 "실시간"으로
+;; 실행 중인 프로그램을 대화식으로 탐색할 수 있습니다.
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 1. Literals and Special Syntactic Rules
+;;; 1. 리터럴 및 특수 구문 규칙
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;; Integers
+;;; 정수
 
-1234 -123           ; Regular decimal notation
-#b0 #b10101         ; Binary notation
-#0 #10101           ; Binary notation (alternative form)
-#o377 #o-111        ; Octal notation
-#d123456789 #d+123  ; Explicitly decimal notation
-#xc0ffe 0x-01       ; Hexadecimal notation
-#2r1010 #8r377      ;Notation with explicit base (up to 36)
-#\a #$ #\ä #\🐭     ;Character notation (the value is the Unicode code point of the character)
-#\x1f42d;           ;Character notation with the value in hexadecimal
+1234 -123           ; 일반 10진수 표기법
+#b0 #b10101         ; 2진수 표기법
+#0 #10101           ; 2진수 표기법 (대체 형식)
+#o377 #o-111        ; 8진수 표기법
+#d123456789 #d+123  ; 명시적 10진수 표기법
+#xc0ffe 0x-01       ; 16진수 표기법
+#2r1010 #8r377      ; 명시적 밑을 사용한 표기법 (최대 36)
+#\a #$ #\ä #\🐭     ; 문자 표기법 (값은 해당 문자의 유니코드 코드 포인트입니다)
+#\x1f42d;           ; 16진수 값을 사용한 문자 표기법
 
-;;; Floating point numbers
+;;; 부동 소수점 숫자
 1.0 +2.0 -1.5 1.0e10 1.111e-10
 
-;;; Strings
+;;; 문자열
 
-"any text between double quotes where \" and other special characters like \n can be escaped".
-; List String
-"Cat: \x1f639;" ; writing unicode in string for regular font ending with semicolon.
+"큰따옴표 사이의 모든 텍스트. \"나 다른 특수 문자(\n 등)는 이스케이프될 수 있습니다."
+; 리스트 문자열
+"Cat: \x1f639;" ; 일반 글꼴의 문자열에 유니코드를 작성하고 세미콜론으로 끝냅니다.
 
-#"This is a binary string \n with some \"escaped\" and quoted (\x1f639;) characters"
-; Binary strings are just strings but function different in the VM.
-; Other ways of writing it are:  #B("a"), #"a", and #B(97).
+#"이것은 일부 \"이스케이프된\" 및 인용된 (\x1f639;) 문자가 있는 바이너리 문자열입니다 \n"
+; 바이너리 문자열은 그냥 문자열이지만 VM에서 다르게 작동합니다.
+; 다른 작성 방법으로는 #B("a"), #"a", #B(97)이 있습니다.
 
 
-;;; Character escaping
+;;; 문자 이스케이프
 
-\b  ; => Backspace
-\t  ; => Tab
-\n  ; => Newline
-\v  ; => Vertical tab
-\f  ; => Form Feed
-\r  ; => Carriage Return
-\e  ; => Escape
-\s  ; => Space
-\d  ; => Delete
+\b  ; => 백스페이스
+\t  ; => 탭
+\n  ; => 개행
+\v  ; => 수직 탭
+\f  ; => 폼 피드
+\r  ; => 캐리지 리턴
+\e  ; => 이스케이프
+\s  ; => 공백
+\d  ; => 삭제
 
-;;; Binaries
-;; It is used to create binaries with any contents.
-#B((#"a" binary) (#"b" binary))                 ; #"ab" (Evaluated form)
+;;; 바이너리
+;; 어떤 내용이든 바이너리를 만드는 데 사용됩니다.
+#B((#"a" binary) (#"b" binary))                 ; #"ab" (평가된 형식)
 
-;;; Lists are: () or (foo bar baz)
+;;; 리스트: () 또는 (foo bar baz)
 
-;;; Tuples are written in: #(value1 value2 ...). Empty tuple #() is also valid.
+;;; 튜플은 #(value1 value2 ...) 형식으로 작성됩니다. 빈 튜플 #()도 유효합니다.
 
-;;; Maps are written as: #M(key1 value1 key2 value2 ...). Empty map #M() is also valid.
+;;; 맵은 #M(key1 value1 key2 value2 ...) 형식으로 작성됩니다. 빈 맵 #M()도 유효합니다.
 
-;;; Symbols: Things that cannot be parsed. Eg: foo, Foo, foo-bar, :foo
-| foo | ; explicit construction of symbol by wrapping vertical bars.
+;;; 심볼: 파싱할 수 없는 것들. 예: foo, Foo, foo-bar, :foo
+| foo | ; 수직 막대로 감싸서 심볼을 명시적으로 생성합니다.
 
-;;; Evaluation
+;;; 평가
 
-;; #.(... some expression ...). E.g. '#.(+ 1 1) will evaluate the (+ 1 1) while it            ;; reads the expression and then be effectively '2.
+;; #.(... 어떤 표현식 ...). 예: '#.(+ 1 1)은 표현식을 읽는 동안 (+ 1 1)을
+;; 평가하여 효과적으로 '2가 됩니다.
 
-;; List comprehension in LFE REPL
+;; LFE REPL에서의 리스트 컴프리헨션
 
 lfe> (list-comp
           ((<- x '(0 1 2 3)))
@@ -123,10 +119,10 @@ lfe> (list-comp
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 2. Core forms
+;; 2. 핵심 형식
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; These forms are the same as those found in Common Lisp and Scheme.
+;; 이 형식들은 커먼 리스프(Common Lisp)와 스킴(Scheme)에서 볼 수 있는 것들과 동일합니다.
 
 (quote e)
 (cons head tail)
@@ -139,19 +135,19 @@ lfe> (list-comp
 
 (lambda (arg ...) ...)
   (match-lambda
-    ((arg ... ) {{(when e ...)}} ...) ; Matches clauses
+    ((arg ... ) {{(when e ...)}} ...) ; 절 일치
     ... )
 (let ((pat {{(when e ...)}} e)
       ...)
   ... )
-(let-function ((name lambda|match-lambda) ; Only define local
-               ... )                      ; functions
+(let-function ((name lambda|match-lambda) ; 지역 함수만 정의
+               ... )
   ... )
-(letrec-function ((name lambda|match-lambda) ; Only define local
-                  ... )                      ; functions
+(letrec-function ((name lambda|match-lambda) ; 지역 함수만 정의
+                  ... )
   ... )
-(let-macro ((name lambda-match-lambda) ; Only define local
-            ...)                       ; macros
+(let-macro ((name lambda-match-lambda) ; 지역 매크로만 정의
+            ...)
   ...)
 (progn ... )
 (if test true-expr {{false-expr}})
@@ -168,56 +164,56 @@ lfe> (list-comp
   {{(case ((pat {{(when e ...)}} ... )
           ... ))}}
   {{(catch
-     ; Next must be tuple of length 3!
+     ; 다음은 반드시 길이가 3인 튜플이어야 합니다!
      (((tuple type value ignore) {{(when e ...)}}
       ... )
      ... )}}
   {{(after ... )}})
 
 (funcall func arg ... )
-(call mod func arg ... ) - Call to Erlang Mod:Func(Arg, ... )
+(call mod func arg ... ) - 얼랭 Mod:Func(Arg, ... ) 호출
 (define-module name declaration ... )
-(extend-module declaration ... ) - Define/extend module and declarations.
+(extend-module declaration ... ) - 모듈 및 선언 정의/확장
 (define-function name lambda|match-lambda)
-(define-macro name lambda|match-lambda) - Define functions/macros at top-level.
+(define-macro name lambda|match-lambda) - 최상위 수준에서 함수/매크로 정의
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 3. Macros
+;; 3. 매크로
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Macros are part of the language and allow you to create abstractions
-;; on top of the core language and standard library that move you closer
-;; toward being able to directly express the things you want to express.
+;; 매크로는 언어의 일부이며, 핵심 언어와 표준 라이브러리 위에
+;; 추상화를 생성하여 표현하고자 하는 것을 더 직접적으로
+;; 표현할 수 있도록 해줍니다.
 
-;; Top-level function
+;; 최상위 함수
 
 (defun name (arg ...) ...)
 
-;; Adding comments in functions
+;; 함수에 주석 추가하기
 
 (defun name
-  "Toplevel function with pattern-matching arguments"
+  "패턴 매칭 인수를 사용하는 최상위 함수"
   ((argpat ...) ...)
   ...)
 
-;; Top-level macro
+;; 최상위 매크로
 
 (defmacro name (arg ...) ...)
 (defmacro name arg ...)
 
-;; Top-level macro with pattern matching arguments
+;; 패턴 매칭 인수를 사용하는 최상위 매크로
 
 (defmacro name
   ((argpat ...) ...)
   ...)
 
-;; Top-level macro using Scheme inspired syntax-rules format
+;; 스킴에서 영감을 받은 syntax-rules 형식을 사용하는 최상위 매크로
 
 (defsyntax name
   (pat exp)
   ...)
 
-;;; Local macros in macro or syntax-rule format
+;;; 매크로 또는 syntax-rule 형식의 지역 매크로
 
 (macrolet ((name (arg ... ) ... )
             ... )
@@ -227,45 +223,45 @@ lfe> (list-comp
              ...)
  ...)
 
-;; Like CLISP
+;; CLISP와 유사
 
 (prog1 ...)
 (prog2 ...)
 
-;; Erlang LFE module
+;; 얼랭 LFE 모듈
 
 (defmodule name ...)
 
-;; Erlang LFE record
+;; 얼랭 LFE 레코드
 
 (defrecord name ...)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 4. Patterns and Guards
+;; 4. 패턴과 가드
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Using patterns in LFE compared to that of Erlang
+;; 얼랭과 비교한 LFE에서의 패턴 사용
 
-;; Erlang                     ;; LFE
+;; 얼랭                     ;; LFE
 ;; {ok, X}                       (tuple 'ok x)
 ;; error                         'error
 ;; {yes, [X|Xs]}                 (tuple 'yes (cons x xs))
 ;; <<34,F/float>>                (binary 34 (f float))
 ;; [P|Ps]=All                    (= (cons p ps) all)
 
-  _    ; => is don't care while pattern matching
+  _    ; => 패턴 매칭 시 신경 쓰지 않음
 
-  (= pattern1 pattern2)     ; => easier, better version of pattern matching
+  (= pattern1 pattern2)     ; => 더 쉽고 나은 버전의 패턴 매칭
 
-;; Guards
+;; 가드
 
-;; Whenever pattern occurs (let, case, receive, lc, etc) it can be followed by an optional
-;; guard which has the form (when test ...).
+;; 패턴이 나타날 때마다 (let, case, receive, lc 등) 선택적으로
+;; (when test ...) 형식의 가드를 뒤따를 수 있습니다.
 
-(progn gtest ...)             ;; => Sequence of guard tests
+(progn gtest ...)             ;; => 가드 테스트의 시퀀스
 (if gexpr gexpr gexpr)
 (type-test e)
-(guard-bif ...)               ;; => Guard BIFs, arithmetic, boolean and comparison operators
+(guard-bif ...)               ;; => 가드 BIF, 산술, 불리언 및 비교 연산자
 
 ;;; REPL
 
@@ -274,7 +270,7 @@ lfe>(set (tuple len status msg) #(8 ok "Trillian"))
 lfe>msg
     "Trillian"
 
-;;; Program illustrating use of Guards
+;;; 가드 사용을 보여주는 프로그램
 
 (defun right-number?
         ((x) (when (orelse (== x 42) (== x 276709)))
@@ -282,56 +278,56 @@ lfe>msg
         ((_) 'false))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 5. Functions
+;; 5. 함수
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; A simple function using if.
+;; if를 사용하는 간단한 함수.
 
 (defun max (x y)
-  "The max function."
+  "max 함수."
   (if (>= x y) x y))
 
-;; Same function using more clause
+;; 더 많은 절을 사용하는 동일한 함수
 
 (defun max
-  "The max function."
+  "max 함수."
   ((x y) (when (>= x y)) x)
   ((x y) y))
 
-;; Same function using similar style but using local functions defined by flet or fletrec
+;; 비슷한 스타일이지만 flet 또는 fletrec으로 정의된 지역 함수를 사용하는 동일한 함수
 
 (defun foo (x y)
-  "The max function."
-  (flet ((m (a b) "Local comment."
+  "max 함수."
+  (flet ((m (a b) "지역 주석."
             (if (>= a b) a b)))
     (m x y)))
 
-;; LFE being Lisp-2 has separate namespaces for variables and functions
-;; Both variables and function/macros are lexically scoped.
-;; Variables are bound by lambda, match-lambda and let.
-;; Functions are bound by top-level defun, flet and fletrec.
-;; Macros are bound by top-level defmacro/defsyntax and by macrolet/syntaxlet.
+;; LFE는 Lisp-2이므로 변수와 함수에 대해 별도의 네임스페이스를 가집니다.
+;; 변수와 함수/매크로는 모두 어휘적으로 범위가 지정됩니다.
+;; 변수는 lambda, match-lambda 및 let에 의해 바인딩됩니다.
+;; 함수는 최상위 defun, flet 및 fletrec에 의해 바인딩됩니다.
+;; 매크로는 최상위 defmacro/defsyntax 및 macrolet/syntaxlet에 의해 바인딩됩니다.
 
-;; (funcall func arg ...) like CL to call lambdas/match-lambdas
-;; (funs) bound to variables are used.
+;; (funcall func arg ...)은 CL처럼 람다/매치-람다를 호출하는 데 사용됩니다.
+;; 변수에 바인딩된 (funs)가 사용됩니다.
 
-;; separate bindings and special for apply.
+;; apply를 위한 별도의 바인딩 및 특수.
 apply _F (...),
 apply _F/3 ( a1, a2, a3 )
 
-;; Cons'ing in function heads
+;; 함수 헤드에서의 Cons'ing
 (defun sum (l) (sum l 0))
   (defun sum
     (('() total) total)
     (((cons h t) total) (sum t (+ h total))))
 
-;; ``cons`` literal instead of constructor form
+;; 생성자 형식 대신 cons 리터럴
       (defun sum (l) (sum l 0))
       (defun sum
         (('() total) total)
         ((`(,h . ,t) total) (sum t (+ h total))))
 
-;; Matching records in function heads
+;; 함수 헤드에서 레코드 매칭
 
 (defun handle_info
   (('ping (= (match-state remote-pid 'undefined) state))
@@ -340,20 +336,20 @@ apply _F/3 ( a1, a2, a3 )
   (('ping state)
    `#(noreply ,state)))
 
-;; Receiving Messages
+;; 메시지 수신
       (defun universal-server ()
         (receive
           ((tuple 'become func)
            (funcall func))))
 
-;; another way for receiving messages
+;; 메시지를 수신하는 또 다른 방법
 
  (defun universal-server ()
         (receive
           (`#(become ,func)
             (funcall func))))
 
-;; Composing a complete function for specific tasks
+;; 특정 작업을 위한 완전한 함수 작성
 
 (defun compose (f g)
   (lambda (x)
@@ -369,10 +365,10 @@ apply _F/3 ( a1, a2, a3 )
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 6. Concurrency
+;; 6. 동시성
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Message passing as done by Erlang's light-weight "processes".
+;; 얼랭의 경량 "프로세스"에 의해 수행되는 메시지 전달.
 
 (defmodule messenger-back
  (export (print-result 0) (send-message 2)))
@@ -389,39 +385,39 @@ apply _F/3 ( a1, a2, a3 )
   (let ((spawned-pid (spawn 'messenger-back 'print-result ())))
     (! spawned-pid (tuple calling-pid msg))))
 
-;; Multiple simultaneous HTTP Requests:
+;; 다중 동시 HTTP 요청:
 
 (defun parse-args (flag)
-  "Given one or more command-line arguments, extract the passed values.
+  "하나 이상의 명령줄 인수가 주어지면 전달된 값을 추출합니다.
 
-  For example, if the following was passed via the command line:
+  예를 들어, 명령줄을 통해 다음이 전달된 경우:
 
     $ erl -my-flag my-value-1 -my-flag my-value-2
 
-  One could then extract it in an LFE program by calling this function:
+  그런 다음 LFE 프로그램에서 이 함수를 호출하여 추출할 수 있습니다:
 
     (let ((args (parse-args 'my-flag)))
       ...
       )
-  In this example, the value assigned to the arg variable would be a list
-  containing the values my-value-1 and my-value-2."
+  이 예에서 arg 변수에 할당된 값은 my-value-1 및 my-value-2 값을
+  포함하는 리스트가 됩니다."
   (let ((`#(ok ,data) (init:get_argument flag)))
     (lists:merge data)))
 
 (defun get-pages ()
-  "With no argument, assume 'url parameter was passed via command line."
+  "인수가 없으면 'url 매개변수가 명령줄을 통해 전달되었다고 가정합니다."
   (let ((urls (parse-args 'url)))
     (get-pages urls)))
 
 (defun get-pages (urls)
-  "Start inets and make (potentially many) HTTP requests."
+  "inets를 시작하고 (잠재적으로 많은) HTTP 요청을 만듭니다."
   (inets:start)
   (plists:map
     (lambda (x)
       (get-page x)) urls))
 
 (defun get-page (url)
-  "Make a single HTTP request."
+  "단일 HTTP 요청을 만듭니다."
   (let* ((method 'get)
          (headers '())
          (request-data `#(,url ,headers))
@@ -435,13 +431,13 @@ apply _F/3 ( a1, a2, a3 )
        (io:format "Result: ~p~n" `(,result))))))
 ```
 
-## Further Reading
+## 더 읽을거리
 
 * [LFE DOCS](http://docs.lfe.io)
 * [LFE GitBook](https://lfe.gitbooks.io/reference-guide/index.html)
 * [LFE Wiki](https://en.wikipedia.org/wiki/LFE_(programming_language))
 
-## Extra Info
+## 추가 정보
 
-* [LFE PDF](http://www.erlang-factory.com/upload/presentations/61/Robertvirding-LispFlavouredErlang.pdf)
+* [LFE PDF](http.www.erlang-factory.com/upload/presentations/61/Robertvirding-LispFlavouredErlang.pdf)
 * [LFE mail](https://groups.google.com/d/msg/lisp-flavoured-erlang/XA5HeLbQQDk/TUHabZCHXB0J)

--- a/ko/livescript.md
+++ b/ko/livescript.md
@@ -1,5 +1,3 @@
-# livescript.md (번역)
-
 ---
 name: LiveScript
 filename: learnLivescript.ls
@@ -7,120 +5,111 @@ contributors:
     - ["Christina Whyte", "http://github.com/kurisuwhyte/"]
 ---
 
-LiveScript is a functional compile-to-JavaScript language which shares
-most of the underlying semantics with its host language. Nice additions
-come with currying, function composition, pattern matching and lots of
-other goodies heavily borrowed from languages like Haskell, F# and
-Scala.
+LiveScript는 함수형 자바스크립트 컴파일 언어로, 호스트 언어와 대부분의 기본 의미를 공유합니다. 커링, 함수 합성, 패턴 매칭 및 Haskell, F#, Scala와 같은 언어에서 많이 차용한 다른 좋은 기능들이 추가되었습니다.
 
-LiveScript is a fork of [Coco](https://github.com/satyr/coco), which is
-itself a fork of [CoffeeScript](https://coffeescript.org/).
+LiveScript는 [Coco](https://github.com/satyr/coco)의 포크이며, Coco 자체는 [CoffeeScript](https://coffeescript.org/)의 포크입니다.
 
 ```livescript
-# Just like its CoffeeScript cousin, LiveScript uses number symbols for
-# single-line comments.
+# CoffeeScript 사촌과 마찬가지로 LiveScript는 한 줄 주석에 숫자 기호를 사용합니다.
 
 /*
- Multi-line comments are written C-style. Use them if you want comments
- to be preserved in the JavaScript output.
+ 여러 줄 주석은 C 스타일로 작성됩니다. 주석을 자바스크립트 출력에
+ 보존하고 싶다면 사용하십시오.
  */
 
-# As far as syntax goes, LiveScript uses indentation to delimit blocks,
-# rather than curly braces, and whitespace to apply functions, rather
-# than parenthesis.
+# 구문 측면에서 LiveScript는 블록을 구분하기 위해 중괄호 대신
+# 들여쓰기를 사용하고, 함수를 적용하기 위해 괄호 대신 공백을 사용합니다.
 
 
 ########################################################################
-## 1. Basic values
+## 1. 기본 값
 ########################################################################
 
-# Lack of value is defined by the keyword `void` instead of `undefined`
-void            # same as `undefined` but safer (can't be overridden)
+# 값의 부재는 `undefined` 키워드 대신 `void`로 정의됩니다.
+void            # `undefined`와 같지만 더 안전합니다 (재정의할 수 없음)
 
-# No valid value is represented by Null.
+# 유효하지 않은 값은 Null로 표시됩니다.
 null
 
 
-# The most basic actual value is the logical type:
+# 가장 기본적인 실제 값은 논리 타입입니다:
 true
 false
 
-# And it has a plethora of aliases that mean the same thing:
+# 그리고 같은 의미를 가진 많은 별칭이 있습니다:
 on; off
 yes; no
 
 
-# Then you get numbers. These are double-precision floats like in JS.
+# 그 다음은 숫자입니다. JS에서와 같이 배정밀도 부동 소수점입니다.
 10
-0.4     # Note that the leading `0` is required
+0.4     # 참고: 앞에 `0`이 필요합니다.
 
-# For readability, you may use underscores and letter suffixes in a
-# number, and these will be ignored by the compiler.
+# 가독성을 위해 숫자에 밑줄과 문자 접미사를 사용할 수 있으며,
+# 컴파일러는 이를 무시합니다.
 12_344km
 
 
-# Strings are immutable sequences of characters, like in JS:
-"Christina"             # apostrophes are okay too!
-"""Multi-line
-   strings
-   are
-   okay
-   too."""
+# 문자열은 JS에서와 같이 불변의 문자 시퀀스입니다:
+"Christina"             # 작은따옴표도 괜찮습니다!
+"""여러 줄
+   문자열도
+   괜찮습니다."""
 
-# Sometimes you want to encode a keyword, the backslash notation makes
-# this easy:
+# 때로는 키워드를 인코딩하고 싶을 때가 있는데, 백슬래시 표기법을 사용하면
+# 쉽게 할 수 있습니다:
 \keyword                # => 'keyword'
 
 
-# Arrays are ordered collections of values.
+# 배열은 순서가 있는 값의 컬렉션입니다.
 fruits =
   * \apple
   * \orange
   * \pear
 
-# They can be expressed more concisely with square brackets:
+# 대괄호를 사용하여 더 간결하게 표현할 수 있습니다:
 fruits = [ \apple, \orange, \pear ]
 
-# You also get a convenient way to create a list of strings, using
-# white space to delimit the items.
+# 공백을 사용하여 항목을 구분하는 편리한 방법으로
+# 문자열 목록을 만들 수도 있습니다.
 fruits = <[ apple orange pear ]>
 
-# You can retrieve an item by their 0-based index:
+# 0부터 시작하는 인덱스로 항목을 검색할 수 있습니다:
 fruits[0]       # => "apple"
 
-# Objects are a collection of unordered key/value pairs, and a few other
-# things (more on that later).
+# 객체는 순서가 없는 키/값 쌍의 컬렉션이며, 몇 가지 다른
+# 기능도 있습니다 (나중에 자세히 설명).
 person =
   name: "Christina"
   likes:
     * "kittens"
     * "and other cute stuff"
 
-# Again, you can express them concisely with curly brackets:
+# 다시 말하지만, 중괄호로 간결하게 표현할 수 있습니다:
 person = {name: "Christina", likes: ["kittens", "and other cute stuff"]}
 
-# You can retrieve an item by their key:
+# 키로 항목을 검색할 수 있습니다:
 person.name     # => "Christina"
 person["name"]  # => "Christina"
 
 
-# Regular expressions use the same syntax as JavaScript:
-trailing-space = /\s$/          # dashed-words become dashedWords
+# 정규 표현식은 자바스크립트와 동일한 구문을 사용합니다:
+trailing-space = /\s$/          # 대시-단어는 대시단어(dashedWords)가 됩니다.
 
-# Except you can do multi-line expressions too!
-# (comments and whitespace just gets ignored)
+# 단, 여러 줄 표현식도 가능합니다!
+# (주석과 공백은 무시됩니다)
 funRE = //
-        function\s+(.+)         # name
-        \s* \((.*)\) \s*        # arguments
-        { (.*) }                # body
+        function\s+(.+)         # 이름
+        \s* \((.*)\) \s*        # 인수
+        { (.*) }                # 본문
         //
 
 
 ########################################################################
-## 2. Basic operations
+## 2. 기본 연산
 ########################################################################
 
-# Arithmetic operators are the same as JavaScript's:
+# 산술 연산자는 자바스크립트와 동일합니다:
 1 + 2   # => 3
 2 - 1   # => 1
 2 * 3   # => 6
@@ -128,9 +117,9 @@ funRE = //
 3 % 2   # => 1
 
 
-# Comparisons are mostly the same too, except that `==` is the same as
-# JS's `===`, where JS's `==` in LiveScript is `~=`, and `===` enables
-# object and array comparisons, and also stricter comparisons:
+# 비교도 대부분 동일하지만, `==`는 JS의 `===`와 같고,
+# JS의 `==`는 LiveScript에서 `~=`이며, `===`는
+# 객체 및 배열 비교와 더 엄격한 비교를 가능하게 합니다:
 2 == 2          # => true
 2 == "2"        # => false
 2 ~= "2"        # => true
@@ -142,55 +131,51 @@ funRE = //
 +0 == -0     # => true
 +0 === -0    # => false
 
-# Other relational operators include <, <=, > and >=
+# 다른 관계 연산자에는 <, <=, > 및 >=가 포함됩니다.
 
-# Logical values can be combined through the logical operators `or`,
-# `and` and `not`
+# 논리 값은 `or`, `and`, `not` 논리 연산자를 통해 결합할 수 있습니다.
 true and false  # => false
 false or true   # => true
 not false       # => true
 
 
-# Collections also get some nice additional operators
+# 컬렉션에는 몇 가지 멋진 추가 연산자도 있습니다.
 [1, 2] ++ [3, 4]                # => [1, 2, 3, 4]
 'a' in <[ a b c ]>              # => true
 'name' of { name: 'Chris' }     # => true
 
 
 ########################################################################
-## 3. Functions
+## 3. 함수
 ########################################################################
 
-# Since LiveScript is functional, you'd expect functions to get a nice
-# treatment. In LiveScript it's even more apparent that functions are
-# first class:
+# LiveScript는 함수형이므로 함수가 멋지게 처리될 것으로 기대할 수 있습니다.
+# LiveScript에서는 함수가 일급이라는 것이 더욱 분명합니다:
 add = (left, right) -> left + right
 add 1, 2        # => 3
 
-# Functions which take no arguments are called with a bang!
+# 인수가 없는 함수는 느낌표로 호출됩니다!
 two = -> 2
 two!
 
-# LiveScript uses function scope, just like JavaScript, and has proper
-# closures too. Unlike JavaScript, the `=` works as a declaration
-# operator, and will always declare the variable on the left hand side.
+# LiveScript는 자바스크립트와 마찬가지로 함수 범위를 사용하며 적절한
+# 클로저도 있습니다. 자바스크립트와 달리 `=`는 선언 연산자로
+# 작동하며 항상 왼쪽 변수를 선언합니다.
 
-# The `:=` operator is available to *reuse* a name from the parent
-# scope.
+# `:=` 연산자는 부모 범위의 이름을 *재사용*하는 데 사용할 수 있습니다.
 
 
-# You can destructure arguments of a function to quickly get to
-# interesting values inside a complex data structure:
+# 복잡한 데이터 구조 내의 흥미로운 값에 빠르게 접근하기 위해
+# 함수의 인수를 분해할 수 있습니다:
 tail = ([head, ...rest]) -> rest
 tail [1, 2, 3]  # => [2, 3]
 
-# You can also transform the arguments using binary or unary
-# operators. Default arguments are also possible.
+# 이항 또는 단항 연산자를 사용하여 인수를 변환할 수도 있습니다.
+# 기본 인수도 가능합니다.
 foo = (a = 1, b = 2) -> a + b
 foo!    # => 3
 
-# You could use it to clone a particular argument to avoid side-effects,
-# for example:
+# 예를 들어 부작용을 피하기 위해 특정 인수를 복제하는 데 사용할 수 있습니다:
 copy = (^^target, source) ->
   for k,v of source => target[k] = v
   target
@@ -199,107 +184,100 @@ copy a, { b: 2 }        # => { a: 1, b: 2 }
 a                       # => { a: 1 }
 
 
-# A function may be curried by using a long arrow rather than a short
-# one:
+# 짧은 화살표 대신 긴 화살표를 사용하여 함수를 커링할 수 있습니다:
 add = (left, right) --> left + right
 add1 = add 1
 add1 2          # => 3
 
-# Functions get an implicit `it` argument, even if you don't declare
-# any.
+# 함수는 선언하지 않아도 암시적인 `it` 인수를 갖습니다.
 identity = -> it
 identity 1      # => 1
 
-# Operators are not functions in LiveScript, but you can easily turn
-# them into one! Enter the operator sectioning:
+# 연산자는 LiveScript에서 함수가 아니지만 쉽게 함수로 바꿀 수 있습니다!
+# 연산자 섹셔닝을 입력하십시오:
 divide-by-two = (/ 2)
 [2, 4, 8, 16].map(divide-by-two) .reduce (+)
 
 
-# Not only of function application lives LiveScript, as in any good
-# functional language you get facilities for composing them:
+# LiveScript는 함수 적용뿐만 아니라, 좋은 함수형 언어에서처럼
+# 함수를 합성하는 기능을 제공합니다:
 double-minus-one = (- 1) . (* 2)
 
-# Other than the usual `f . g` mathematical formulae, you get the `>>`
-# and `<<` operators, that describe how the flow of values through the
-# functions.
+# 일반적인 `f . g` 수학 공식 외에도 `>>` 및 `<<` 연산자를 사용하여
+# 함수를 통한 값의 흐름을 설명할 수 있습니다.
 double-minus-one = (* 2) >> (- 1)
 double-minus-one = (- 1) << (* 2)
 
 
-# And talking about flow of value, LiveScript gets the `|>` and `<|`
-# operators that apply a value to a function:
+# 값의 흐름에 대해 말하자면, LiveScript는 값을 함수에 적용하는
+# `|>` 및 `<|` 연산자를 사용합니다:
 map = (f, xs) --> xs.map f
 [1 2 3] |> map (* 2)            # => [2 4 6]
 
-# You can also choose where you want the value to be placed, just mark
-# the place with an underscore (_):
+# 밑줄(_)로 위치를 표시하여 값을 배치할 위치를 선택할 수도 있습니다:
 reduce = (f, xs, initial) --> xs.reduce f, initial
 [1 2 3] |> reduce (+), _, 0     # => 6
 
 
-# The underscore is also used in regular partial application, which you
-# can use for any function:
+# 밑줄은 일반 부분 적용에도 사용되며, 모든 함수에 사용할 수 있습니다:
 div = (left, right) -> left / right
 div-by-two = div _, 2
 div-by-two 4      # => 2
 
 
-# Last, but not least, LiveScript has back-calls, which might help
-# with some callback-based code (though you should try more functional
-# approaches, like Promises):
+# 마지막으로, LiveScript에는 백-콜(back-calls)이 있어 일부 콜백 기반 코드에
+# 도움이 될 수 있습니다(그러나 Promises와 같은 더 기능적인 접근 방식을
+# 시도해야 합니다):
 readFile = (name, f) -> f name
 a <- readFile 'foo'
 b <- readFile 'bar'
 console.log a + b
 
-# Same as:
+# 다음과 동일:
 readFile 'foo', (a) -> readFile 'bar', (b) -> console.log a + b
 
 
 ########################################################################
-## 4. Patterns, guards and control-flow
+## 4. 패턴, 가드 및 제어 흐름
 ########################################################################
 
-# You can branch computations with the `if...else` expression:
+# `if...else` 표현식으로 계산을 분기할 수 있습니다:
 x = if n > 0 then \positive else \negative
 
-# Instead of `then`, you can use `=>`
+# `then` 대신 `=>`를 사용할 수 있습니다.
 x = if n > 0 => \positive
     else        \negative
 
-# Complex conditions are better-off expressed with the `switch`
-# expression, though:
+# 복잡한 조건은 `switch` 표현식으로 더 잘 표현됩니다:
 y = {}
 x = switch
   | (typeof y) is \number => \number
   | (typeof y) is \string => \string
   | 'length' of y         => \array
-  | otherwise             => \object      # `otherwise` and `_` always matches.
+  | otherwise             => \object      # `otherwise`와 `_`는 항상 일치합니다.
 
-# Function bodies, declarations and assignments get a free `switch`, so
-# you don't need to type it again:
+# 함수 본문, 선언 및 할당은 무료 `switch`를 얻으므로
+# 다시 입력할 필요가 없습니다:
 take = (n, [x, ...xs]) -->
                         | n == 0 => []
                         | _      => [x] ++ take (n - 1), xs
 
 
 ########################################################################
-## 5. Comprehensions
+## 5. 컴프리헨션
 ########################################################################
 
-# While the functional helpers for dealing with lists and objects are
-# right there in the JavaScript's standard library (and complemented on
-# the prelude-ls, which is a "standard library" for LiveScript),
-# comprehensions will usually allow you to do this stuff faster and with
-# a nice syntax:
+# 목록 및 객체를 다루기 위한 함수형 도우미는 자바스크립트의 표준 라이브러리에
+# 바로 있으며(그리고 LiveScript의 "표준 라이브러리"인 prelude-ls에서 보완됨),
+# 컴프리헨션을 사용하면 일반적으로 이러한 작업을 더 빠르고 멋진 구문으로
+# 수행할 수 있습니다:
 oneToTwenty = [1 to 20]
 evens       = [x for x in oneToTwenty when x % 2 == 0]
 
-# `when` and `unless` can be used as filters in the comprehension.
+# `when`과 `unless`는 컴프리헨션에서 필터로 사용할 수 있습니다.
 
-# Object comprehension works in the same way, except that it gives you
-# back an object rather than an Array:
+# 객체 컴프리헨션은 배열 대신 객체를 반환한다는 점을 제외하고는
+# 동일한 방식으로 작동합니다:
 copy = { [k, v] for k, v of source }
 
 
@@ -307,9 +285,9 @@ copy = { [k, v] for k, v of source }
 ## 4. OOP
 ########################################################################
 
-# While LiveScript is a functional language in most aspects, it also has
-# some niceties for imperative and object oriented programming. One of
-# them is class syntax and some class sugar inherited from CoffeeScript:
+# LiveScript는 대부분의 측면에서 함수형 언어이지만, 명령형 및
+# 객체 지향 프로그래밍을 위한 몇 가지 좋은 기능도 있습니다. 그 중 하나는
+# CoffeeScript에서 상속받은 클래스 구문과 클래스 슈가입니다:
 class Animal
   (@name, kind) ->
     @kind = kind
@@ -322,9 +300,8 @@ class Cat extends Animal
 kitten = new Cat 'Mei'
 kitten.purr!      # => "*Mei (a cat) purrs*"
 
-# Besides the classical single-inheritance pattern, you can also provide
-# as many mixins as you would like for a class. Mixins are just plain
-# objects:
+# 고전적인 단일 상속 패턴 외에도 클래스에 원하는 만큼 많은
+# 믹스인을 제공할 수 있습니다. 믹스인은 일반 객체일 뿐입니다:
 Huggable =
   hug: -> @action 'is hugged'
 
@@ -334,13 +311,12 @@ kitten = new SnugglyCat 'Purr'
 kitten.hug!     # => "*Mei (a cat) is hugged*"
 ```
 
-## Further reading
+## 더 읽을거리
 
-There's just so much more to LiveScript, but this should be enough to
-get you started writing little functional things in it. The
-[official website](http://livescript.net/) has a lot of information on the
-language, and a nice online compiler for you to try stuff out!
+LiveScript에 대해 더 많은 것이 있지만, 이것으로 작은 기능적인 것들을
+작성하기 시작하기에 충분할 것입니다.
+[공식 웹사이트](http://livescript.net/)에는 언어에 대한 많은 정보와
+시도해 볼 수 있는 멋진 온라인 컴파일러가 있습니다!
 
-You may also want to grab yourself some
-[prelude.ls](http://gkz.github.io/prelude-ls/), and check out the `#livescript`
-channel on the Freenode network.
+[prelude.ls](http://gkz.github.io/prelude-ls/)를 사용해보고, Freenode
+네트워크의 `#livescript` 채널을 확인해 볼 수도 있습니다.

--- a/ko/logtalk.md
+++ b/ko/logtalk.md
@@ -1,5 +1,3 @@
-# logtalk.md (번역)
-
 ---
 name: Logtalk
 filename: learnlogtalk.lgt
@@ -7,29 +5,29 @@ contributors:
     - ["Paulo Moura", "http://github.com/pmoura"]
 ---
 
-Logtalk is an object-oriented logic programming language that extends and leverages Prolog with modern code encapsulation and code reuse mechanisms without compromising its declarative programming features. Logtalk is implemented in highly portable code and can use most modern and standards compliant Prolog implementations as a back-end compiler.
+Logtalk는 선언적 프로그래밍 기능을 손상시키지 않으면서 최신 코드 캡슐화 및 코드 재사용 메커니즘으로 Prolog를 확장하고 활용하는 객체 지향 논리 프로그래밍 언어입니다. Logtalk는 이식성이 뛰어난 코드로 구현되었으며 대부분의 최신 표준 준수 Prolog 구현을 백엔드 컴파일러로 사용할 수 있습니다.
 
-To keep its size reasonable, this tutorial necessarily assumes that the reader have a working knowledge of Prolog and is biased towards describing Logtalk object-oriented features.
+이 튜토리얼은 적절한 크기를 유지하기 위해 독자가 Prolog에 대한 실무 지식을 가지고 있으며 Logtalk 객체 지향 기능을 설명하는 데 편향되어 있다고 가정합니다.
 
-# Syntax
+# 구문
 
-Logtalk uses standard Prolog syntax with the addition of a few operators and directives for a smooth learning curve and wide portability. One important consequence is that Prolog code can be easily encapsulated in objects with little or no changes. Moreover, Logtalk can transparently interpret most Prolog modules as Logtalk objects.
+Logtalk는 원활한 학습 곡선과 넓은 이식성을 위해 몇 가지 연산자와 지시어를 추가한 표준 Prolog 구문을 사용합니다. 한 가지 중요한 결과는 Prolog 코드를 거의 또는 전혀 변경하지 않고 객체에 쉽게 캡슐화할 수 있다는 것입니다. 또한 Logtalk는 대부분의 Prolog 모듈을 Logtalk 객체로 투명하게 해석할 수 있습니다.
 
-The main operators are:
+주요 연산자는 다음과 같습니다:
 
-* `::/2` - sending a message to an object
-* `::/1` - sending a message to _self_ (i.e. to the object that received the message being processed)
-* `^^/1` - _super_ call (of an inherited or imported predicate)
+* `::/2` - 객체에 메시지 보내기
+* `::/1` - _self_에 메시지 보내기 (즉, 처리 중인 메시지를 받은 객체에)
+* `^^/1` - _super_ 호출 (상속되거나 가져온 술어의)
 
-Some of the most important entity and predicate directives will be introduced in the next sections.
+가장 중요한 엔티티 및 술어 지시어 중 일부는 다음 섹션에서 소개됩니다.
 
-# Entities and roles
+# 엔티티와 역할
 
-Logtalk provides _objects_, _protocols_, and _categories_ as first-class entities. Relations between entities define _patterns of code reuse_ and the _roles_ played by the entities. For example, when an object _instantiates_ another object, the first object plays the role of an instance and the second object plays the role of a class. An _extends_ relation between two objects implies that both objects play the role of prototypes, with one of them extending the other, its parent prototype.
+Logtalk는 _객체_, _프로토콜_, _카테고리_를 일급 엔티티로 제공합니다. 엔티티 간의 관계는 _코드 재사용 패턴_과 엔티티가 수행하는 _역할_을 정의합니다. 예를 들어, 한 객체가 다른 객체를 _인스턴스화_할 때 첫 번째 객체는 인스턴스 역할을 하고 두 번째 객체는 클래스 역할을 합니다. 두 객체 간의 _확장_ 관계는 두 객체 모두 프로토타입 역할을 하며, 그중 하나가 다른 하나, 즉 부모 프로토타입을 확장함을 의미합니다.
 
-# Defining an object
+# 객체 정의하기
 
-An object encapsulates predicate declarations and definitions. Objects can be created dynamically but are usually static and defined in source files. A single source file can contain any number of entity definitions. A simple object, defining a list member public predicate:
+객체는 술어 선언과 정의를 캡슐화합니다. 객체는 동적으로 생성될 수 있지만 일반적으로 정적이며 소스 파일에 정의됩니다. 단일 소스 파일에는 여러 엔티티 정의가 포함될 수 있습니다. 리스트 멤버 공개 술어를 정의하는 간단한 객체:
 
 ```logtalk
 :- object(list).
@@ -42,23 +40,20 @@ An object encapsulates predicate declarations and definitions. Objects can be cr
 :- end_object.
 ```
 
-# Compiling and loading source files
+# 소스 파일 컴파일 및 로드
 
-Assuming that the code above for the `list` object is saved in a `list.lgt` file, it can be compiled and loaded using the `logtalk_load/1` built-in predicate or its abbreviation, `{}/1`, with the file path as argument (the extension can be omitted):
+위의 `list` 객체 코드가 `list.lgt` 파일에 저장되어 있다고 가정하면, `logtalk_load/1` 내장 술어 또는 그 약어인 `{}/1`을 사용하여 파일 경로를 인수로 전달하여 컴파일하고 로드할 수 있습니다(확장자는 생략 가능).
 
 ```logtalk
 ?- {list}.
 yes
 ```
 
-In general, entities may have dependencies on entities defined in other source files (e.g. library entities). To load a file and all its dependencies, the advised solution is to define a
-_loader_ file that loads all the necessary files for an application. A loader file is simply a source file, typically named `loader.lgt`, that makes calls to the `logtalk_load/1-2`
-built-in predicates, usually from an `initialization/1` directive for portability and
-standards compliance. Loader files are provided for all libraries, tools, and examples.
+일반적으로 엔티티는 다른 소스 파일(예: 라이브러리 엔티티)에 정의된 엔티티에 대한 종속성을 가질 수 있습니다. 파일과 모든 종속성을 로드하려면, 애플리케이션에 필요한 모든 파일을 로드하는 _로더_ 파일을 정의하는 것이 좋습니다. 로더 파일은 일반적으로 `loader.lgt`라는 이름의 소스 파일이며, 이식성 및 표준 준수를 위해 일반적으로 `initialization/1` 지시어에서 `logtalk_load/1-2` 내장 술어를 호출합니다. 로더 파일은 모든 라이브러리, 도구 및 예제에 제공됩니다.
 
-# Sending a message to an object
+# 객체에 메시지 보내기
 
-The `::/2` infix operator is used to send a message to an object. As in Prolog, we can backtrack for alternative solutions:
+`::/2` 중위 연산자는 객체에 메시지를 보내는 데 사용됩니다. Prolog에서와 같이 대체 솔루션을 위해 백트랙할 수 있습니다:
 
 ```logtalk
 ?- list::member(X, [1,2,3]).
@@ -68,7 +63,7 @@ X = 3
 yes
 ```
 
-Encapsulation is enforced. A predicate can be declared _public_, _protected_, or _private_. It can also be _local_ when there is no scope directive for it. For example:
+캡슐화가 적용됩니다. 술어는 _public_, _protected_ 또는 _private_으로 선언될 수 있습니다. 범위 지시어가 없는 경우 _local_일 수도 있습니다. 예:
 
 ```logtalk
 :- object(scopes).
@@ -81,7 +76,7 @@ Encapsulation is enforced. A predicate can be declared _public_, _protected_, or
 :- end_object.
 ```
 
-Assuming the object is saved in a `scopes.lgt` file:
+객체가 `scopes.lgt` 파일에 저장되어 있다고 가정합니다:
 
 ```logtalk
 ?- {scopes}.
@@ -102,7 +97,7 @@ Error = error(
 yes
 ```
 
-When the predicate in a message is unknown for the object (the role it plays determines the lookup procedures), we also get an error. For example:
+메시지의 술어가 객체에 대해 알려지지 않은 경우(객체가 수행하는 역할이 조회 절차를 결정함)에도 오류가 발생합니다. 예:
 
 ```logtalk
 ?- catch(scopes::unknown, Error, true).
@@ -113,11 +108,11 @@ Error = error(
 yes
 ```
 
-A subtle point is that predicate scope directives specify predicate _calling_ semantics, not _definition_ semantics. For example, if an object playing the role of a class declares a predicate private, the predicate can be defined in subclasses and instances *but* can only be called in its instances _from_ the class.
+미묘한 점은 술어 범위 지시어는 술어 _호출_ 의미를 지정하며 _정의_ 의미가 아니라는 것입니다. 예를 들어, 클래스 역할을 하는 객체가 술어를 private으로 선언하면, 해당 술어는 서브클래스와 인스턴스에서 정의될 수 있지만, 해당 인스턴스에서는 클래스 _에서만_ 호출할 수 있습니다.
 
-# Defining and implementing a protocol
+# 프로토콜 정의 및 구현
 
-Protocols contain predicate declarations that can be implemented by any number of objects and categories:
+프로토콜에는 여러 객체 및 카테고리에서 구현할 수 있는 술어 선언이 포함됩니다:
 
 ```logtalk
 :- protocol(listp).
@@ -136,7 +131,7 @@ Protocols contain predicate declarations that can be implemented by any number o
 :- end_object.
 ```
 
-The scope of the protocol predicates can be restricted using protected or private implementation. For example:
+프로토콜 술어의 범위는 protected 또는 private 구현을 사용하여 제한할 수 있습니다. 예:
 
 ```logtalk
 :- object(stack,
@@ -145,14 +140,14 @@ The scope of the protocol predicates can be restricted using protected or privat
 :- end_object.
 ```
 
-In fact, all entity relations (in an entity opening directive) can be qualified as public (the default), protected, or private.
+실제로 모든 엔티티 관계(엔티티 열기 지시어에서)는 public(기본값), protected 또는 private으로 한정될 수 있습니다.
 
-# Prototypes
+# 프로토타입
 
-An object without an _instantiation_ or _specialization_ relation with another object plays the role of a prototype. A prototype can _extend_ another object, its parent prototype.
+다른 객체와 _인스턴스화_ 또는 _특수화_ 관계가 없는 객체는 프로토타입 역할을 합니다. 프로토타입은 다른 객체, 즉 부모 프로토타입을 _확장_할 수 있습니다.
 
 ```logtalk
-% clyde, our prototypical elephant
+% 우리의 프로토타입 코끼리, clyde
 :- object(clyde).
 
 	:- public(color/1).
@@ -163,7 +158,7 @@ An object without an _instantiation_ or _specialization_ relation with another o
 
 :- end_object.
 
-% fred, another elephant, is like clyde, except that he's white
+% 또 다른 코끼리 fred는 clyde와 같지만 흰색입니다.
 :- object(fred,
 	extends(clyde)).
 
@@ -172,7 +167,7 @@ An object without an _instantiation_ or _specialization_ relation with another o
 :- end_object.
 ```
 
-When answering a message sent to an object playing the role of a prototype, we validate the message and look for an answer first in the prototype itself and, if not found, we delegate to the prototype parents if any:
+프로토타입 역할을 하는 객체로 전송된 메시지에 응답할 때, 우리는 메시지를 확인하고 먼저 프로토타입 자체에서 답을 찾고, 찾지 못하면 부모 프로토타입에 위임합니다:
 
 ```logtalk
 ?- fred::number_of_legs(N).
@@ -184,7 +179,7 @@ C = white
 yes
 ```
 
-A message is valid if the corresponding predicate is declared (and the sender is within scope) but it will fail, rather then throwing an error, if the predicate is not defined. This is called the _closed-world assumption_. For example, consider the following object, saved in a `foo.lgt` file:
+해당 술어가 선언되고(송신자가 범위 내에 있는 경우) 메시지가 유효하지만, 술어가 정의되지 않은 경우 오류를 발생시키는 대신 실패합니다. 이것을 _폐쇄 세계 가정_이라고 합니다. 예를 들어, `foo.lgt` 파일에 저장된 다음 객체를 고려하십시오:
 
 ```logtalk
 :- object(foo).
@@ -194,7 +189,7 @@ A message is valid if the corresponding predicate is declared (and the sender is
 :- end_object.
 ```
 
-Loading the file and trying to call the `bar/0` predicate fails as expected. Note that this is different from calling an _unknown_ predicate, which results in an error:
+파일을 로드하고 `bar/0` 술어를 호출하려고 하면 예상대로 실패합니다. 이것은 _알려지지 않은_ 술어를 호출하는 것과는 다르며, 오류가 발생합니다:
 
 ```logtalk
 ?- {foo}.
@@ -211,12 +206,12 @@ Error = error(
 yes
 ```
 
-# Classes and instances
+# 클래스와 인스턴스
 
-In order to define objects playing the role of classes and/or instances, an object must have at least an instantiation or a specialization relation with another object. Objects playing the role of meta-classes can be used when we need to see a class also as an instance. We use the following example to also illustrate how to dynamically create new objects at runtime:
+클래스 및/또는 인스턴스 역할을 하는 객체를 정의하려면, 객체는 다른 객체와 최소한 하나의 인스턴스화 또는 특수화 관계를 가져야 합니다. 클래스를 인스턴스로도 봐야 할 때 메타클래스 역할을 하는 객체를 사용할 수 있습니다. 다음 예제를 사용하여 런타임에 새 객체를 동적으로 생성하는 방법을 설명합니다:
 
 ```logtalk
-% a simple, generic, metaclass defining a new/2 predicate for its instances
+% 인스턴스에 대한 new/2 술어를 정의하는 간단하고 일반적인 메타클래스
 :- object(metaclass,
 	instantiates(metaclass)).
 
@@ -227,7 +222,7 @@ In order to define objects playing the role of classes and/or instances, an obje
 
 :- end_object.
 
-% a simple class defining age/1 and name/1 predicate for its instances
+% 인스턴스에 대한 age/1 및 name/1 술어를 정의하는 간단한 클래스
 :- object(person,
 	instantiates(metaclass)).
 
@@ -235,12 +230,12 @@ In order to define objects playing the role of classes and/or instances, an obje
 		age/1, name/1
 	]).
 
-	% a default value for age/1
+	% age/1의 기본값
 	age(42).
 
 :- end_object.
 
-% a static instance of the class person
+% person 클래스의 정적 인스턴스
 :- object(john,
 	instantiates(person)).
 
@@ -250,7 +245,7 @@ In order to define objects playing the role of classes and/or instances, an obje
 :- end_object.
 ```
 
-When answering a message sent to an object playing the role of an instance, we validate the message by starting in its class and going up to its class superclasses if necessary. Assuming that the message is valid, then we look for an answer starting in the instance itself:
+인스턴스 역할을 하는 객체로 전송된 메시지에 응답할 때, 클래스에서 시작하여 필요한 경우 클래스 슈퍼클래스까지 올라가서 메시지를 확인합니다. 메시지가 유효하다고 가정하면, 인스턴스 자체에서 시작하여 답을 찾습니다:
 
 ```logtalk
 ?- person::new(Instance, [name(paulo)]).
@@ -270,12 +265,12 @@ Age = 12
 yes
 ```
 
-# Categories
+# 카테고리
 
-A category is a fine grained unit of code reuse, used to encapsulate a _cohesive_ set of predicate declarations and definitions, implementing a _single_ functionality, that can be imported into any object. A category can thus be seen as the dual concept of a protocol. In the following example, we define categories representing car engines and then import them into car objects:
+카테고리는 모든 객체로 가져올 수 있는 _단일_ 기능을 구현하는 _응집력 있는_ 술어 선언 및 정의 집합을 캡슐화하는 데 사용되는 세분화된 코드 재사용 단위입니다. 따라서 카테고리는 프로토콜의 이중 개념으로 볼 수 있습니다. 다음 예에서는 자동차 엔진을 나타내는 카테고리를 정의한 다음 자동차 객체로 가져옵니다:
 
 ```logtalk
-% a protocol describing engine characteristics
+% 엔진 특성을 설명하는 프로토콜
 :- protocol(carenginep).
 
 	:- public([
@@ -289,7 +284,7 @@ A category is a fine grained unit of code reuse, used to encapsulate a _cohesive
 
 :- end_protocol.
 
-% a typical engine defined as a category
+% 카테고리로 정의된 일반적인 엔진
 :- category(classic,
 	implements(carenginep)).
 
@@ -302,19 +297,19 @@ A category is a fine grained unit of code reuse, used to encapsulate a _cohesive
 
 :- end_category.
 
-% a souped up version of the previous engine
+% 이전 엔진의 개조 버전
 :- category(sport,
 	extends(classic)).
 
 	reference('M180.941').
 	horsepower_rpm(HP, RPM) :-
-		^^horsepower_rpm(ClassicHP, ClassicRPM),	% "super" call
+		^^horsepower_rpm(ClassicHP, ClassicRPM),	% "super" 호출
 		HP is truncate(ClassicHP*1.23),
 		RPM is truncate(ClassicRPM*0.762).
 
 :- end_category.
 
-% with engines (and other components), we may start "assembling" some cars
+% 엔진(및 기타 구성 요소)으로 일부 자동차 "조립"을 시작할 수 있습니다.
 :- object(sedan,
 	imports(classic)).
 
@@ -326,7 +321,7 @@ A category is a fine grained unit of code reuse, used to encapsulate a _cohesive
 :- end_object.
 ```
 
-Categories are independently compiled and thus allow importing objects to be updated by simple updating the imported categories without requiring object recompilation. Categories also provide _runtime transparency_. I.e. the category protocol adds to the protocol of the objects importing the category:
+카테고리는 독립적으로 컴파일되므로 객체 재컴파일 없이 가져온 카테고리를 간단히 업데이트하여 가져오는 객체를 업데이트할 수 있습니다. 카테고리는 또한 _런타임 투명성_을 제공합니다. 즉, 카테고리 프로토콜은 카테고리를 가져오는 객체의 프로토콜에 추가됩니다:
 
 ```logtalk
 ?- sedan::current_predicate(Predicate).
@@ -339,9 +334,9 @@ Predicate = fuel/1
 yes
 ```
 
-# Hot patching
+# 핫 패치
 
-Categories can be also be used for hot-patching objects. A category can add new predicates to an object and/or replace object predicate definitions. For example, consider the following object:
+카테고리는 객체를 핫 패치하는 데에도 사용할 수 있습니다. 카테고리는 객체에 새 술어를 추가하거나 객체 술어 정의를 대체할 수 있습니다. 예를 들어, 다음 객체를 고려하십시오:
 
 ```logtalk
 :- object(buggy).
@@ -352,7 +347,7 @@ Categories can be also be used for hot-patching objects. A category can add new 
 :- end_object.
 ```
 
-Assume that the object prints the wrong string when sent the message `p/0`:
+객체가 `p/0` 메시지를 받았을 때 잘못된 문자열을 인쇄한다고 가정합니다:
 
 ```logtalk
 ?- {buggy}.
@@ -363,19 +358,19 @@ foo
 yes
 ```
 
-If the object source code is not available and we need to fix an application running the object code, we can simply define a category that fixes the buggy predicate:
+객체 소스 코드를 사용할 수 없고 객체 코드를 실행하는 애플리케이션을 수정해야 하는 경우, 버그가 있는 술어를 수정하는 카테고리를 간단히 정의할 수 있습니다:
 
 ```logtalk
 :- category(patch,
 	complements(buggy)).
 
-	% fixed p/0 def
+	% 수정된 p/0 정의
 	p :- write(bar).
 
 :- end_category.
 ```
 
-After compiling and loading the category into the running application we will now get:
+실행 중인 애플리케이션에 카테고리를 컴파일하고 로드한 후에는 다음을 얻게 됩니다:
 
 ```logtalk
 ?- set_logtalk_flag(complements, allow).
@@ -389,11 +384,11 @@ bar
 yes
 ```
 
-As hot-patching forcefully breaks encapsulation, the `complements` compiler flag can be set (globally or on a per-object basis) to allow, restrict, or prevent it.
+핫 패치는 캡슐화를 강제로 깨뜨리므로, `complements` 컴파일러 플래그를 (전역적으로 또는 객체별로) 설정하여 허용, 제한 또는 방지할 수 있습니다.
 
-# Parametric objects and categories
+# 매개변수 객체 및 카테고리
 
-Objects and categories can be parameterized by using as identifier a compound term instead of an atom. Object and category parameters are _logical variables_ shared with all encapsulated predicates. An example with geometric circles:
+객체 및 카테고리는 식별자로 원자 대신 복합 항을 사용하여 매개변수화할 수 있습니다. 객체 및 카테고리 매개변수는 모든 캡슐화된 술어와 공유되는 _논리 변수_입니다. 기하학적 원에 대한 예:
 
 ```logtalk
 :- object(circle(_Radius, _Color)).
@@ -413,7 +408,7 @@ Objects and categories can be parameterized by using as identifier a compound te
 :- end_object.
 ```
 
-Parametric objects are used just as any other object, usually providing values for the parameters when sending a message:
+매개변수 객체는 다른 객체와 마찬가지로 사용되며, 일반적으로 메시지를 보낼 때 매개변수 값을 제공합니다:
 
 ```logtalk
 ?- circle(1.23, blue)::area(Area).
@@ -421,7 +416,7 @@ Area = 4.75291
 yes
 ```
 
-Parametric objects also provide a simple way of associating a set of predicates with a plain Prolog predicate. Prolog facts can be interpreted as _parametric object proxies_ when they have the same functor and arity as the identifiers of parametric objects. Handy syntax is provided to for working with proxies. For example, assuming the following clauses for a `circle/2` predicate:
+매개변수 객체는 또한 술어 집합을 일반 Prolog 술어와 연결하는 간단한 방법을 제공합니다. Prolog 사실은 매개변수 객체의 식별자와 동일한 함자 및 인수를 가질 때 _매개변수 객체 프록시_로 해석될 수 있습니다. 프록시 작업을 위한 편리한 구문이 제공됩니다. 예를 들어, `circle/2` 술어에 대한 다음 절을 가정합니다:
 
 ```logtalk
 circle(1.23, blue).
@@ -431,7 +426,7 @@ circle(5.74, black).
 circle(8.32, cyan).
 ```
 
-With these clauses loaded, we can easily compute for example a list with the areas of all the circles:
+이러한 절이 로드되면, 모든 원의 면적 목록을 쉽게 계산할 수 있습니다:
 
 ```logtalk
 ?- findall(Area, {circle(_, _)}::area(Area), Areas).
@@ -439,15 +434,15 @@ Areas = [4.75291, 43.2412, 0.477836, 103.508, 217.468]
 yes
 ```
 
-The `{Goal}::Message` construct proves `Goal`, possibly instantiating any variables in it, and sends `Message` to the resulting term.
+`{Goal}::Message` 구문은 `Goal`을 증명하고(아마도 그 안의 변수를 인스턴스화함), 결과 항에 `Message`를 보냅니다.
 
-# Events and monitors
+# 이벤트와 모니터
 
-Logtalk supports _event-driven programming_ by allowing defining events and monitors for those events. An event is simply the sending of a message to an object. Interpreting message sending as an atomic activity, a _before_ event and an _after_ event are recognized. Event monitors define event handler predicates, `before/3` and `after/3`, and can query, register, and delete a system-wide event registry that associates events with monitors. For example, a simple tracer for any message being sent using the `::/2` control construct can be defined as:
+Logtalk는 이벤트와 해당 이벤트에 대한 모니터를 정의하여 _이벤트 기반 프로그래밍_을 지원합니다. 이벤트는 단순히 객체에 메시지를 보내는 것입니다. 메시지 보내기를 원자적 활동으로 해석하면 _before_ 이벤트와 _after_ 이벤트가 인식됩니다. 이벤트 모니터는 이벤트 핸들러 술어 `before/3` 및 `after/3`을 정의하고, 이벤트를 모니터와 연결하는 시스템 전체 이벤트 레지스트리를 쿼리, 등록 및 삭제할 수 있습니다. 예를 들어, `::/2` 제어 구문을 사용하여 전송되는 모든 메시지에 대한 간단한 추적기는 다음과 같이 정의할 수 있습니다:
 
 ```logtalk
 :- object(tracer,
-	implements(monitoring)).    % built-in protocol for event handlers
+	implements(monitoring)).    % 이벤트 핸들러를 위한 내장 프로토콜
 
 	:- initialization(define_events(_, _, _, _, tracer)).
 
@@ -462,7 +457,7 @@ Logtalk supports _event-driven programming_ by allowing defining events and moni
 :- end_object.
 ```
 
-Assuming that the `tracer` object and the `list` object defined earlier are compiled and loaded, we can observe the event handlers in action by sending a message:
+앞서 정의한 `tracer` 객체와 `list` 객체가 컴파일되고 로드되었다고 가정하면, 메시지를 보내 이벤트 핸들러의 동작을 관찰할 수 있습니다:
 
 ```logtalk
 ?- set_logtalk_flag(events, allow).
@@ -480,13 +475,13 @@ X = 3
 yes
 ```
 
-Events can be set and deleted dynamically at runtime by calling the `define_events/5` and `abolish_events/5` built-in predicates.
+`define_events/5` 및 `abolish_events/5` 내장 술어를 호출하여 런타임에 이벤트를 동적으로 설정하고 삭제할 수 있습니다.
 
-Event-driven programming can be seen as a form of _computational reflection_. But note that events are only generated when using the `::/2` message-sending control construct.
+이벤트 기반 프로그래밍은 _계산적 리플렉션_의 한 형태로 볼 수 있습니다. 그러나 이벤트는 `::/2` 메시지 전송 제어 구문을 사용할 때만 생성된다는 점에 유의하십시오.
 
-# Lambda expressions
+# 람다 표현식
 
-Logtalk supports lambda expressions. Lambda parameters are represented using a list with the `(>>)/2` infix operator connecting them to the lambda. Some simple examples using library `meta`:
+Logtalk는 람다 표현식을 지원합니다. 람다 매개변수는 `(>>)/2` 중위 연산자를 사용하여 람다에 연결된 목록을 사용하여 표현됩니다. 라이브러리 `meta`를 사용한 몇 가지 간단한 예:
 
 ```logtalk
 ?- {meta(loader)}.
@@ -497,7 +492,7 @@ Ys = [2,4,6]
 yes
 ```
 
-Currying is also supported:
+커링도 지원됩니다:
 
 ```logtalk
 ?- meta::map([X]>>([Y]>>(Y is 2*X)), [1,2,3], Ys).
@@ -505,11 +500,11 @@ Ys = [2,4,6]
 yes
 ```
 
-Lambda free variables can be expressed using the extended syntax `{Free1, ...}/[Parameter1, ...]>>Lambda`.
+람다 자유 변수는 확장된 구문 `{Free1, ...}/[Parameter1, ...]>>Lambda`를 사용하여 표현할 수 있습니다.
 
-# Macros
+# 매크로
 
-Terms and goals in source files can be _expanded_ at compile time by specifying a _hook object_ that defines term-expansion and goal-expansion rules. For example, consider the following simple object, saved in a `source.lgt` file:
+소스 파일의 항과 목표는 텀 확장 및 목표 확장 규칙을 정의하는 _후크 객체_를 지정하여 컴파일 타임에 _확장_될 수 있습니다. 예를 들어, `source.lgt` 파일에 저장된 다음 간단한 객체를 고려하십시오:
 
 ```logtalk
 :- object(source).
@@ -522,21 +517,21 @@ Terms and goals in source files can be _expanded_ at compile time by specifying 
 :- end_object.
 ```
 
-Assume the following hook object, saved in a `my_macros.lgt` file, that expands clauses and calls to the `foo/1` local predicate:
+`foo/1` 로컬 술어에 대한 절과 호출을 확장하는 `my_macros.lgt` 파일에 저장된 다음 후크 객체를 가정합니다:
 
 ```logtalk
 :- object(my_macros,
-	implements(expanding)).    % built-in protocol for expanding predicates
+	implements(expanding)).    % 술어 확장을 위한 내장 프로토콜
 
 	term_expansion(foo(Char), baz(Code)) :-
-		char_code(Char, Code). % standard built-in predicate
+		char_code(Char, Code). % 표준 내장 술어
 
 	goal_expansion(foo(X), baz(X)).
 
 :- end_object.
 ```
 
-After loading the macros file, we can then expand our source file with it using the `hook` compiler flag:
+매크로 파일을 로드한 후, `hook` 컴파일러 플래그를 사용하여 소스 파일을 확장할 수 있습니다:
 
 ```logtalk
 ?- logtalk_load(my_macros), logtalk_load(source, [hook(my_macros)]).
@@ -549,8 +544,8 @@ X = 99
 true
 ```
 
-The Logtalk library provides support for combining hook objects using different workflows (for example, defining a pipeline of expansions).
+Logtalk 라이브러리는 다른 워크플로를 사용하여 후크 객체를 결합하는 지원을 제공합니다(예: 확장 파이프라인 정의).
 
-# Further information
+# 추가 정보
 
-Visit the [Logtalk website](http://logtalk.org) for more information.
+자세한 내용은 [Logtalk 웹사이트](http://logtalk.org)를 방문하십시오.

--- a/ko/lolcode.md
+++ b/ko/lolcode.md
@@ -1,5 +1,3 @@
-# lolcode.md (번역)
-
 ---
 name: LOLCODE
 filename: learnLOLCODE.lol
@@ -7,55 +5,54 @@ contributors:
     - ["abactel", "https://github.com/abactel"]
 ---
 
-LOLCODE is an esoteric programming language designed to resemble the speech of [lolcats](https://upload.wikimedia.org/wikipedia/commons/a/ab/Lolcat_in_folder.jpg?1493656347257).
+LOLCODE는 [롤캣](https://upload.wikimedia.org/wikipedia/commons/a/ab/Lolcat_in_folder.jpg?1493656347257)의 말투를 닮도록 설계된 난해한 프로그래밍 언어입니다.
 
 ```
-BTW This is an inline comment
-BTW All code must begin with `HAI <language version>` and end with `KTHXBYE`
+BTW 이건 한 줄 주석임
+BTW 모든 코드는 `HAI <언어 버전>`으로 시작해서 `KTHXBYE`로 끝나야 함
 
 HAI 1.3
-CAN HAS STDIO? BTW Importing standard headers
+CAN HAS STDIO? BTW 표준 헤더 가져오는 중
 
 OBTW
      ==========================================================================
-     ================================= BASICS =================================
+     ================================= 기초 ===================================
      ==========================================================================
 TLDR
 
-BTW Displaying text:
+BTW 텍스트 표시하기:
 VISIBLE "HELLO WORLD"
 
-BTW Declaring variables:
+BTW 변수 선언하기:
 I HAS A MESSAGE ITZ "CATZ ARE GOOD"
 VISIBLE MESSAGE
 
 OBTW
-    (This is a codeblock.) Variables are dynamically typed so you don't need to
-    declare their type. A variable's type matches its content. These are the
-    types:
+    (이건 코드 블록임.) 변수는 동적 타입이라서 타입을 선언할 필요 없음.
+    변수 타입은 내용에 따라 정해짐. 타입 종류는 다음과 같음:
 TLDR
 
-I HAS A STRING  ITZ "DOGZ ARE GOOOD" BTW type is YARN
-I HAS A INTEGER ITZ 42               BTW type is NUMBR
-I HAS A FLOAT   ITZ 3.1415           BTW type is NUMBAR
-I HAS A BOOLEAN ITZ WIN              BTW type is TROOF
-I HAS A UNTYPED                      BTW type is NOOB
+I HAS A STRING  ITZ "DOGZ ARE GOOOD" BTW 타입은 YARN (실)
+I HAS A INTEGER ITZ 42               BTW 타입은 NUMBR (숫자)
+I HAS A FLOAT   ITZ 3.1415           BTW 타입은 NUMBAR (소수)
+I HAS A BOOLEAN ITZ WIN              BTW 타입은 TROOF (진실)
+I HAS A UNTYPED                      BTW 타입은 NOOB (뉴비)
 
-BTW Accepting user input:
+BTW 사용자 입력 받기:
 I HAS A AGE
 GIMMEH AGE
-BTW The variable is stored as a YARN. To convert it into NUMBR:
+BTW 변수는 YARN으로 저장됨. NUMBR로 바꾸려면:
 AGE IS NOW A NUMBR
 
 OBTW
      ==========================================================================
-     ================================== MATH ==================================
+     ================================== 수학 ==================================
      ==========================================================================
 TLDR
 
-BTW LOLCODE uses polish notation style math.
+BTW LOLCODE는 폴란드 표기법 스타일의 수학을 씀.
 
-BTW Basic mathematical notation:
+BTW 기본 수학 표기법:
 
 SUM OF 21 AN 33         BTW 21 + 33
 DIFF OF 90 AN 10        BTW 90 - 10
@@ -65,19 +62,19 @@ MOD OF 43 AN 64         BTW 43 modulo 64
 BIGGR OF 23 AN 53       BTW max(23, 53)
 SMALLR OF 53 AN 45      BTW min(53, 45)
 
-BTW Binary notation:
+BTW 2진 표기법:
 
-BOTH OF WIN AN WIN           BTW and: WIN if x=WIN, y=WIN
-EITHER OF FAIL AN WIN        BTW or: FAIL if x=FAIL, y=FAIL
-WON OF WIN AN FAIL           BTW xor: FAIL if x=y
-NOT FAIL                     BTW unary negation: WIN if x=FAIL
-ALL OF WIN AN WIN MKAY   BTW infinite arity AND
-ANY OF WIN AN FAIL MKAY  BTW infinite arity OR
+BOTH OF WIN AN WIN           BTW 그리고: x=WIN, y=WIN이면 WIN
+EITHER OF FAIL AN WIN        BTW 또는: x=FAIL, y=FAIL이면 FAIL
+WON OF WIN AN FAIL           BTW xor: x=y이면 FAIL
+NOT FAIL                     BTW 단항 부정: x=FAIL이면 WIN
+ALL OF WIN AN WIN MKAY   BTW 무한 인수 AND
+ANY OF WIN AN FAIL MKAY  BTW 무한 인수 OR
 
-BTW Comparison:
+BTW 비교:
 
-BOTH SAEM "CAT" AN "DOG"             BTW WIN if x == y
-DIFFRINT 732 AN 184                  BTW WIN if x != y
+BOTH SAEM "CAT" AN "DOG"             BTW x == y 이면 WIN
+DIFFRINT 732 AN 184                  BTW x != y 이면 WIN
 BOTH SAEM 12 AN BIGGR OF 12 AN 4     BTW x >= y
 BOTH SAEM 43 AN SMALLR OF 43 AN 56   BTW x <= y
 DIFFRINT 64 AN SMALLR OF 64 AN 2     BTW x > y
@@ -85,41 +82,41 @@ DIFFRINT 75 AN BIGGR OF 75 AN 643    BTW x < y
 
 OBTW
      ==========================================================================
-     ============================== FLOW CONTROL ==============================
+     ============================== 흐름 제어 ==============================
      ==========================================================================
 TLDR
 
-BTW If/then statement:
+BTW If/then 문:
 I HAS A ANIMAL
 GIMMEH ANIMAL
 BOTH SAEM ANIMAL AN "CAT", O RLY?
     YA RLY
-        VISIBLE "YOU HAV A CAT"
+        VISIBLE "고양이가 있군요"
     MEBBE BOTH SAEM ANIMAL AN "MAUS"
-        VISIBLE "NOM NOM NOM. I EATED IT."
+        VISIBLE "냠냠냠. 내가 먹었음."
     NO WAI
-        VISIBLE "AHHH IS A WOOF WOOF"
+        VISIBLE "으악 멍멍이다"
 OIC
 
-BTW Case statement:
+BTW Case 문:
 I HAS A COLOR
 GIMMEH COLOR
 COLOR, WTF?
     OMG "R"
-        VISIBLE "RED FISH"
+        VISIBLE "빨간 물고기"
         GTFO
     OMG "Y"
-        VISIBLE "YELLOW FISH"
-        BTW Since there is no `GTFO` the next statements will also be tested
+        VISIBLE "노란 물고기"
+        BTW `GTFO`가 없어서 다음 문장도 테스트될 거임
     OMG "G"
     OMG "B"
-        VISIBLE "FISH HAS A FLAVOR"
+        VISIBLE "물고기는 맛이 있음"
         GTFO
     OMGWTF
-        VISIBLE "FISH IS TRANSPARENT OHNO WAT"
+        VISIBLE "물고기가 투명해 오노 왓"
 OIC
 
-BTW For loop:
+BTW For 반복문:
 I HAS A TEMPERATURE
 GIMMEH TEMPERATURE
 TEMPERATURE IS NOW A NUMBR
@@ -127,61 +124,61 @@ IM IN YR LOOP UPPIN YR ITERATOR TIL BOTH SAEM ITERATOR AN TEMPERATURE
     VISIBLE ITERATOR
 IM OUTTA YR LOOP
 
-BTW While loop:
+BTW While 반복문:
 IM IN YR LOOP NERFIN YR ITERATOR WILE DIFFRINT ITERATOR AN -10
     VISIBLE ITERATOR
 IM OUTTA YR LOOP
 
 OBTW
      =========================================================================
-     ================================ Strings ================================
+     =============================== 문자열 ================================
      =========================================================================
 TLDR
 
-BTW Linebreaks:
-VISIBLE "FIRST LINE :) SECOND LINE"
+BTW 줄바꿈:
+VISIBLE "첫 번째 줄 :) 두 번째 줄"
 
-BTW Tabs:
-VISIBLE ":>SPACES ARE SUPERIOR"
+BTW 탭:
+VISIBLE ":>공백이 최고임"
 
-BTW Bell (goes beep):
-VISIBLE "NXT CUSTOMER PLS :o"
+BTW 벨 (삑 소리 남):
+VISIBLE "다음 손님 오세요 :o"
 
-BTW Literal double quote:
-VISIBLE "HE SAID :"I LIKE CAKE:""
+BTW 리터럴 큰따옴표:
+VISIBLE "그가 말했음 :"나는 케이크를 좋아해:""
 
-BTW Literal colon:
-VISIBLE "WHERE I LIVE:: CYBERSPACE"
+BTW 리터럴 콜론:
+VISIBLE "내가 사는 곳:: 사이버 공간"
 
 OBTW
      =========================================================================
-     =============================== FUNCTIONS ===============================
+     =============================== 함수 ===============================
      =========================================================================
 TLDR
 
-BTW Declaring a new function:
-HOW IZ I SELECTMOVE YR MOVE BTW `MOVE` is an argument
+BTW 새 함수 선언하기:
+HOW IZ I SELECTMOVE YR MOVE BTW `MOVE`는 인수임
     BOTH SAEM MOVE AN "ROCK", O RLY?
         YA RLY
-            VISIBLE "YOU HAV A ROCK"
+            VISIBLE "바위가 있군요"
         NO WAI
-            VISIBLE "OH NO IS A SNIP-SNIP"
+            VISIBLE "오노 가위-가위다"
     OIC
-    GTFO BTW This returns NOOB
+    GTFO BTW 이건 NOOB를 반환함
 IF U SAY SO
 
-BTW Declaring a function and returning a value:
+BTW 함수 선언하고 값 반환하기:
 HOW IZ I IZYELLOW
     FOUND YR "YELLOW"
 IF U SAY SO
 
-BTW Calling a function:
+BTW 함수 호출하기:
 I IZ IZYELLOW MKAY
 
 KTHXBYE
 ```
 
-## Further reading:
+## 더 읽을거리:
 
-- [LCI compiler](https://github.com/justinmeza/lci)
-- [Official spec](https://github.com/justinmeza/lolcode-spec/blob/master/v1.2/lolcode-spec-v1.2.md)
+- [LCI 컴파일러](https://github.com/justinmeza/lci)
+- [공식 사양](https://github.com/justinmeza/lolcode-spec/blob/master/v1.2/lolcode-spec-v1.2.md)

--- a/ko/m.md
+++ b/ko/m.md
@@ -1,5 +1,3 @@
-# m.md (번역)
-
 ---
 name: M (MUMPS)
 contributors:
@@ -7,111 +5,97 @@ contributors:
 filename: LEARNM.m
 ---
 
-M, or MUMPS (Massachusetts General Hospital Utility Multi-Programming System) is
-a procedural language with a built-in NoSQL database. Or, it’s a database with
-an integrated language optimized for accessing and manipulating that database.
-A key feature of M is that accessing local variables in memory and persistent
-storage use the same basic syntax, so there's no separate query
-language to remember. This makes it fast to program with, especially for
-beginners. M's syntax was designed to be concise in an era where
-computer memory was expensive and limited. This concise style means that a lot
-more fits on one screen without scrolling.
+M 또는 MUMPS(Massachusetts General Hospital Utility Multi-Programming System)는 내장 NoSQL 데이터베이스가 있는 절차적 언어입니다. 또는 데이터베이스에 접근하고 조작하는 데 최적화된 통합 언어가 있는 데이터베이스입니다. M의 주요 특징은 메모리의 지역 변수와 영구 저장소에 접근하는 데 동일한 기본 구문을 사용하므로 별도의 쿼리 언어를 기억할 필요가 없다는 것입니다. 이로 인해 특히 초보자에게 프로그래밍이 빠릅니다. M의 구문은 컴퓨터 메모리가 비싸고 제한적이었던 시대에 간결하게 설계되었습니다. 이 간결한 스타일은 스크롤 없이 한 화면에 더 많은 내용을 담을 수 있다는 것을 의미합니다.
 
-The M database is a hierarchical key-value store designed for high-throughput
-transaction processing. The database is organized into tree structures called
-"globals", (for global variables) which are sparse data structures with parallels
-to modern formats like JSON.
+M 데이터베이스는 높은 처리량의 트랜잭션 처리를 위해 설계된 계층적 키-값 저장소입니다. 데이터베이스는 "글로벌"(전역 변수용)이라는 트리 구조로 구성되며, 이는 JSON과 같은 최신 형식과 유사한 희소 데이터 구조입니다.
 
-Originally designed in 1966 for the healthcare applications, M continues to be
-used widely by healthcare systems and financial institutions for high-throughput
-real-time applications.
+원래 1966년 의료 애플리케이션을 위해 설계된 M은 의료 시스템 및 금융 기관에서 높은 처리량의 실시간 애플리케이션을 위해 계속 널리 사용되고 있습니다.
 
-### Example
+### 예제
 
-Here's an example M program using expanded syntax to calculate the Fibonacci series:
+다음은 확장된 구문을 사용하여 피보나치 수열을 계산하는 M 프로그램의 예입니다:
 
 ```
-fib ; compute the first few Fibonacci terms
+fib ; 첫 몇 개의 피보나치 항 계산
     new i,a,b,sum
-    set (a,b)=1 ; Initial conditions
+    set (a,b)=1 ; 초기 조건
     for i=1:1 do  quit:sum>1000
     . set sum=a+b
     . write !,sum
     . set a=b,b=sum
 ```
 
-### Comments
-Comments in M need at least one space before the comment marker of semicolon.
-Comments that start with at least two semicolons (;;) are guaranteed to be accessible
-within a running program.
+### 주석
+M의 주석은 세미콜론 주석 마커 앞에 최소 한 칸의 공백이 필요합니다.
+최소 두 개의 세미콜론(;;)으로 시작하는 주석은 실행 중인 프로그램 내에서 접근할 수 있음이 보장됩니다.
 
 ```
- ;   Comments start with a semicolon (;)
+ ;   주석은 세미콜론(;)으로 시작합니다.
 ```
 
-### Data Types
+### 데이터 타입
 
-M has one data type (String) and three interpretations of that string.:
+M에는 하나의 데이터 타입(문자열)과 해당 문자열에 대한 세 가지 해석이 있습니다.:
 
 ```
-;   Strings - Characters enclosed in double quotes.
-;       "" is the null string. Use "" within a string for "
-;       Examples: "hello", "Scrooge said, ""Bah, Humbug!"""
+;   문자열 - 큰따옴표로 묶인 문자.
+;       ""는 null 문자열입니다. 문자열 내에서 "를 사용하려면 ""를 사용하십시오.
+;       예: "hello", "Scrooge said, ""Bah, Humbug!"""
 ;
-;   Numbers - no commas, leading and trailing 0 removed.
-;       Scientific notation with 'E'.  (not 'e')
-;       Numbers with at least with IEEE 754 double-precision values (guaranteed 15 digits of precision)
-;       Examples: 20 (stored as 20) , 1e3 (stored as 1000), 0500.20 (stored as 500.2),
-;                 the US National Debt AT sometime on 12-OCT-2020 retrieved from http://www.usdebt.org is 27041423576201.15)
-;                     (required to be stored as at least 27041422576201.10 but most implementations store as 27041432576201.15)
+;   숫자 - 쉼표 없음, 앞뒤 0 제거.
+;       'E'를 사용한 과학적 표기법 ('e'가 아님).
+;       최소 IEEE 754 배정밀도 값을 가짐(15자리 정밀도 보장).
+;       예: 20 (20으로 저장됨), 1e3 (1000으로 저장됨), 0500.20 (500.2로 저장됨),
+;                 2020년 10월 12일 http://www.usdebt.org에서 검색한 미국 국가 부채는 27041423576201.15입니다)
+;                     (최소 27041422576201.10으로 저장되어야 하지만 대부분의 구현에서는 27041432576201.15로 저장합니다)
 ;
-;   Truthvalues - String interpreted as 0  is used for false and any string interpreted as non-zero (such as 1) for true.
+;   진리값 - 0으로 해석되는 문자열은 false로 사용되고, 0이 아닌 값(예: 1)으로 해석되는 모든 문자열은 true로 사용됩니다.
 ```
 
-### Commands
+### 명령어
 
-Commands are case insensitive, and have full form, and a shortened abbreviation, often the first letter. Commands have zero or more arguments,depending on the command. This page includes programs written in this terse syntax. M is whitespace-aware. Spaces are treated as a delimiter between commands and arguments. Each command is separated from its arguments by 1 space. Commands with zero arguments are followed by 2 spaces. (technically these are called argumentless commands)
+명령어는 대소문자를 구분하지 않으며, 전체 형식과 종종 첫 글자로 된 축약형이 있습니다. 명령어는 명령어에 따라 0개 이상의 인수를 가집니다. 이 페이지에는 이 간결한 구문으로 작성된 프로그램이 포함되어 있습니다. M은 공백을 인식합니다. 공백은 명령어와 인수 사이의 구분 기호로 처리됩니다. 각 명령어는 인수와 1개의 공백으로 구분됩니다. 인수가 없는 명령어 뒤에는 2개의 공백이 옵니다. (기술적으로 이것을 인수 없는 명령어라고 합니다)
 
-#### Common Commands from all National and International Standards of M
+#### 모든 국내 및 국제 M 표준의 공통 명령어
 
-#### Write (abbreviated as W)
+#### Write (W로 축약)
 
-Print data to the current device.
+현재 장치에 데이터 인쇄.
 
 ```
 WRITE !,"hello world"
 ```
 
-Output Formatting characters:
+출력 서식 문자:
 
- The ! character is syntax for a new line.
- The # character is syntax for a new page.
- The sequence of the ? character and then a numeric expression is syntax for output of spaces until the number'th colum is printed.
+ ! 문자는 새 줄에 대한 구문입니다.
+ # 문자는 새 페이지에 대한 구문입니다.
+ ? 문자와 숫자 표현식의 시퀀스는 해당 숫자 열이 인쇄될 때까지 공백을 출력하는 구문입니다.
 
-Multiple statements can be provided as additional arguments before the space separators to the next command:
+다음 명령어로 가기 전 공백 구분자 앞에 여러 문장을 추가 인수로 제공할 수 있습니다:
 
 ```
 w !,"foo bar"," ","baz"
 ```
 
-#### Read (abbreviated as R)
+#### Read (R로 축약)
 
-Retrieve input from the user
+사용자로부터 입력 검색
 
 ```
 READ var
-r !,"Wherefore art thou Romeo? ",why
+r !,"로미오, 왜 그대는 로미오인가요? ",why
 ```
 
-As with all M commands, multiple arguments can be passed to a read command. Constants like quoted strings, numbers, and formatting characters are output directly. Values for both global variables and local variables are retrieved from the user. The terminal waits for the user to enter the first variable before displaying the second prompt.
+모든 M 명령어와 마찬가지로 read 명령어에도 여러 인수를 전달할 수 있습니다. 따옴표로 묶인 문자열, 숫자, 서식 문자와 같은 상수는 직접 출력됩니다. 전역 변수와 지역 변수의 값은 모두 사용자로부터 검색됩니다. 터미널은 사용자가 첫 번째 변수를 입력할 때까지 기다렸다가 두 번째 프롬프트를 표시합니다.
 
 ```
-r !,"Better one, or two? ",lorem," Better two, or three? ",ipsum
+r !,"첫 번째가 낫나요, 두 번째가 낫나요? ",lorem," 두 번째가 낫나요, 세 번째가 낫나요? ",ipsum
 ```
 
-#### Set (abbreviated as S)
+#### Set (S로 축약)
 
-Assign a value to a variable
+변수에 값 할당
 
 ```
 SET name="Benjamin Franklin"
@@ -122,23 +106,23 @@ w !,centi,!,micro
 ;.00001
 ```
 
-#### Kill (abbreviated as K)
+#### Kill (K로 축약)
 
-Remove a variable from memory or remove a database entry from disk.
-A database node (global variable) is killed depending on the variable name being prefixed by the caret character (^).
-If it is not, then the local variable is removed from memory.
-If KILLed, automatic garbage collection occurs.
+메모리에서 변수를 제거하거나 디스크에서 데이터베이스 항목을 제거합니다.
+데이터베이스 노드(전역 변수)는 변수 이름 앞에 캐럿 문자(^)가 붙는지 여부에 따라 제거됩니다.
+그렇지 않으면 지역 변수가 메모리에서 제거됩니다.
+KILL되면 자동 가비지 수집이 발생합니다.
 
 ```
 KILL centi
 k micro
 ```
 
-### Globals and Arrays
+### 전역 변수와 배열
 
-In addition to local variables, M has persistent, shared variables that are the built-in database of M.  They are stored to disk and called _globals_. Global names must start with a __caret__ (__^__).
+지역 변수 외에도 M에는 M의 내장 데이터베이스인 영구 공유 변수가 있습니다. 이들은 디스크에 저장되며 _글로벌_이라고 합니다. 전역 이름은 반드시 __캐럿__(__^__)으로 시작해야 합니다.
 
-Any variable (local or global) can be an array with the assignment of a _subscript_. Arrays are sparse and do not have a predefined size. Only if data is stored will a value use memory. Arrays should be visualized like trees, where subscripts are branches and assigned values are leaves. Not all nodes in an array need to have a value.
+모든 변수(지역 또는 전역)는 _아래 첨자_를 할당하여 배열이 될 수 있습니다. 배열은 희소하며 미리 정의된 크기가 없습니다. 데이터가 저장된 경우에만 값이 메모리를 사용합니다. 배열은 아래 첨자가 분기이고 할당된 값이 잎인 트리처럼 시각화해야 합니다. 배열의 모든 노드에 값이 있어야 하는 것은 아닙니다.
 
 ```
 s ^cars=20
@@ -149,91 +133,91 @@ s ^cars("Tesla",2,"Doors")=5
 w !,^cars
 ; 20
 w !,^cars("Tesla")
-; null value - there's no value assigned to this node but it has children
+; null 값 - 이 노드에는 값이 할당되지 않았지만 자식이 있습니다.
 w !,^cars("Tesla",1,"Name")
 ; Model 3
 ```
 
-The index values of Arrays are automatically sorted in order. There is a catchphrase of "MUMPS means never having to say you are sorting". Take advantage of the built-in sorting by setting your value of interest as the last child subscript of an array rather than its value, and then storing an empty string for that node.
+배열의 인덱스 값은 자동으로 정렬됩니다. "MUMPS는 정렬한다고 말할 필요가 없다는 것을 의미한다"는 캐치프레이즈가 있습니다. 관심 있는 값을 값 대신 배열의 마지막 자식 아래 첨자로 설정한 다음 해당 노드에 빈 문자열을 저장하여 내장 정렬을 활용하십시오.
 
 ```
-; A log of temperatures by date and time
+; 날짜 및 시간별 온도 기록
 s ^TEMPS("11/12","0600",32)=""
 s ^TEMPS("11/12","1030",48)=""
 s ^TEMPS("11/12","1400",49)=""
 s ^TEMPS("11/12","1700",43)=""
 ```
 
-### Operators
+### 연산자
 
 ```
-; Assignment:       =
-; Unary:            +   Convert a string value into a numeric value.
-; Arthmetic:
-;                   +   addition
-;                   -   subtraction
-;                   *   multiplication
-;                   /   floating-point division
-;                   \   integer division
-;                   #   modulo
-;                   **  exponentiation
-; Logical:
+; 할당:       =
+; 단항:            +   문자열 값을 숫자 값으로 변환합니다.
+; 산술:
+;                   +   덧셈
+;                   -   뺄셈
+;                   *   곱셈
+;                   /   부동 소수점 나눗셈
+;                   \   정수 나눗셈
+;                   #   모듈로
+;                   **  거듭제곱
+; 논리:
 ;                   &   and
 ;                   !   or
 ;                   '   not
-; Comparison:
-;                   =   equal
-;                   '=  not equal
-;                   >   greater than
-;                   <   less than
-;                   '>  not greater / less than or equal to
-;                   '<  not less / greater than or equal to
-; String operators:
-;                   _   concatenate
-;                   [   contains ­          a contains b
-;                   ]]  sorts after  ­      a comes after b
-;                   '[  does not contain
-;                   ']] does not sort after
+; 비교:
+;                   =   같음
+;                   '=  같지 않음
+;                   >   보다 큼
+;                   <   보다 작음
+;                   '>  크지 않음 / 작거나 같음
+;                   '<  작지 않음 / 크거나 같음
+; 문자열 연산자:
+;                   _   연결
+;                   [   포함           a는 b를 포함
+;                   ]]  정렬 후         a는 b 뒤에 옴
+;                   '[  포함하지 않음
+;                   ']] 정렬 후가 아님
 ```
 
-#### Order of operations
+#### 연산 순서
 
-Operations in M are _strictly_ evaluated left to right. No operator has precedence over any other.
-For example, there is NO order of operations where multiply is evaluated before addition.
-To change this order, just use parentheses to group expressions to be evaluated first.
+M의 연산은 _엄격하게_ 왼쪽에서 오른쪽으로 평가됩니다. 다른 연산자보다 우선 순위가 높은 연산자는 없습니다.
+예를 들어, 덧셈보다 곱셈이 먼저 평가되는 연산 순서는 없습니다.
+이 순서를 변경하려면 괄호를 사용하여 먼저 평가할 표현식을 그룹화하면 됩니다.
 
 ```
 w 5+3*20
 ;160
-;You probably wanted 65
+;아마 65를 원했을 것입니다.
 write 5+(3*20)
 ```
 
-### Flow Control, Blocks, & Code Structure
+### 흐름 제어, 블록 및 코드 구조
 
-A single M file is called a _routine_. Within a given routine, you can break your code up into smaller chunks with _tags_. The tag starts in column 1 and the commands pertaining to that tag are indented.
+단일 M 파일을 _루틴_이라고 합니다. 주어진 루틴 내에서 코드를 _태그_를 사용하여 더 작은 덩어리로 나눌 수 있습니다. 태그는 1열에서 시작하고 해당 태그에 관련된 명령어는 들여쓰기됩니다.
 
-A tag can accept parameters and return a value, this is a function. A function is called with '$$':
+태그는 매개변수를 받고 값을 반환할 수 있으며, 이것이 함수입니다. 함수는 '$$'로 호출됩니다:
 
 ```
-; Execute the 'tag' function, which has two parameters, and write the result.
+; 'tag' 함수를 실행하고, 두 개의 매개변수를 가지며, 결과를 씁니다.
 w !,$$tag^routine(a,b)
 ```
 
-M has an execution stack. When all levels of the stack have returned, the program ends. Levels are added to the stack with _do_ commands and removed with _quit_ commands.
+M에는 실행 스택이 있습니다. 스택의 모든 수준이 반환되면 프로그램이 종료됩니다. 수준은 _do_ 명령어로 스택에 추가되고 _quit_ 명령어로 제거됩니다.
 
-#### Do (abbreviated as D)
+#### Do (D로 축약)
 
-With an argument: execute a block of code & add a level to the stack.
+인수 사용: 코드 블록을 실행하고 스택에 수준을 추가합니다.
 
 ```
-d ^routine    ;run a routine from the beginning.
-;             ;routines are identified by a caret.
-d tag         ;run a tag in the current routine
-d tag^routine ;run a tag in different routine
+d ^routine    ;루틴을 처음부터 실행합니다.
+;             ;루틴은 캐럿으로 식별됩니다.
+d tag         ;현재 루틴에서 태그를 실행합니다.
+d tag^routine ;다른 루틴에서 태그를 실행합니다.
 ```
 
-Argumentless do: used to create blocks of code. The block is indented with a period for each level of the block:
+인수 없는 do: 코드 블록을 만드는 데 사용됩니다. 블록은 블록의 각 수준에 대해 마침표로 들여쓰기됩니다:
 
 ```
 set a=1
@@ -245,61 +229,61 @@ if a=1 do
 w "hello"
 ```
 
-#### Quit (abbreviated as Q)
-Stop executing this block and return to the previous stack level.
-Quit can return a value, following the comamnd with a single space.
-Quit can stop a loop. remember to follow with two spaces.
-Quit outside a loop will return from the current subroutine followed by two spaces or a linefeed
+#### Quit (Q로 축약)
+이 블록 실행을 중지하고 이전 스택 수준으로 돌아갑니다.
+Quit는 명령어 뒤에 단일 공백을 붙여 값을 반환할 수 있습니다.
+Quit는 루프를 중지할 수 있습니다. 두 개의 공백을 붙이는 것을 잊지 마십시오.
+루프 외부의 Quit는 현재 서브루틴에서 반환되며 두 개의 공백이나 개행 문자가 뒤따릅니다.
 
-#### New (abbreviated as N)
-Hide with a cleared value a given variable's value _for just this stack level_. Useful for preventing side effects.
+#### New (N로 축약)
+주어진 변수의 값을 _이 스택 수준에서만_ 지워진 값으로 숨깁니다. 부작용을 방지하는 데 유용합니다.
 
-Putting all this together, we can create a full example of an M routine:
+이 모든 것을 종합하여 M 루틴의 전체 예를 만들 수 있습니다:
 
 ```
-; RECTANGLE - a routine to deal with rectangle math
-    q ; quit if a specific tag is not called
+; RECTANGLE - 사각형 수학을 다루는 루틴
+    q ; 특정 태그가 호출되지 않으면 종료
 
 main
-    n length,width ; New length and width so any previous value doesn't persist
-    w !,"Welcome to RECTANGLE. Enter the dimensions of your rectangle."
-    r !,"Length? ",length,!,"Width? ",width
-    d area(length,width)            ;Do/Call subroutine using a tag
-    s per=$$perimeter(length,width)      ;Get the value of a function
-    w !,"Perimeter: ",per
+    n length,width ; 이전 값이 유지되지 않도록 새 길이와 너비
+    w !,"RECTANGLE에 오신 것을 환영합니다. 사각형의 치수를 입력하십시오."
+    r !,"길이? ",length,!,"너비? ",width
+    d area(length,width)            ;태그를 사용하여 서브루틴 호출/실행
+    s per=$$perimeter(length,width)      ;함수 값 가져오기
+    w !,"둘레: ",per
     quit
 
-area(length,width)  ; This is a tag that accepts parameters.
-                    ; It's not a function since it quits with no value.
-    w !, "Area: ",length*width
-    q  ; Quit: return to the previous level of the stack.
+area(length,width)  ; 매개변수를 받는 태그입니다.
+                    ; 값이 없이 종료되므로 함수가 아닙니다.
+    w !, "면적: ",length*width
+    q  ; 종료: 스택의 이전 수준으로 돌아갑니다.
 
 perimeter(length,width)
-    q 2*(length+width) ; Returns a value using Quit ; this is a function
+    q 2*(length+width) ; Quit를 사용하여 값을 반환합니다. ; 이것은 함수입니다.
 ```
 
 
 
-### Conditionals, Looping and $Order()
+### 조건문, 반복문 및 $Order()
 
-F(or) loops can follow a few different patterns:
+F(or) 루프는 몇 가지 다른 패턴을 따를 수 있습니다:
 
 ```jinja
-;Finite loop with counter
+;카운터가 있는 유한 루프
 ;f var=start:increment:stop
 
 f i=0:5:25 w i," "
 ;0 5 10 15 20 25
 
-; Infinite loop with counter
-; The counter will keep incrementing forever. Use a conditional with Quit to get out of the loop.
+; 카운터가 있는 무한 루프
+; 카운터는 영원히 증가합니다. 루프를 빠져나가려면 조건부 Quit를 사용하십시오.
 ;f var=start:increment
 
 f j=1:1 w j," " i j>1E3 q
-; Print 1-1000 separated by a space
+; 공백으로 구분된 1-1000 인쇄
 
-;Argumentless for - infinite loop. Use a conditional with Quit.
-;   Also read as "forever" - f or for followed by two spaces.
+;인수 없는 for - 무한 루프. 조건부 Quit를 사용하십시오.
+;   "영원히"로도 읽습니다 - f 또는 for 뒤에 두 개의 공백.
 s var=""
 f  s var=var_"%" w !,var i var="%%%%%%%%%%" q
 ; %
@@ -314,94 +298,94 @@ f  s var=var_"%" w !,var i var="%%%%%%%%%%" q
 ; %%%%%%%%%%
 ```
 
-#### I(f), E(lse), Postconditionals
+#### I(f), E(lse), 후조건
 
-M has an if/else construct for conditional evaluation, but any command can be conditionally executed without an extra if statement using a _postconditional_. This is a condition that occurs immediately after the command, separated with a colon (:).
+M에는 조건부 평가를 위한 if/else 구조가 있지만, 모든 명령어는 _후조건_을 사용하여 추가 if 문 없이 조건부로 실행될 수 있습니다. 이것은 명령어 바로 뒤에 콜론(:)으로 구분되어 나타나는 조건입니다.
 
 ```jinja
-; Conditional using traditional if/else
-r "Enter a number: ",num
-i num>100 w !,"huge"
-e i num>10 w !,"big"
-e w !,"small"
+;전통적인 if/else를 사용한 조건문
+r "숫자 입력: ",num
+i num>100 w !,"엄청 큼"
+e i num>10 w !,"큼"
+e w !,"작음"
 
-; Postconditionals are especially useful in a for loop.
-; This is the dominant for loop construct:
-;   a 'for' statement
-;   that tests for a 'quit' condition with a postconditional
-;   then 'do'es an indented block for each iteration
+; 후조건은 for 루프에서 특히 유용합니다.
+; 이것이 지배적인 for 루프 구조입니다:
+;   'for' 문
+;   후조건으로 'quit' 조건을 테스트하는
+;   그런 다음 각 반복에 대해 들여쓰기된 블록을 'do'합니다.
 
 s var=""
-f  s var=var_"%" q:var="%%%%%%%%%%" d  ;Read as "Quit if var equals "%%%%%%%%%%"
+f  s var=var_"%" q:var="%%%%%%%%%%" d  ;"var가 "%%%%%%%%%%"이면 종료"로 읽습니다.
 . w !,var
 
-;Bonus points - the $L(ength) built-in function makes this even terser
+;보너스 포인트 - $L(ength) 내장 함수를 사용하면 훨씬 더 간결해집니다.
 
 s var=""
 f  s var=var_"%" q:$L(var)>10  d  ;
 . w !,var
 ```
 
-#### Array Looping - $Order
-As we saw in the previous example, M has built-in functions called with a single $, compared to user-defined functions called with $$. These functions have shortened abbreviations, like commands.
-One of the most useful is __$Order()__ / $O(). When given an array subscript, $O returns the next subscript in that array. When it reaches the last subscript, it returns "".
+#### 배열 반복 - $Order
+이전 예에서 보았듯이 M에는 $$로 호출되는 사용자 정의 함수와 비교하여 단일 $로 호출되는 내장 함수가 있습니다. 이 함수들은 명령어처럼 축약형이 있습니다.
+가장 유용한 것 중 하나는 __$Order()__ / $O()입니다. 배열 아래 첨자를 주면 $O는 해당 배열의 다음 아래 첨자를 반환합니다. 마지막 아래 첨자에 도달하면 ""를 반환합니다.
 
 ```jinja
-;Let's call back to our ^TEMPS global from earlier:
-; A log of temperatures by date and time
+;이전의 ^TEMPS 전역 변수를 다시 호출해 봅시다:
+; 날짜 및 시간별 온도 기록
 s ^TEMPS("11/12","0600",32)=""
 s ^TEMPS("11/12","0600",48)=""
 s ^TEMPS("11/12","1400",49)=""
 s ^TEMPS("11/12","1700",43)=""
-; Some more
+; 일부 추가
 s ^TEMPS("11/16","0300",27)=""
 s ^TEMPS("11/16","1130",32)=""
 s ^TEMPS("11/16","1300",47)=""
 
-;Here's a loop to print out all the dates we have temperatures for:
-n date,time ; Initialize these variables with ""
+;온도가 있는 모든 날짜를 인쇄하는 루프입니다:
+n date,time ; 이 변수들을 ""로 초기화합니다.
 
-; This line reads: forever; set date as the next date in ^TEMPS.
-; If date was set to "", it means we're at the end, so quit.
-; Do the block below
+; 이 줄은 다음과 같이 읽습니다: 영원히; date를 ^TEMPS의 다음 날짜로 설정합니다.
+; date가 ""로 설정되면 끝에 도달했음을 의미하므로 종료합니다.
+; 아래 블록을 실행합니다.
 f  s date=$ORDER(^TEMPS(date)) q:date="" d
 . w !,date
 
-; Add in times too:
+; 시간도 추가합니다:
 f  s date=$ORDER(^TEMPS(date)) q:date=""  d
-. w !,"Date: ",date
+. w !,"날짜: ",date
 . f  s time=$O(^TEMPS(date,time)) q:time=""  d
-. . w !,"Time: ",time
+. . w !,"시간: ",time
 
-; Build an index that sorts first by temperature -
-; what dates and times had a given temperature?
+; 온도를 기준으로 먼저 정렬하는 인덱스를 만듭니다 -
+; 특정 온도였던 날짜와 시간은?
 n date,time,temp
 f  s date=$ORDER(^TEMPS(date)) q:date=""  d
 . f  s time=$O(^TEMPS(date,time)) q:time=""  d
 . . f  s temp=$O(^TEMPS(date,time,temp)) q:temp=""  d
 . . . s ^TEMPINDEX(temp,date,time)=""
 
-;This will produce a global like
+;이것은 다음과 같은 전역 변수를 생성합니다.
 ^TEMPINDEX(27,"11/16","0300")
 ^TEMPINDEX(32,"11/12","0600")
 ^TEMPINDEX(32,"11/16","1130")
 ```
 
-## Further Reading
+## 더 읽을거리
 
-There's lots more to learn about M. A great short tutorial comes from the University of Northern Iowa and  Professor Kevin O'Kane's [Introduction to the MUMPS Language][1] presentation.  More about M using VistA is at
+M에 대해 배울 것이 훨씬 더 많습니다. 북부 아이오와 대학의 Kevin O'Kane 교수의 [MUMPS 언어 소개][1] 프레젠테이션에서 훌륭한 짧은 튜토리얼을 제공합니다. VistA를 사용한 M에 대한 자세한 내용은
 
-Intersystems has some products which are a super-set of the M programming language.
+Intersystems에는 M 프로그래밍 언어의 상위 집합인 일부 제품이 있습니다.
 
-* [Iris Description Page][5]
-* [Cache Description Page][6]
+* [Iris 설명 페이지][5]
+* [Cache 설명 페이지][6]
 
-To install an M interpreter / database on your computer, try a [YottaDB Docker image][2].
+컴퓨터에 M 인터프리터 / 데이터베이스를 설치하려면 [YottaDB Docker 이미지][2]를 사용해 보십시오.
 
-YottaDB and its precursor, GT.M, have thorough documentation on all the language features including database transactions, locking, and replication:
+YottaDB와 그 전신인 GT.M은 데이터베이스 트랜잭션, 잠금 및 복제를 포함한 모든 언어 기능에 대한 철저한 문서를 가지고 있습니다:
 
-* [YottaDB Programmer's Guide][3]
-* [GT.M Programmer's Guide][4]
+* [YottaDB 프로그래머 가이드][3]
+* [GT.M 프로그래머 가이드][4]
 
 [1]: https://www.cs.uni.edu/~okane/source/MUMPS-MDH/MumpsTutorial.pdf
 [2]: https://yottadb.com/product/get-started/


### PR DESCRIPTION
I've translated a batch of markdown files in the `ko/` directory that were marked with `(번역)` on the first line.

I performed the translation on the markdown content, leaving the YAML frontmatter and code blocks untouched. I also removed the `(번역)` marker from the translated files.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
