### PR TITLE
Translate all remaining markdown files to Korean

### DIFF
--- a/ko/lean4.md
+++ b/ko/lean4.md
@@ -1,5 +1,3 @@
-# lean4.md (번역)
-
 ---
 name: "Lean 4"
 filename: learnlean4.lean
@@ -8,12 +6,11 @@ contributors:
     - ["Ferinko", "https://github.com/Ferinko"]
 ---
 
-[Lean 4](https://lean-lang.org/) is a dependently typed functional programming
-language and an interactive theorem prover.
+[Lean 4](https://lean-lang.org/)는 종속 타입 함수형 프로그래밍 언어이자 대화형 정리 증명기입니다.
 
 ```lean4
 /-
-An enumerated data type.
+열거형 데이터 타입입니다.
 -/
 inductive Grade where
   | A : Grade
@@ -22,7 +19,7 @@ inductive Grade where
 deriving Repr
 
 /-
-Functions.
+함수입니다.
 -/
 def grade (m : Nat) : Grade :=
   if 80 <= m then Grade.A
@@ -35,18 +32,17 @@ def lowMarks  := 25 + 25
 #eval grade lowMarks
 
 #check (0 : Nat)
-/- #check (0 : Grade) -/ /- This is an error. -/
+/- #check (0 : Grade) -/ /- 이것은 오류입니다. -/
 
 /-
-Types themselves are values.
+타입 자체도 값입니다.
 -/
 #check (Nat : Type)
 
 /-
-Mathematical propositions are values in Lean. `Prop` is the type of
-propositions.
+수학적 명제는 Lean에서 값입니다. `Prop`은 명제의 타입입니다.
 
-Here are some simple propositions.
+다음은 몇 가지 간단한 명제입니다.
 -/
 
 #check 0 = 1
@@ -54,40 +50,37 @@ Here are some simple propositions.
 #check 2^9 - 2^8 = 2^8
 
 /-
-Notice Lean displays `0 = 1 : Prop` to say:
+Lean은 `0 = 1 : Prop`을 표시하여 다음을 말합니다:
 
-  The statement "0 = 1" is a proposition.
+  "0 = 1" 문장은 명제입니다.
 
-We want to distinguish true propositions and false propositions. We do this via
-proofs.
+우리는 참인 명제와 거짓인 명제를 구별하고 싶습니다. 우리는 증명을 통해 이를 수행합니다.
 
-Each proposition is a type. `0 = 1` is a type, `1 = 1` is another type.
+각 명제는 타입입니다. `0 = 1`은 타입이고, `1 = 1`은 다른 타입입니다.
 
-A proposition is true iff there is a value of that type.
+명제는 해당 타입의 값이 있는 경우에만 참입니다.
 
-How do we construct a value of type `1 = 1`? We use a constructor that is
-defined for that type.
+`1 = 1` 타입의 값을 어떻게 생성할까요? 해당 타입에 대해 정의된 생성자를 사용합니다.
 
-  `Eq.refl a` constructs a value of type `a = a`. (reflexivity)
+  `Eq.refl a`는 `a = a` 타입의 값을 생성합니다. (반사성)
 
-Using this we can prove `1 = 1` as follows.
+이를 사용하여 다음과 같이 `1 = 1`을 증명할 수 있습니다.
 -/
 
 theorem one_eq_one : 1 = 1 := Eq.refl 1
 
 /-
-But there is no way to prove (construct a value of type) `0 = 1`.
+하지만 `0 = 1`을 증명할 (타입의 값을 생성할) 방법은 없습니다.
 
-The following will fail. As will `Eq.refl 1`
+다음은 실패합니다. `Eq.refl 1`도 마찬가지입니다.
 -/
 
 /- theorem zero_eq_one : 0 = 1 := Eq.refl 0 -/
 
 /-
-Let us prove an inequality involving variables.
+변수를 포함하는 부등식을 증명해 봅시다.
 
-The `calc` primitive allows us to prove equalities using stepwise
-calculations. Each step has to be justified by a proof.
+`calc` 프리미티브를 사용하면 단계별 계산을 통해 등식을 증명할 수 있습니다. 각 단계는 증명으로 정당화되어야 합니다.
 -/
 theorem plus_squared (a b : Nat) : (a+b)^2 = a^2 + 2*a*b + b^2 :=
   calc
@@ -102,37 +95,34 @@ theorem plus_squared (a b : Nat) : (a+b)^2 = a^2 + 2*a*b + b^2 :=
     _       = a^2 + 2*(a*b) + b^2     := by rw [← Nat.two_mul _]
     _       = a^2 + 2*a*b + b^2       := by rw [Nat.mul_assoc _ _ _]
 /-
-Underscores can be used when there is no ambiguity in what is to be matched.
+일치시킬 대상에 모호함이 없을 때 밑줄을 사용할 수 있습니다.
 
-For example, in the first step, we want to apply `Nat.pow_two (a+b)`. But,
-`(a+b)` is the only pattern here to apply `Nat.pow_two`. So we can omit it.
+예를 들어, 첫 번째 단계에서 `Nat.pow_two (a+b)`를 적용하려고 합니다. 하지만,
+`(a+b)`는 여기서 `Nat.pow_two`를 적용할 유일한 패턴입니다. 그래서 생략할 수 있습니다.
 -/
 
 /-
-Let us now prove more "realistic" theorems. Those involving logical connectives.
+이제 더 "현실적인" 정리, 즉 논리적 연결사를 포함하는 정리를 증명해 봅시다.
 
-First, we define even and odd numbers.
+먼저, 짝수와 홀수를 정의합니다.
 -/
 def Even (n : Nat) := ∃ k, n = 2*k
 def Odd  (n : Nat) := ∃ k, n = 2*k + 1
 
 /-
-To prove an existential, we can provide specific values if we know them.
+존재 증명을 하려면, 우리가 안다면 특정 값을 제공할 수 있습니다.
 -/
 theorem zero_even : Even 0 :=
   have h : 0 = 2 * 0 := Eq.symm (Nat.mul_zero 2)
   Exists.intro 0 h
 /-
-`Exists.intro v h` proves `∃ x, p x` by substituting `x` by `v` and using the
-proof `h` for `p v`.
+`Exists.intro v h`는 `x`를 `v`로 치환하고 `p v`에 대한 증명 `h`를 사용하여 `∃ x, p x`를 증명합니다.
 -/
 
 /-
-Now, we will see how to use hypothesis that are existentials to prove
-conclusions that are existentials.
+이제, 존재 가설을 사용하여 존재 결론을 증명하는 방법을 살펴보겠습니다.
 
-The curly braces around parameters `n` and `m` indicate that they are
-implicit. Here, Lean will infer them from `hn` and `hm`.
+매개변수 `n`과 `m` 주위의 중괄호는 그것들이 암시적임을 나타냅니다. 여기서 Lean은 `hn`과 `hm`에서 그것들을 추론할 것입니다.
 -/
 theorem even_mul_even_is_even' {n m : Nat} (hn : Even n) (hm : Even m) : Even (n*m) :=
   Exists.elim hn (fun k1 hk1 =>
@@ -146,10 +136,9 @@ theorem even_mul_even_is_even' {n m : Nat} (hn : Even n) (hm : Even m) : Even (n
   )
 
 /-
-Most proofs are written using *tactics*. These are commands to Lean that guide
-it to construct proofs by itself.
+대부분의 증명은 *전술(tactics)*을 사용하여 작성됩니다. 이것들은 Lean이 스스로 증명을 구성하도록 안내하는 명령어입니다.
 
-The same theorem, proved using tactics.
+전술을 사용하여 증명된 동일한 정리입니다.
 -/
 theorem even_mul_even_is_even {n m : Nat} (hn : Even n) (hm : Even m) : Even (n*m) := by
   have ⟨k1, hk1⟩ := hn
@@ -160,7 +149,7 @@ theorem even_mul_even_is_even {n m : Nat} (hn : Even n) (hm : Even m) : Even (n*
     _   = 2 * (k1 * (2 * k2)) := by rw [Nat.mul_assoc]
 
 /-
-Let us work with implications.
+함의(implications)를 다루어 봅시다.
 -/
 theorem succ_of_even_is_odd' {n : Nat} : Even n → Odd (n+1) :=
   fun hn =>
@@ -170,19 +159,15 @@ theorem succ_of_even_is_odd' {n : Nat} : Even n → Odd (n+1) :=
         n + 1 = 2 * k + 1 := by rw [hk]
     )
 /-
-To prove an implication `p → q`, you have to write a function that takes a proof
-of `p` and construct a proof of `q`.
+함의 `p → q`를 증명하려면 `p`의 증명을 받아 `q`의 증명을 구성하는 함수를 작성해야 합니다.
 
-Here, `pn` is proof of `Even n := ∃ k, n = 2 *k`. Eliminating the existential
-gets us `k` and a proof `hk` of `n = 2 * k`.
+여기서 `pn`은 `Even n := ∃ k, n = 2 *k`의 증명입니다. 존재 한정자를 제거하면 `k`와 `n = 2 * k`의 증명 `hk`를 얻습니다.
 
-Now, we have to introduce the existential `∃ k, n + 1 = 2 * k + 1`. This `k` is
-the same as `k` for `n`. And, the equation is proved by a simple calculation
-that substitutes `2 * k` for `n`, which is allowed by `hk`.
+이제 존재 한정자 `∃ k, n + 1 = 2 * k + 1`을 도입해야 합니다. 이 `k`는 `n`에 대한 `k`와 동일합니다. 그리고 방정식은 `hk`에 의해 허용되는 `n`을 `2 * k`로 치환하는 간단한 계산으로 증명됩니다.
 -/
 
 /-
-Same theorem, now using tactics.
+전술을 사용하여 동일한 정리입니다.
 -/
 theorem succ_of_even_is_odd {n : Nat} : Even n → Odd (n+1) := by
   intro hn
@@ -191,54 +176,47 @@ theorem succ_of_even_is_odd {n : Nat} : Even n → Odd (n+1) := by
   rw [hk]
 
 /-
-The following theorem can be proved similarly.
+다음 정리는 비슷하게 증명될 수 있습니다.
 
-We will use this theorem later.
+이 정리는 나중에 사용할 것입니다.
 
-A `sorry` proves any theorem. It should not be used in real proofs.
+`sorry`는 어떤 정리든 증명합니다. 실제 증명에서는 사용해서는 안 됩니다.
 -/
 theorem succ_of_odd_is_even {n : Nat} : Odd n → Even (n+1) := sorry
 
 /-
-We can use theorems by applying them.
+정리를 적용하여 사용할 수 있습니다.
 -/
 example : Odd 1 := by
   apply succ_of_even_is_odd
   exact zero_even
 /-
-The two new tactics are:
+두 가지 새로운 전술은 다음과 같습니다:
 
-  - `apply p` where `p` is an implication `q → r` and `r` is the goal rewrites
-  the goal to `q`. More generally, `apply t` will unify the current goal with
-  the conclusion of `t` and generate goals for each hypothesis of `t`.
-  - `exact h` solves the goal by stating that the goal is the same as `h`.
+  - `apply p`는 `p`가 함의 `q → r`이고 `r`이 목표일 때 목표를 `q`로 다시 씁니다. 더 일반적으로 `apply t`는 현재 목표를 `t`의 결론과 통합하고 `t`의 각 가설에 대한 목표를 생성합니다.
+  - `exact h`는 목표가 `h`와 동일하다고 명시하여 목표를 해결합니다.
 -/
 
 /-
-Let us see examples of disjunctions.
+선언(disjunctions)의 예를 살펴봅시다.
 -/
 example : Even 0 ∨ Odd 0 := Or.inl zero_even
 example : Even 0 ∨ Odd 1 := Or.inl zero_even
 example : Odd 1 ∨ Even 0 := Or.inr zero_even
 /-
-Here, we always know from `p ∨ q` which of `p` and/or `q` is correct. So we can
-introduce a proof of the correct side.
+여기서, 우리는 항상 `p ∨ q`에서 `p`와/또는 `q` 중 어느 것이 올바른지 알 수 있습니다. 그래서 우리는 올바른 쪽의 증명을 도입할 수 있습니다.
 -/
 
 /-
-Let us see a more "standard" disjunction.
+더 "표준적인" 선언을 살펴봅시다.
 
-Here, from the hypothesis that `n : Nat`, we cannot determine whether `n` is
-even or odd. So we cannot construct `Or` directly.
+여기서, `n : Nat`라는 가설에서 `n`이 짝수인지 홀수인지 결정할 수 없습니다. 그래서 우리는 `Or`를 직접 구성할 수 없습니다.
 
-But, for any specific `n`, we will know which one to construct.
+하지만, 어떤 특정한 `n`에 대해서는 어떤 것을 구성해야 할지 알게 될 것입니다.
 
-This is exactly what induction allows us to do. We introduce the `induction`
-tactic.
+이것이 바로 귀납법이 우리에게 허용하는 것입니다. `induction` 전술을 도입합니다.
 
-The inductive hypothesis is a disjunction. When disjunctions appear at the
-hypothesis, we use *proof by exhaustive cases*. This is done using the `cases`
-tactic.
+귀납적 가설은 선언입니다. 가설에 선언이 나타나면 *철저한 사례별 증명*을 사용합니다. 이것은 `cases` 전술을 사용하여 수행됩니다.
 -/
 theorem even_or_odd {n : Nat} : Even n ∨ Odd n := by
   induction n
@@ -248,12 +226,11 @@ theorem even_or_odd {n : Nat} : Even n ∨ Odd n := by
     | inl h => right ; apply (succ_of_even_is_odd h)
     | inr h => left  ; apply (succ_of_odd_is_even h)
 /-
-`induction` is not just for natural numbers. It is for any type, since all types
-in Lean are inductive.
+`induction`은 자연수만을 위한 것이 아닙니다. Lean의 모든 타입은 귀납적이므로 모든 타입에 대해 사용할 수 있습니다.
 -/
 
 /-
-We now state Collatz conjecture. The proof is left as an exercise to the reader.
+이제 콜라츠 추측을 기술합니다. 증명은 독자를 위한 연습 문제로 남겨둡니다.
 -/
 def collatz_next (n : Nat) : Nat :=
   if n % 2 = 0 then n / 2 else 3 * n + 1
@@ -266,53 +243,48 @@ def iter (k : Nat) (f : Nat → Nat) :=
 theorem collatz : ∀ n, n > 0 → ∃ k, iter k collatz_next n = 1 := sorry
 
 /-
-Now, some "corner cases" in logic.
+이제 논리학의 몇 가지 "코너 케이스"입니다.
 -/
 
 /-
-The proposition `True` is something that can be trivially proved.
+명제 `True`는 자명하게 증명될 수 있는 것입니다.
 
-`True.intro` is a constructor for proving `True`. Notice that it needs no
-inputs.
+`True.intro`는 `True`를 증명하기 위한 생성자입니다. 입력이 필요 없다는 점에 유의하십시오.
 -/
 theorem obvious : True := True.intro
 
 /-
-On the other hand, there is no constructor for `False`.
+반면에 `False`에 대한 생성자는 없습니다.
 
-We have to use `sorry`.
+`sorry`를 사용해야 합니다.
 -/
 theorem impossible : False := sorry
 
 /-
-Any `False` in the hypothesis allows us to conclude anything.
+가설에 있는 어떤 `False`라도 우리에게 무엇이든 결론 내리게 할 수 있습니다.
 
-Written in term style, we use the eliminator `False.elim`. It takes a proof of
-`False`, here `h`, and concludes whatever is the goal.
+항(term) 스타일로 작성할 때, 우리는 제거자 `False.elim`을 사용합니다. 이것은 `False`의 증명(여기서는 `h`)을 받아 목표가 무엇이든 결론을 내립니다.
 -/
 theorem nonsense (h : False) : 0 = 1 := False.elim h
 
 /-
-The `contradiction` tactic uses any `False` in the hypothesis to conclude the
-goal.
+`contradiction` 전술은 가설에 있는 어떤 `False`라도 사용하여 목표를 결론 내립니다.
 -/
 theorem more_nonsense (h : False) : 1 = 2 := by contradiction
 
 /-
-To illustrate constructive vs classical logic, we now prove the contrapositive
-theorem.
+구성주의 논리와 고전주의 논리의 차이를 설명하기 위해, 이제 대우(contrapositive) 정리를 증명합니다.
 
-The forward direction does not require classical logic.
+순방향은 고전주의 논리를 요구하지 않습니다.
 -/
 theorem contrapositive_forward' (p q : Prop) : (p → q) → (¬q → ¬p) :=
   fun pq => fun hqf => fun hp => hqf (pq hp)
 /-
-Use the definition `¬q := q → False`. Notice that we have to construct `p →
-False` given `p → q` and `q → False`. This is just function composition.
+정의 `¬q := q → False`를 사용하십시오. `p → q`와 `q → False`가 주어졌을 때 `p → False`를 구성해야 한다는 점에 유의하십시오. 이것은 단지 함수 합성일 뿐입니다.
 -/
 
 /-
-The above proof, using tactics.
+위 증명을 전술을 사용하여 다시 작성한 것입니다.
 -/
 theorem contrapositive_forward (p q : Prop) : (p → q) → (¬q → ¬p) := by
   intro hpq
@@ -322,14 +294,14 @@ theorem contrapositive_forward (p q : Prop) : (p → q) → (¬q → ¬p) := by
   contradiction
 
 /-
-The reverse requires classical logic.
+역방향은 고전주의 논리를 요구합니다.
 
-Here, we are required to construct a `q` given values of following types:
+여기서, 우리는 다음 타입의 값들이 주어졌을 때 `q`를 구성해야 합니다:
 
   - `(q → False) → (p → False)`.
   - `p`.
 
-This is impossible without using the law of excluded middle.
+이것은 배중률을 사용하지 않고는 불가능합니다.
 -/
 theorem contrapositive_reverse' (p q : Prop) : (¬q → ¬p) → (p → q) :=
   fun hnqnp =>
@@ -337,15 +309,11 @@ theorem contrapositive_reverse' (p q : Prop) : (¬q → ¬p) → (p → q) :=
     (fun hq  => fun  _ => hq)
     (fun hnq => fun hp => absurd hp (hnqnp hnq))
 /-
-Law of excluded middle tells us that we will have a `q` or a `q → False`. In the
-first case, it is trivial to construct a `q`, we already have it. In the second
-case, we give the `q → False` to obtain a `p → False`.  Then, we use the fact
-(in constructive logic) that given `p` and `p → False`, we can construct
-`False`. Once, we have `False`, we can construct anything, and specifically `q`.
+배중률은 우리에게 `q` 또는 `q → False`가 있을 것이라고 말해줍니다. 첫 번째 경우, `q`를 구성하는 것은 자명합니다. 우리는 이미 그것을 가지고 있습니다. 두 번째 경우, `p → False`를 얻기 위해 `q → False`를 제공합니다. 그런 다음, `p`와 `p → False`가 주어지면 `False`를 구성할 수 있다는 사실(구성주의 논리에서)을 사용합니다. 일단 `False`를 가지게 되면, 우리는 무엇이든 구성할 수 있으며, 구체적으로 `q`를 구성할 수 있습니다.
 -/
 
 /-
-Same proof, using tactics.
+전술을 사용한 동일한 증명입니다.
 -/
 theorem contrapositive_reverse (p q : Prop) : (¬q → ¬p) → (p → q) := by
   intro hnqnp
@@ -356,17 +324,15 @@ theorem contrapositive_reverse (p q : Prop) : (¬q → ¬p) → (p → q) := by
   case inr h => specialize hnqnp h ; contradiction
 
 /-
-To illustrate how we can define an work with axiomatic systems. Here is a
-definition of Groups and some proofs directly translated from "Topics in
-Algebra" by Herstein, Second edition.
+공리 체계를 정의하고 작업하는 방법을 설명하기 위해, Herstein의 "대수학의 주제들(Topics in Algebra)" 제2판에서 직접 번역한 군(Group)의 정의와 몇 가지 증명을 소개합니다.
 -/
 
 /-
-A `section` introduces a namespace.
+`section`은 네임스페이스를 도입합니다.
 -/
 section GroupTheory
 /-
-To define abstract objects like groups, we may use `class`.
+군과 같은 추상적인 객체를 정의하기 위해 `class`를 사용할 수 있습니다.
 -/
 class Group (G : Type u) where
   op : G → G → G
@@ -376,21 +342,20 @@ class Group (G : Type u) where
   inverse: ∀ a : G, ∃ b : G, op a b = e ∧ op b a = e
 
 /-
-Let us introduce some notation to make this convenient.
+이것을 편리하게 만들기 위해 몇 가지 표기법을 도입합시다.
 -/
 open Group
 infixl:70 " * " => op
 
 /-
-`G` will always stand for a group and variables `a b c` will be elements of that
-group in this `section`.
+이 `section`에서 `G`는 항상 군을 나타내고 변수 `a b c`는 해당 군의 원소가 될 것입니다.
 -/
 variable [Group G] {a b c : G}
 
 def is_identity (e' : G) := ∀ a : G, (a * e' = a ∧ e' * a = a)
 
 /-
-We prove that the identity element is unique.
+항등원이 유일함을 증명합니다.
 -/
 theorem identity_element_unique : ∀ e' : G, is_identity e' → e' = e := by
   intro e'
@@ -401,12 +366,11 @@ theorem identity_element_unique : ∀ e' : G, is_identity e' → e' = e := by
   have ⟨_, h2⟩ := h'
   exact Eq.trans (Eq.symm h2) h1
 /-
-Note that we used the `identity` axiom.
+`identity` 공리를 사용했음에 유의하십시오.
 -/
 
 /-
-Left cancellation. We have to use both `identity` and `inverse` axioms from
-`Group`.
+왼쪽 소거. `Group`의 `identity`와 `inverse` 공리를 모두 사용해야 합니다.
 -/
 theorem left_cancellation : ∀ x y : G, a * x = a * y → x = y := by
   have h1 := inverse a
@@ -423,12 +387,12 @@ theorem left_cancellation : ∀ x y : G, a * x = a * y → x = y := by
     _ = (e : G) * y  := by rw [h2]
     _ = y            := (identity y).right
 
-end GroupTheory /- Variables `G`, `a`, `b`, `c` are now not in scope. -/
+end GroupTheory /- 변수 `G`, `a`, `b`, `c`는 이제 범위에 없습니다. -/
 
 /-
-Let us see a mutually recursive definition.
+상호 재귀적인 정의를 살펴봅시다.
 
-The game of Nim with two heaps.
+두 개의 힙이 있는 님(Nim) 게임입니다.
 -/
 abbrev between (lower what upper : Nat) : Prop := lower ≤ what ∧ what ≤ upper
 
@@ -457,9 +421,7 @@ example : Bob 0 0 := by
     intro a ; have := a.right ; contradiction
 
 /-
-We have to convince Lean of termination when a function is defined using just a
-`def`. Here's a simple primality checking algorithm that tests all candidate
-divisors.
+단지 `def`를 사용하여 함수가 정의될 때, 우리는 Lean에게 종료를 확신시켜야 합니다. 다음은 모든 후보 약수를 테스트하는 간단한 소수 판별 알고리즘입니다.
 -/
 def prime' (n : Nat) : Bool :=
   if h : n < 2 then
@@ -468,7 +430,7 @@ def prime' (n : Nat) : Bool :=
     @go 2 n (by omega)
 where
   go (d : Nat) (n : Nat) {_ : n ≥ d} : Bool :=
-    if h : n = d then /- `h` needed for `omega` below. -/
+    if h : n = d then /- `omega`가 아래에서 필요로 하는 `h`. -/
       true
     else if n % d = 0 then
       false
@@ -476,22 +438,16 @@ where
       @go (Nat.succ d) n (by omega)
   termination_by (n - d)
 /-
-We have to specify that the recursive function `go` terminates because `n-k`
-decreases in each recursive call. This needs the hypothesis `n > k` at the
-recursive call site. But the function itself can only assume that `n ≥ k`. We
-label the test `n ≤ k` by `h` so that the falsification of this proposition can
-be used by `omega` later to conclude that `n > k`.
+재귀 함수 `go`가 각 재귀 호출에서 `n-k`가 감소하기 때문에 종료된다는 것을 명시해야 합니다. 이를 위해서는 재귀 호출 위치에 `n > k`라는 가설이 필요합니다. 하지만 함수 자체는 `n ≥ k`라고만 가정할 수 있습니다. 우리는 `n ≤ k` 테스트를 `h`로 레이블을 지정하여, 나중에 `omega`가 `n > k`라고 결론 내리는 데 이 명제의 반증을 사용할 수 있도록 합니다.
 
-The tactic `omega` can solve simple equalities and inequalities.
+`omega` 전술은 간단한 등식과 부등식을 풀 수 있습니다.
 -/
 /-
-You can also instruct Lean to not check for totality by prefixing `partial` to
-`def`.
+또한 `def` 앞에 `partial`을 붙여 Lean이 전체성(totality)을 확인하지 않도록 지시할 수 있습니다.
 -/
 
 /-
-Or, we can rewrite the function to test the divisors from largest to
-smallest. In this case, Lean easily verifies that the function is total.
+또는, 약수를 가장 큰 것부터 가장 작은 것 순으로 테스트하도록 함수를 다시 작성할 수 있습니다. 이 경우 Lean은 함수가 전체(total)임을 쉽게 확인합니다.
 -/
 def prime (n : Nat) : Bool :=
   if n < 2 then
@@ -507,14 +463,13 @@ where
     else
       go (d-1) n
 /-
-Now, to Lean, it is obvious that `go` will terminate because `d` decreases in
-each recursive call.
+이제 Lean에게는 각 재귀 호출에서 `d`가 감소하기 때문에 `go`가 종료될 것이라는 점이 명백합니다.
 -/
 #eval prime 57
 #eval prime 97
 ```
 
-For further learning, see:
+더 자세한 학습을 원하시면 다음을 참조하십시오:
 
 * [Functional Programming in Lean](https://lean-lang.org/functional_programming_in_lean/)
 * [Theorem Proving in Lean 4](https://lean-lang.org/theorem_proving_in_lean4/)

--- a/ko/lfe.md
+++ b/ko/lfe.md
@@ -1,5 +1,3 @@
-# lfe.md (번역)
-
 ---
 name: "Lisp Flavoured Erlang (LFE)"
 filename: lispflavourederlang.lfe
@@ -7,114 +5,112 @@ contributors:
   - ["Pratik Karki", "https://github.com/prertik"]
 ---
 
-Lisp Flavoured Erlang (LFE) is a functional, concurrent, general-purpose programming
-language and Lisp dialect (Lisp-2) built on top of Core Erlang and the Erlang Virtual Machine (BEAM).
+Lisp Flavoured Erlang(LFE)는 함수형, 동시성, 범용 프로그래밍 언어이자 코어 얼랭(Core Erlang) 및 얼랭 가상 머신(BEAM) 위에 구축된 리스프 방언(Lisp-2)입니다.
 
-LFE can be obtained from [LFE](https://github.com/rvirding/lfe).
-The classic starting point is the [LFE docs](http://docs.lfe.io).
+LFE는 [LFE](https://github.com/rvirding/lfe)에서 얻을 수 있습니다.
+고전적인 시작점은 [LFE 문서](http://docs.lfe.io)입니다.
 
 ```lisp
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 0. Syntax
+;;; 0. 구문
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;; General form.
+;;; 일반적인 형식.
 
-;; Lisp is comprised of two syntaxes, the ATOM and the S-expression.
-;; `forms` are known as grouped S-expressions.
+;; 리스프는 ATOM과 S-표현식이라는 두 가지 구문으로 구성됩니다.
+;; `form`은 그룹화된 S-표현식으로 알려져 있습니다.
 
-8  ; an atom; it evaluates to itself
+8  ; 아톰; 자기 자신으로 평가됩니다.
 
-:ERLANG ;Atom; evaluates to the symbol :ERLANG.
+:ERLANG ; 아톰; 심볼 :ERLANG으로 평가됩니다.
 
-t  ; another atom which denotes true.
+t  ; true를 나타내는 또 다른 아톰입니다.
 
-(* 2 21) ; an S- expression
+(* 2 21) ; S-표현식입니다.
 
-'(8 :foo t)  ;another one
+'(8 :foo t)  ; 또 다른 예시입니다.
 
 
-;;; Comments
+;;; 주석
 
-;; Single line comments start with a semicolon; use two for normal
-;; comments, three for section comments, and four fo file-level
-;; comments.
+;; 한 줄 주석은 세미콜론으로 시작합니다. 일반 주석에는 두 개,
+;; 섹션 주석에는 세 개, 파일 수준 주석에는 네 개를 사용하십시오.
 
-;; Block Comment
+;; 블록 주석
 
-   #| comment text |#
+   #| 주석 텍스트 |#
 
-;;; Environment
+;;; 환경
 
-;; LFE is the de-facto standard.
+;; LFE는 사실상의 표준입니다.
 
-;; Libraries can be used directly from the Erlang ecosystem. Rebar3 is the build tool.
+;; 라이브러리는 얼랭 생태계에서 직접 사용할 수 있습니다. Rebar3가 빌드 도구입니다.
 
-;; LFE is usually developed with a text editor(preferably Emacs) and a REPL
-;; (Read Evaluate Print Loop) running at the same time. The REPL
-;; allows for interactive exploration of the program as it is "live"
-;; in the system.
+;; LFE는 보통 텍스트 편집기(가급적 이맥스)와 REPL(Read Evaluate Print Loop)을
+;; 동시에 실행하여 개발합니다. REPL을 사용하면 시스템에서 "실시간"으로
+;; 실행 중인 프로그램을 대화식으로 탐색할 수 있습니다.
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 1. Literals and Special Syntactic Rules
+;;; 1. 리터럴 및 특수 구문 규칙
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;; Integers
+;;; 정수
 
-1234 -123           ; Regular decimal notation
-#b0 #b10101         ; Binary notation
-#0 #10101           ; Binary notation (alternative form)
-#o377 #o-111        ; Octal notation
-#d123456789 #d+123  ; Explicitly decimal notation
-#xc0ffe 0x-01       ; Hexadecimal notation
-#2r1010 #8r377      ;Notation with explicit base (up to 36)
-#\a #$ #\ä #\🐭     ;Character notation (the value is the Unicode code point of the character)
-#\x1f42d;           ;Character notation with the value in hexadecimal
+1234 -123           ; 일반 10진수 표기법
+#b0 #b10101         ; 2진수 표기법
+#0 #10101           ; 2진수 표기법 (대체 형식)
+#o377 #o-111        ; 8진수 표기법
+#d123456789 #d+123  ; 명시적 10진수 표기법
+#xc0ffe 0x-01       ; 16진수 표기법
+#2r1010 #8r377      ; 명시적 밑을 사용한 표기법 (최대 36)
+#\a #$ #\ä #\🐭     ; 문자 표기법 (값은 해당 문자의 유니코드 코드 포인트입니다)
+#\x1f42d;           ; 16진수 값을 사용한 문자 표기법
 
-;;; Floating point numbers
+;;; 부동 소수점 숫자
 1.0 +2.0 -1.5 1.0e10 1.111e-10
 
-;;; Strings
+;;; 문자열
 
-"any text between double quotes where \" and other special characters like \n can be escaped".
-; List String
-"Cat: \x1f639;" ; writing unicode in string for regular font ending with semicolon.
+"큰따옴표 사이의 모든 텍스트. \"나 다른 특수 문자(\n 등)는 이스케이프될 수 있습니다."
+; 리스트 문자열
+"Cat: \x1f639;" ; 일반 글꼴의 문자열에 유니코드를 작성하고 세미콜론으로 끝냅니다.
 
-#"This is a binary string \n with some \"escaped\" and quoted (\x1f639;) characters"
-; Binary strings are just strings but function different in the VM.
-; Other ways of writing it are:  #B("a"), #"a", and #B(97).
+#"이것은 일부 \"이스케이프된\" 및 인용된 (\x1f639;) 문자가 있는 바이너리 문자열입니다 \n"
+; 바이너리 문자열은 그냥 문자열이지만 VM에서 다르게 작동합니다.
+; 다른 작성 방법으로는 #B("a"), #"a", #B(97)이 있습니다.
 
 
-;;; Character escaping
+;;; 문자 이스케이프
 
-\b  ; => Backspace
-\t  ; => Tab
-\n  ; => Newline
-\v  ; => Vertical tab
-\f  ; => Form Feed
-\r  ; => Carriage Return
-\e  ; => Escape
-\s  ; => Space
-\d  ; => Delete
+\b  ; => 백스페이스
+\t  ; => 탭
+\n  ; => 개행
+\v  ; => 수직 탭
+\f  ; => 폼 피드
+\r  ; => 캐리지 리턴
+\e  ; => 이스케이프
+\s  ; => 공백
+\d  ; => 삭제
 
-;;; Binaries
-;; It is used to create binaries with any contents.
-#B((#"a" binary) (#"b" binary))                 ; #"ab" (Evaluated form)
+;;; 바이너리
+;; 어떤 내용이든 바이너리를 만드는 데 사용됩니다.
+#B((#"a" binary) (#"b" binary))                 ; #"ab" (평가된 형식)
 
-;;; Lists are: () or (foo bar baz)
+;;; 리스트: () 또는 (foo bar baz)
 
-;;; Tuples are written in: #(value1 value2 ...). Empty tuple #() is also valid.
+;;; 튜플은 #(value1 value2 ...) 형식으로 작성됩니다. 빈 튜플 #()도 유효합니다.
 
-;;; Maps are written as: #M(key1 value1 key2 value2 ...). Empty map #M() is also valid.
+;;; 맵은 #M(key1 value1 key2 value2 ...) 형식으로 작성됩니다. 빈 맵 #M()도 유효합니다.
 
-;;; Symbols: Things that cannot be parsed. Eg: foo, Foo, foo-bar, :foo
-| foo | ; explicit construction of symbol by wrapping vertical bars.
+;;; 심볼: 파싱할 수 없는 것들. 예: foo, Foo, foo-bar, :foo
+| foo | ; 수직 막대로 감싸서 심볼을 명시적으로 생성합니다.
 
-;;; Evaluation
+;;; 평가
 
-;; #.(... some expression ...). E.g. '#.(+ 1 1) will evaluate the (+ 1 1) while it            ;; reads the expression and then be effectively '2.
+;; #.(... 어떤 표현식 ...). 예: '#.(+ 1 1)은 표현식을 읽는 동안 (+ 1 1)을
+;; 평가하여 효과적으로 '2가 됩니다.
 
-;; List comprehension in LFE REPL
+;; LFE REPL에서의 리스트 컴프리헨션
 
 lfe> (list-comp
           ((<- x '(0 1 2 3)))
@@ -123,10 +119,10 @@ lfe> (list-comp
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 2. Core forms
+;; 2. 핵심 형식
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; These forms are the same as those found in Common Lisp and Scheme.
+;; 이 형식들은 커먼 리스프(Common Lisp)와 스킴(Scheme)에서 볼 수 있는 것들과 동일합니다.
 
 (quote e)
 (cons head tail)
@@ -139,19 +135,19 @@ lfe> (list-comp
 
 (lambda (arg ...) ...)
   (match-lambda
-    ((arg ... ) {{(when e ...)}} ...) ; Matches clauses
+    ((arg ... ) {{(when e ...)}} ...) ; 절 일치
     ... )
 (let ((pat {{(when e ...)}} e)
       ...)
   ... )
-(let-function ((name lambda|match-lambda) ; Only define local
-               ... )                      ; functions
+(let-function ((name lambda|match-lambda) ; 지역 함수만 정의
+               ... )
   ... )
-(letrec-function ((name lambda|match-lambda) ; Only define local
-                  ... )                      ; functions
+(letrec-function ((name lambda|match-lambda) ; 지역 함수만 정의
+                  ... )
   ... )
-(let-macro ((name lambda-match-lambda) ; Only define local
-            ...)                       ; macros
+(let-macro ((name lambda-match-lambda) ; 지역 매크로만 정의
+            ...)
   ...)
 (progn ... )
 (if test true-expr {{false-expr}})
@@ -168,56 +164,56 @@ lfe> (list-comp
   {{(case ((pat {{(when e ...)}} ... )
           ... ))}}
   {{(catch
-     ; Next must be tuple of length 3!
+     ; 다음은 반드시 길이가 3인 튜플이어야 합니다!
      (((tuple type value ignore) {{(when e ...)}}
       ... )
      ... )}}
   {{(after ... )}})
 
 (funcall func arg ... )
-(call mod func arg ... ) - Call to Erlang Mod:Func(Arg, ... )
+(call mod func arg ... ) - 얼랭 Mod:Func(Arg, ... ) 호출
 (define-module name declaration ... )
-(extend-module declaration ... ) - Define/extend module and declarations.
+(extend-module declaration ... ) - 모듈 및 선언 정의/확장
 (define-function name lambda|match-lambda)
-(define-macro name lambda|match-lambda) - Define functions/macros at top-level.
+(define-macro name lambda|match-lambda) - 최상위 수준에서 함수/매크로 정의
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 3. Macros
+;; 3. 매크로
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Macros are part of the language and allow you to create abstractions
-;; on top of the core language and standard library that move you closer
-;; toward being able to directly express the things you want to express.
+;; 매크로는 언어의 일부이며, 핵심 언어와 표준 라이브러리 위에
+;; 추상화를 생성하여 표현하고자 하는 것을 더 직접적으로
+;; 표현할 수 있도록 해줍니다.
 
-;; Top-level function
+;; 최상위 함수
 
 (defun name (arg ...) ...)
 
-;; Adding comments in functions
+;; 함수에 주석 추가하기
 
 (defun name
-  "Toplevel function with pattern-matching arguments"
+  "패턴 매칭 인수를 사용하는 최상위 함수"
   ((argpat ...) ...)
   ...)
 
-;; Top-level macro
+;; 최상위 매크로
 
 (defmacro name (arg ...) ...)
 (defmacro name arg ...)
 
-;; Top-level macro with pattern matching arguments
+;; 패턴 매칭 인수를 사용하는 최상위 매크로
 
 (defmacro name
   ((argpat ...) ...)
   ...)
 
-;; Top-level macro using Scheme inspired syntax-rules format
+;; 스킴에서 영감을 받은 syntax-rules 형식을 사용하는 최상위 매크로
 
 (defsyntax name
   (pat exp)
   ...)
 
-;;; Local macros in macro or syntax-rule format
+;;; 매크로 또는 syntax-rule 형식의 지역 매크로
 
 (macrolet ((name (arg ... ) ... )
             ... )
@@ -227,45 +223,45 @@ lfe> (list-comp
              ...)
  ...)
 
-;; Like CLISP
+;; CLISP와 유사
 
 (prog1 ...)
 (prog2 ...)
 
-;; Erlang LFE module
+;; 얼랭 LFE 모듈
 
 (defmodule name ...)
 
-;; Erlang LFE record
+;; 얼랭 LFE 레코드
 
 (defrecord name ...)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 4. Patterns and Guards
+;; 4. 패턴과 가드
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Using patterns in LFE compared to that of Erlang
+;; 얼랭과 비교한 LFE에서의 패턴 사용
 
-;; Erlang                     ;; LFE
+;; 얼랭                     ;; LFE
 ;; {ok, X}                       (tuple 'ok x)
 ;; error                         'error
 ;; {yes, [X|Xs]}                 (tuple 'yes (cons x xs))
 ;; <<34,F/float>>                (binary 34 (f float))
 ;; [P|Ps]=All                    (= (cons p ps) all)
 
-  _    ; => is don't care while pattern matching
+  _    ; => 패턴 매칭 시 신경 쓰지 않음
 
-  (= pattern1 pattern2)     ; => easier, better version of pattern matching
+  (= pattern1 pattern2)     ; => 더 쉽고 나은 버전의 패턴 매칭
 
-;; Guards
+;; 가드
 
-;; Whenever pattern occurs (let, case, receive, lc, etc) it can be followed by an optional
-;; guard which has the form (when test ...).
+;; 패턴이 나타날 때마다 (let, case, receive, lc 등) 선택적으로
+;; (when test ...) 형식의 가드를 뒤따를 수 있습니다.
 
-(progn gtest ...)             ;; => Sequence of guard tests
+(progn gtest ...)             ;; => 가드 테스트의 시퀀스
 (if gexpr gexpr gexpr)
 (type-test e)
-(guard-bif ...)               ;; => Guard BIFs, arithmetic, boolean and comparison operators
+(guard-bif ...)               ;; => 가드 BIF, 산술, 불리언 및 비교 연산자
 
 ;;; REPL
 
@@ -274,7 +270,7 @@ lfe>(set (tuple len status msg) #(8 ok "Trillian"))
 lfe>msg
     "Trillian"
 
-;;; Program illustrating use of Guards
+;;; 가드 사용을 보여주는 프로그램
 
 (defun right-number?
         ((x) (when (orelse (== x 42) (== x 276709)))
@@ -282,56 +278,56 @@ lfe>msg
         ((_) 'false))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 5. Functions
+;; 5. 함수
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; A simple function using if.
+;; if를 사용하는 간단한 함수.
 
 (defun max (x y)
-  "The max function."
+  "max 함수."
   (if (>= x y) x y))
 
-;; Same function using more clause
+;; 더 많은 절을 사용하는 동일한 함수
 
 (defun max
-  "The max function."
+  "max 함수."
   ((x y) (when (>= x y)) x)
   ((x y) y))
 
-;; Same function using similar style but using local functions defined by flet or fletrec
+;; 비슷한 스타일이지만 flet 또는 fletrec으로 정의된 지역 함수를 사용하는 동일한 함수
 
 (defun foo (x y)
-  "The max function."
-  (flet ((m (a b) "Local comment."
+  "max 함수."
+  (flet ((m (a b) "지역 주석."
             (if (>= a b) a b)))
     (m x y)))
 
-;; LFE being Lisp-2 has separate namespaces for variables and functions
-;; Both variables and function/macros are lexically scoped.
-;; Variables are bound by lambda, match-lambda and let.
-;; Functions are bound by top-level defun, flet and fletrec.
-;; Macros are bound by top-level defmacro/defsyntax and by macrolet/syntaxlet.
+;; LFE는 Lisp-2이므로 변수와 함수에 대해 별도의 네임스페이스를 가집니다.
+;; 변수와 함수/매크로는 모두 어휘적으로 범위가 지정됩니다.
+;; 변수는 lambda, match-lambda 및 let에 의해 바인딩됩니다.
+;; 함수는 최상위 defun, flet 및 fletrec에 의해 바인딩됩니다.
+;; 매크로는 최상위 defmacro/defsyntax 및 macrolet/syntaxlet에 의해 바인딩됩니다.
 
-;; (funcall func arg ...) like CL to call lambdas/match-lambdas
-;; (funs) bound to variables are used.
+;; (funcall func arg ...)은 CL처럼 람다/매치-람다를 호출하는 데 사용됩니다.
+;; 변수에 바인딩된 (funs)가 사용됩니다.
 
-;; separate bindings and special for apply.
+;; apply를 위한 별도의 바인딩 및 특수.
 apply _F (...),
 apply _F/3 ( a1, a2, a3 )
 
-;; Cons'ing in function heads
+;; 함수 헤드에서의 Cons'ing
 (defun sum (l) (sum l 0))
   (defun sum
     (('() total) total)
     (((cons h t) total) (sum t (+ h total))))
 
-;; ``cons`` literal instead of constructor form
+;; 생성자 형식 대신 cons 리터럴
       (defun sum (l) (sum l 0))
       (defun sum
         (('() total) total)
         ((`(,h . ,t) total) (sum t (+ h total))))
 
-;; Matching records in function heads
+;; 함수 헤드에서 레코드 매칭
 
 (defun handle_info
   (('ping (= (match-state remote-pid 'undefined) state))
@@ -340,20 +336,20 @@ apply _F/3 ( a1, a2, a3 )
   (('ping state)
    `#(noreply ,state)))
 
-;; Receiving Messages
+;; 메시지 수신
       (defun universal-server ()
         (receive
           ((tuple 'become func)
            (funcall func))))
 
-;; another way for receiving messages
+;; 메시지를 수신하는 또 다른 방법
 
  (defun universal-server ()
         (receive
           (`#(become ,func)
             (funcall func))))
 
-;; Composing a complete function for specific tasks
+;; 특정 작업을 위한 완전한 함수 작성
 
 (defun compose (f g)
   (lambda (x)
@@ -369,10 +365,10 @@ apply _F/3 ( a1, a2, a3 )
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 6. Concurrency
+;; 6. 동시성
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Message passing as done by Erlang's light-weight "processes".
+;; 얼랭의 경량 "프로세스"에 의해 수행되는 메시지 전달.
 
 (defmodule messenger-back
  (export (print-result 0) (send-message 2)))
@@ -389,39 +385,39 @@ apply _F/3 ( a1, a2, a3 )
   (let ((spawned-pid (spawn 'messenger-back 'print-result ())))
     (! spawned-pid (tuple calling-pid msg))))
 
-;; Multiple simultaneous HTTP Requests:
+;; 다중 동시 HTTP 요청:
 
 (defun parse-args (flag)
-  "Given one or more command-line arguments, extract the passed values.
+  "하나 이상의 명령줄 인수가 주어지면 전달된 값을 추출합니다.
 
-  For example, if the following was passed via the command line:
+  예를 들어, 명령줄을 통해 다음이 전달된 경우:
 
     $ erl -my-flag my-value-1 -my-flag my-value-2
 
-  One could then extract it in an LFE program by calling this function:
+  그런 다음 LFE 프로그램에서 이 함수를 호출하여 추출할 수 있습니다:
 
     (let ((args (parse-args 'my-flag)))
       ...
       )
-  In this example, the value assigned to the arg variable would be a list
-  containing the values my-value-1 and my-value-2."
+  이 예에서 arg 변수에 할당된 값은 my-value-1 및 my-value-2 값을
+  포함하는 리스트가 됩니다."
   (let ((`#(ok ,data) (init:get_argument flag)))
     (lists:merge data)))
 
 (defun get-pages ()
-  "With no argument, assume 'url parameter was passed via command line."
+  "인수가 없으면 'url 매개변수가 명령줄을 통해 전달되었다고 가정합니다."
   (let ((urls (parse-args 'url)))
     (get-pages urls)))
 
 (defun get-pages (urls)
-  "Start inets and make (potentially many) HTTP requests."
+  "inets를 시작하고 (잠재적으로 많은) HTTP 요청을 만듭니다."
   (inets:start)
   (plists:map
     (lambda (x)
       (get-page x)) urls))
 
 (defun get-page (url)
-  "Make a single HTTP request."
+  "단일 HTTP 요청을 만듭니다."
   (let* ((method 'get)
          (headers '())
          (request-data `#(,url ,headers))
@@ -435,13 +431,13 @@ apply _F/3 ( a1, a2, a3 )
        (io:format "Result: ~p~n" `(,result))))))
 ```
 
-## Further Reading
+## 더 읽을거리
 
 * [LFE DOCS](http://docs.lfe.io)
 * [LFE GitBook](https://lfe.gitbooks.io/reference-guide/index.html)
 * [LFE Wiki](https://en.wikipedia.org/wiki/LFE_(programming_language))
 
-## Extra Info
+## 추가 정보
 
-* [LFE PDF](http://www.erlang-factory.com/upload/presentations/61/Robertvirding-LispFlavouredErlang.pdf)
+* [LFE PDF](http.www.erlang-factory.com/upload/presentations/61/Robertvirding-LispFlavouredErlang.pdf)
 * [LFE mail](https://groups.google.com/d/msg/lisp-flavoured-erlang/XA5HeLbQQDk/TUHabZCHXB0J)

--- a/ko/livescript.md
+++ b/ko/livescript.md
@@ -1,5 +1,3 @@
-# livescript.md (번역)
-
 ---
 name: LiveScript
 filename: learnLivescript.ls
@@ -7,120 +5,111 @@ contributors:
     - ["Christina Whyte", "http://github.com/kurisuwhyte/"]
 ---
 
-LiveScript is a functional compile-to-JavaScript language which shares
-most of the underlying semantics with its host language. Nice additions
-come with currying, function composition, pattern matching and lots of
-other goodies heavily borrowed from languages like Haskell, F# and
-Scala.
+LiveScript는 함수형 자바스크립트 컴파일 언어로, 호스트 언어와 대부분의 기본 의미를 공유합니다. 커링, 함수 합성, 패턴 매칭 및 Haskell, F#, Scala와 같은 언어에서 많이 차용한 다른 좋은 기능들이 추가되었습니다.
 
-LiveScript is a fork of [Coco](https://github.com/satyr/coco), which is
-itself a fork of [CoffeeScript](https://coffeescript.org/).
+LiveScript는 [Coco](https://github.com/satyr/coco)의 포크이며, Coco 자체는 [CoffeeScript](https://coffeescript.org/)의 포크입니다.
 
 ```livescript
-# Just like its CoffeeScript cousin, LiveScript uses number symbols for
-# single-line comments.
+# CoffeeScript 사촌과 마찬가지로 LiveScript는 한 줄 주석에 숫자 기호를 사용합니다.
 
 /*
- Multi-line comments are written C-style. Use them if you want comments
- to be preserved in the JavaScript output.
+ 여러 줄 주석은 C 스타일로 작성됩니다. 주석을 자바스크립트 출력에
+ 보존하고 싶다면 사용하십시오.
  */
 
-# As far as syntax goes, LiveScript uses indentation to delimit blocks,
-# rather than curly braces, and whitespace to apply functions, rather
-# than parenthesis.
+# 구문 측면에서 LiveScript는 블록을 구분하기 위해 중괄호 대신
+# 들여쓰기를 사용하고, 함수를 적용하기 위해 괄호 대신 공백을 사용합니다.
 
 
 ########################################################################
-## 1. Basic values
+## 1. 기본 값
 ########################################################################
 
-# Lack of value is defined by the keyword `void` instead of `undefined`
-void            # same as `undefined` but safer (can't be overridden)
+# 값의 부재는 `undefined` 키워드 대신 `void`로 정의됩니다.
+void            # `undefined`와 같지만 더 안전합니다 (재정의할 수 없음)
 
-# No valid value is represented by Null.
+# 유효하지 않은 값은 Null로 표시됩니다.
 null
 
 
-# The most basic actual value is the logical type:
+# 가장 기본적인 실제 값은 논리 타입입니다:
 true
 false
 
-# And it has a plethora of aliases that mean the same thing:
+# 그리고 같은 의미를 가진 많은 별칭이 있습니다:
 on; off
 yes; no
 
 
-# Then you get numbers. These are double-precision floats like in JS.
+# 그 다음은 숫자입니다. JS에서와 같이 배정밀도 부동 소수점입니다.
 10
-0.4     # Note that the leading `0` is required
+0.4     # 참고: 앞에 `0`이 필요합니다.
 
-# For readability, you may use underscores and letter suffixes in a
-# number, and these will be ignored by the compiler.
+# 가독성을 위해 숫자에 밑줄과 문자 접미사를 사용할 수 있으며,
+# 컴파일러는 이를 무시합니다.
 12_344km
 
 
-# Strings are immutable sequences of characters, like in JS:
-"Christina"             # apostrophes are okay too!
-"""Multi-line
-   strings
-   are
-   okay
-   too."""
+# 문자열은 JS에서와 같이 불변의 문자 시퀀스입니다:
+"Christina"             # 작은따옴표도 괜찮습니다!
+"""여러 줄
+   문자열도
+   괜찮습니다."""
 
-# Sometimes you want to encode a keyword, the backslash notation makes
-# this easy:
+# 때로는 키워드를 인코딩하고 싶을 때가 있는데, 백슬래시 표기법을 사용하면
+# 쉽게 할 수 있습니다:
 \keyword                # => 'keyword'
 
 
-# Arrays are ordered collections of values.
+# 배열은 순서가 있는 값의 컬렉션입니다.
 fruits =
   * \apple
   * \orange
   * \pear
 
-# They can be expressed more concisely with square brackets:
+# 대괄호를 사용하여 더 간결하게 표현할 수 있습니다:
 fruits = [ \apple, \orange, \pear ]
 
-# You also get a convenient way to create a list of strings, using
-# white space to delimit the items.
+# 공백을 사용하여 항목을 구분하는 편리한 방법으로
+# 문자열 목록을 만들 수도 있습니다.
 fruits = <[ apple orange pear ]>
 
-# You can retrieve an item by their 0-based index:
+# 0부터 시작하는 인덱스로 항목을 검색할 수 있습니다:
 fruits[0]       # => "apple"
 
-# Objects are a collection of unordered key/value pairs, and a few other
-# things (more on that later).
+# 객체는 순서가 없는 키/값 쌍의 컬렉션이며, 몇 가지 다른
+# 기능도 있습니다 (나중에 자세히 설명).
 person =
   name: "Christina"
   likes:
     * "kittens"
     * "and other cute stuff"
 
-# Again, you can express them concisely with curly brackets:
+# 다시 말하지만, 중괄호로 간결하게 표현할 수 있습니다:
 person = {name: "Christina", likes: ["kittens", "and other cute stuff"]}
 
-# You can retrieve an item by their key:
+# 키로 항목을 검색할 수 있습니다:
 person.name     # => "Christina"
 person["name"]  # => "Christina"
 
 
-# Regular expressions use the same syntax as JavaScript:
-trailing-space = /\s$/          # dashed-words become dashedWords
+# 정규 표현식은 자바스크립트와 동일한 구문을 사용합니다:
+trailing-space = /\s$/          # 대시-단어는 대시단어(dashedWords)가 됩니다.
 
-# Except you can do multi-line expressions too!
-# (comments and whitespace just gets ignored)
+# 단, 여러 줄 표현식도 가능합니다!
+# (주석과 공백은 무시됩니다)
 funRE = //
-        function\s+(.+)         # name
-        \s* \((.*)\) \s*        # arguments
-        { (.*) }                # body
+        function\s+(.+)         # 이름
+        \s* \((.*)\) \s*        # 인수
+        { (.*) }                # 본문
         //
 
 
 ########################################################################
-## 2. Basic operations
+## 2. 기본 연산
 ########################################################################
 
-# Arithmetic operators are the same as JavaScript's:
+# 산술 연산자는 자바스크립트와 동일합니다:
 1 + 2   # => 3
 2 - 1   # => 1
 2 * 3   # => 6
@@ -128,9 +117,9 @@ funRE = //
 3 % 2   # => 1
 
 
-# Comparisons are mostly the same too, except that `==` is the same as
-# JS's `===`, where JS's `==` in LiveScript is `~=`, and `===` enables
-# object and array comparisons, and also stricter comparisons:
+# 비교도 대부분 동일하지만, `==`는 JS의 `===`와 같고,
+# JS의 `==`는 LiveScript에서 `~=`이며, `===`는
+# 객체 및 배열 비교와 더 엄격한 비교를 가능하게 합니다:
 2 == 2          # => true
 2 == "2"        # => false
 2 ~= "2"        # => true
@@ -142,55 +131,51 @@ funRE = //
 +0 == -0     # => true
 +0 === -0    # => false
 
-# Other relational operators include <, <=, > and >=
+# 다른 관계 연산자에는 <, <=, > 및 >=가 포함됩니다.
 
-# Logical values can be combined through the logical operators `or`,
-# `and` and `not`
+# 논리 값은 `or`, `and`, `not` 논리 연산자를 통해 결합할 수 있습니다.
 true and false  # => false
 false or true   # => true
 not false       # => true
 
 
-# Collections also get some nice additional operators
+# 컬렉션에는 몇 가지 멋진 추가 연산자도 있습니다.
 [1, 2] ++ [3, 4]                # => [1, 2, 3, 4]
 'a' in <[ a b c ]>              # => true
 'name' of { name: 'Chris' }     # => true
 
 
 ########################################################################
-## 3. Functions
+## 3. 함수
 ########################################################################
 
-# Since LiveScript is functional, you'd expect functions to get a nice
-# treatment. In LiveScript it's even more apparent that functions are
-# first class:
+# LiveScript는 함수형이므로 함수가 멋지게 처리될 것으로 기대할 수 있습니다.
+# LiveScript에서는 함수가 일급이라는 것이 더욱 분명합니다:
 add = (left, right) -> left + right
 add 1, 2        # => 3
 
-# Functions which take no arguments are called with a bang!
+# 인수가 없는 함수는 느낌표로 호출됩니다!
 two = -> 2
 two!
 
-# LiveScript uses function scope, just like JavaScript, and has proper
-# closures too. Unlike JavaScript, the `=` works as a declaration
-# operator, and will always declare the variable on the left hand side.
+# LiveScript는 자바스크립트와 마찬가지로 함수 범위를 사용하며 적절한
+# 클로저도 있습니다. 자바스크립트와 달리 `=`는 선언 연산자로
+# 작동하며 항상 왼쪽 변수를 선언합니다.
 
-# The `:=` operator is available to *reuse* a name from the parent
-# scope.
+# `:=` 연산자는 부모 범위의 이름을 *재사용*하는 데 사용할 수 있습니다.
 
 
-# You can destructure arguments of a function to quickly get to
-# interesting values inside a complex data structure:
+# 복잡한 데이터 구조 내의 흥미로운 값에 빠르게 접근하기 위해
+# 함수의 인수를 분해할 수 있습니다:
 tail = ([head, ...rest]) -> rest
 tail [1, 2, 3]  # => [2, 3]
 
-# You can also transform the arguments using binary or unary
-# operators. Default arguments are also possible.
+# 이항 또는 단항 연산자를 사용하여 인수를 변환할 수도 있습니다.
+# 기본 인수도 가능합니다.
 foo = (a = 1, b = 2) -> a + b
 foo!    # => 3
 
-# You could use it to clone a particular argument to avoid side-effects,
-# for example:
+# 예를 들어 부작용을 피하기 위해 특정 인수를 복제하는 데 사용할 수 있습니다:
 copy = (^^target, source) ->
   for k,v of source => target[k] = v
   target
@@ -199,107 +184,100 @@ copy a, { b: 2 }        # => { a: 1, b: 2 }
 a                       # => { a: 1 }
 
 
-# A function may be curried by using a long arrow rather than a short
-# one:
+# 짧은 화살표 대신 긴 화살표를 사용하여 함수를 커링할 수 있습니다:
 add = (left, right) --> left + right
 add1 = add 1
 add1 2          # => 3
 
-# Functions get an implicit `it` argument, even if you don't declare
-# any.
+# 함수는 선언하지 않아도 암시적인 `it` 인수를 갖습니다.
 identity = -> it
 identity 1      # => 1
 
-# Operators are not functions in LiveScript, but you can easily turn
-# them into one! Enter the operator sectioning:
+# 연산자는 LiveScript에서 함수가 아니지만 쉽게 함수로 바꿀 수 있습니다!
+# 연산자 섹셔닝을 입력하십시오:
 divide-by-two = (/ 2)
 [2, 4, 8, 16].map(divide-by-two) .reduce (+)
 
 
-# Not only of function application lives LiveScript, as in any good
-# functional language you get facilities for composing them:
+# LiveScript는 함수 적용뿐만 아니라, 좋은 함수형 언어에서처럼
+# 함수를 합성하는 기능을 제공합니다:
 double-minus-one = (- 1) . (* 2)
 
-# Other than the usual `f . g` mathematical formulae, you get the `>>`
-# and `<<` operators, that describe how the flow of values through the
-# functions.
+# 일반적인 `f . g` 수학 공식 외에도 `>>` 및 `<<` 연산자를 사용하여
+# 함수를 통한 값의 흐름을 설명할 수 있습니다.
 double-minus-one = (* 2) >> (- 1)
 double-minus-one = (- 1) << (* 2)
 
 
-# And talking about flow of value, LiveScript gets the `|>` and `<|`
-# operators that apply a value to a function:
+# 값의 흐름에 대해 말하자면, LiveScript는 값을 함수에 적용하는
+# `|>` 및 `<|` 연산자를 사용합니다:
 map = (f, xs) --> xs.map f
 [1 2 3] |> map (* 2)            # => [2 4 6]
 
-# You can also choose where you want the value to be placed, just mark
-# the place with an underscore (_):
+# 밑줄(_)로 위치를 표시하여 값을 배치할 위치를 선택할 수도 있습니다:
 reduce = (f, xs, initial) --> xs.reduce f, initial
 [1 2 3] |> reduce (+), _, 0     # => 6
 
 
-# The underscore is also used in regular partial application, which you
-# can use for any function:
+# 밑줄은 일반 부분 적용에도 사용되며, 모든 함수에 사용할 수 있습니다:
 div = (left, right) -> left / right
 div-by-two = div _, 2
 div-by-two 4      # => 2
 
 
-# Last, but not least, LiveScript has back-calls, which might help
-# with some callback-based code (though you should try more functional
-# approaches, like Promises):
+# 마지막으로, LiveScript에는 백-콜(back-calls)이 있어 일부 콜백 기반 코드에
+# 도움이 될 수 있습니다(그러나 Promises와 같은 더 기능적인 접근 방식을
+# 시도해야 합니다):
 readFile = (name, f) -> f name
 a <- readFile 'foo'
 b <- readFile 'bar'
 console.log a + b
 
-# Same as:
+# 다음과 동일:
 readFile 'foo', (a) -> readFile 'bar', (b) -> console.log a + b
 
 
 ########################################################################
-## 4. Patterns, guards and control-flow
+## 4. 패턴, 가드 및 제어 흐름
 ########################################################################
 
-# You can branch computations with the `if...else` expression:
+# `if...else` 표현식으로 계산을 분기할 수 있습니다:
 x = if n > 0 then \positive else \negative
 
-# Instead of `then`, you can use `=>`
+# `then` 대신 `=>`를 사용할 수 있습니다.
 x = if n > 0 => \positive
     else        \negative
 
-# Complex conditions are better-off expressed with the `switch`
-# expression, though:
+# 복잡한 조건은 `switch` 표현식으로 더 잘 표현됩니다:
 y = {}
 x = switch
   | (typeof y) is \number => \number
   | (typeof y) is \string => \string
   | 'length' of y         => \array
-  | otherwise             => \object      # `otherwise` and `_` always matches.
+  | otherwise             => \object      # `otherwise`와 `_`는 항상 일치합니다.
 
-# Function bodies, declarations and assignments get a free `switch`, so
-# you don't need to type it again:
+# 함수 본문, 선언 및 할당은 무료 `switch`를 얻으므로
+# 다시 입력할 필요가 없습니다:
 take = (n, [x, ...xs]) -->
                         | n == 0 => []
                         | _      => [x] ++ take (n - 1), xs
 
 
 ########################################################################
-## 5. Comprehensions
+## 5. 컴프리헨션
 ########################################################################
 
-# While the functional helpers for dealing with lists and objects are
-# right there in the JavaScript's standard library (and complemented on
-# the prelude-ls, which is a "standard library" for LiveScript),
-# comprehensions will usually allow you to do this stuff faster and with
-# a nice syntax:
+# 목록 및 객체를 다루기 위한 함수형 도우미는 자바스크립트의 표준 라이브러리에
+# 바로 있으며(그리고 LiveScript의 "표준 라이브러리"인 prelude-ls에서 보완됨),
+# 컴프리헨션을 사용하면 일반적으로 이러한 작업을 더 빠르고 멋진 구문으로
+# 수행할 수 있습니다:
 oneToTwenty = [1 to 20]
 evens       = [x for x in oneToTwenty when x % 2 == 0]
 
-# `when` and `unless` can be used as filters in the comprehension.
+# `when`과 `unless`는 컴프리헨션에서 필터로 사용할 수 있습니다.
 
-# Object comprehension works in the same way, except that it gives you
-# back an object rather than an Array:
+# 객체 컴프리헨션은 배열 대신 객체를 반환한다는 점을 제외하고는
+# 동일한 방식으로 작동합니다:
 copy = { [k, v] for k, v of source }
 
 
@@ -307,9 +285,9 @@ copy = { [k, v] for k, v of source }
 ## 4. OOP
 ########################################################################
 
-# While LiveScript is a functional language in most aspects, it also has
-# some niceties for imperative and object oriented programming. One of
-# them is class syntax and some class sugar inherited from CoffeeScript:
+# LiveScript는 대부분의 측면에서 함수형 언어이지만, 명령형 및
+# 객체 지향 프로그래밍을 위한 몇 가지 좋은 기능도 있습니다. 그 중 하나는
+# CoffeeScript에서 상속받은 클래스 구문과 클래스 슈가입니다:
 class Animal
   (@name, kind) ->
     @kind = kind
@@ -322,9 +300,8 @@ class Cat extends Animal
 kitten = new Cat 'Mei'
 kitten.purr!      # => "*Mei (a cat) purrs*"
 
-# Besides the classical single-inheritance pattern, you can also provide
-# as many mixins as you would like for a class. Mixins are just plain
-# objects:
+# 고전적인 단일 상속 패턴 외에도 클래스에 원하는 만큼 많은
+# 믹스인을 제공할 수 있습니다. 믹스인은 일반 객체일 뿐입니다:
 Huggable =
   hug: -> @action 'is hugged'
 
@@ -334,13 +311,12 @@ kitten = new SnugglyCat 'Purr'
 kitten.hug!     # => "*Mei (a cat) is hugged*"
 ```
 
-## Further reading
+## 더 읽을거리
 
-There's just so much more to LiveScript, but this should be enough to
-get you started writing little functional things in it. The
-[official website](http://livescript.net/) has a lot of information on the
-language, and a nice online compiler for you to try stuff out!
+LiveScript에 대해 더 많은 것이 있지만, 이것으로 작은 기능적인 것들을
+작성하기 시작하기에 충분할 것입니다.
+[공식 웹사이트](http://livescript.net/)에는 언어에 대한 많은 정보와
+시도해 볼 수 있는 멋진 온라인 컴파일러가 있습니다!
 
-You may also want to grab yourself some
-[prelude.ls](http://gkz.github.io/prelude-ls/), and check out the `#livescript`
-channel on the Freenode network.
+[prelude.ls](http://gkz.github.io/prelude-ls/)를 사용해보고, Freenode
+네트워크의 `#livescript` 채널을 확인해 볼 수도 있습니다.

--- a/ko/logtalk.md
+++ b/ko/logtalk.md
@@ -1,5 +1,3 @@
-# logtalk.md (번역)
-
 ---
 name: Logtalk
 filename: learnlogtalk.lgt
@@ -7,29 +5,29 @@ contributors:
     - ["Paulo Moura", "http://github.com/pmoura"]
 ---
 
-Logtalk is an object-oriented logic programming language that extends and leverages Prolog with modern code encapsulation and code reuse mechanisms without compromising its declarative programming features. Logtalk is implemented in highly portable code and can use most modern and standards compliant Prolog implementations as a back-end compiler.
+Logtalk는 선언적 프로그래밍 기능을 손상시키지 않으면서 최신 코드 캡슐화 및 코드 재사용 메커니즘으로 Prolog를 확장하고 활용하는 객체 지향 논리 프로그래밍 언어입니다. Logtalk는 이식성이 뛰어난 코드로 구현되었으며 대부분의 최신 표준 준수 Prolog 구현을 백엔드 컴파일러로 사용할 수 있습니다.
 
-To keep its size reasonable, this tutorial necessarily assumes that the reader have a working knowledge of Prolog and is biased towards describing Logtalk object-oriented features.
+이 튜토리얼은 적절한 크기를 유지하기 위해 독자가 Prolog에 대한 실무 지식을 가지고 있으며 Logtalk 객체 지향 기능을 설명하는 데 편향되어 있다고 가정합니다.
 
-# Syntax
+# 구문
 
-Logtalk uses standard Prolog syntax with the addition of a few operators and directives for a smooth learning curve and wide portability. One important consequence is that Prolog code can be easily encapsulated in objects with little or no changes. Moreover, Logtalk can transparently interpret most Prolog modules as Logtalk objects.
+Logtalk는 원활한 학습 곡선과 넓은 이식성을 위해 몇 가지 연산자와 지시어를 추가한 표준 Prolog 구문을 사용합니다. 한 가지 중요한 결과는 Prolog 코드를 거의 또는 전혀 변경하지 않고 객체에 쉽게 캡슐화할 수 있다는 것입니다. 또한 Logtalk는 대부분의 Prolog 모듈을 Logtalk 객체로 투명하게 해석할 수 있습니다.
 
-The main operators are:
+주요 연산자는 다음과 같습니다:
 
-* `::/2` - sending a message to an object
-* `::/1` - sending a message to _self_ (i.e. to the object that received the message being processed)
-* `^^/1` - _super_ call (of an inherited or imported predicate)
+* `::/2` - 객체에 메시지 보내기
+* `::/1` - _self_에 메시지 보내기 (즉, 처리 중인 메시지를 받은 객체에)
+* `^^/1` - _super_ 호출 (상속되거나 가져온 술어의)
 
-Some of the most important entity and predicate directives will be introduced in the next sections.
+가장 중요한 엔티티 및 술어 지시어 중 일부는 다음 섹션에서 소개됩니다.
 
-# Entities and roles
+# 엔티티와 역할
 
-Logtalk provides _objects_, _protocols_, and _categories_ as first-class entities. Relations between entities define _patterns of code reuse_ and the _roles_ played by the entities. For example, when an object _instantiates_ another object, the first object plays the role of an instance and the second object plays the role of a class. An _extends_ relation between two objects implies that both objects play the role of prototypes, with one of them extending the other, its parent prototype.
+Logtalk는 _객체_, _프로토콜_, _카테고리_를 일급 엔티티로 제공합니다. 엔티티 간의 관계는 _코드 재사용 패턴_과 엔티티가 수행하는 _역할_을 정의합니다. 예를 들어, 한 객체가 다른 객체를 _인스턴스화_할 때 첫 번째 객체는 인스턴스 역할을 하고 두 번째 객체는 클래스 역할을 합니다. 두 객체 간의 _확장_ 관계는 두 객체 모두 프로토타입 역할을 하며, 그중 하나가 다른 하나, 즉 부모 프로토타입을 확장함을 의미합니다.
 
-# Defining an object
+# 객체 정의하기
 
-An object encapsulates predicate declarations and definitions. Objects can be created dynamically but are usually static and defined in source files. A single source file can contain any number of entity definitions. A simple object, defining a list member public predicate:
+객체는 술어 선언과 정의를 캡슐화합니다. 객체는 동적으로 생성될 수 있지만 일반적으로 정적이며 소스 파일에 정의됩니다. 단일 소스 파일에는 여러 엔티티 정의가 포함될 수 있습니다. 리스트 멤버 공개 술어를 정의하는 간단한 객체:
 
 ```logtalk
 :- object(list).
@@ -42,23 +40,20 @@ An object encapsulates predicate declarations and definitions. Objects can be cr
 :- end_object.
 ```
 
-# Compiling and loading source files
+# 소스 파일 컴파일 및 로드
 
-Assuming that the code above for the `list` object is saved in a `list.lgt` file, it can be compiled and loaded using the `logtalk_load/1` built-in predicate or its abbreviation, `{}/1`, with the file path as argument (the extension can be omitted):
+위의 `list` 객체 코드가 `list.lgt` 파일에 저장되어 있다고 가정하면, `logtalk_load/1` 내장 술어 또는 그 약어인 `{}/1`을 사용하여 파일 경로를 인수로 전달하여 컴파일하고 로드할 수 있습니다(확장자는 생략 가능).
 
 ```logtalk
 ?- {list}.
 yes
 ```
 
-In general, entities may have dependencies on entities defined in other source files (e.g. library entities). To load a file and all its dependencies, the advised solution is to define a
-_loader_ file that loads all the necessary files for an application. A loader file is simply a source file, typically named `loader.lgt`, that makes calls to the `logtalk_load/1-2`
-built-in predicates, usually from an `initialization/1` directive for portability and
-standards compliance. Loader files are provided for all libraries, tools, and examples.
+일반적으로 엔티티는 다른 소스 파일(예: 라이브러리 엔티티)에 정의된 엔티티에 대한 종속성을 가질 수 있습니다. 파일과 모든 종속성을 로드하려면, 애플리케이션에 필요한 모든 파일을 로드하는 _로더_ 파일을 정의하는 것이 좋습니다. 로더 파일은 일반적으로 `loader.lgt`라는 이름의 소스 파일이며, 이식성 및 표준 준수를 위해 일반적으로 `initialization/1` 지시어에서 `logtalk_load/1-2` 내장 술어를 호출합니다. 로더 파일은 모든 라이브러리, 도구 및 예제에 제공됩니다.
 
-# Sending a message to an object
+# 객체에 메시지 보내기
 
-The `::/2` infix operator is used to send a message to an object. As in Prolog, we can backtrack for alternative solutions:
+`::/2` 중위 연산자는 객체에 메시지를 보내는 데 사용됩니다. Prolog에서와 같이 대체 솔루션을 위해 백트랙할 수 있습니다:
 
 ```logtalk
 ?- list::member(X, [1,2,3]).
@@ -68,7 +63,7 @@ X = 3
 yes
 ```
 
-Encapsulation is enforced. A predicate can be declared _public_, _protected_, or _private_. It can also be _local_ when there is no scope directive for it. For example:
+캡슐화가 적용됩니다. 술어는 _public_, _protected_ 또는 _private_으로 선언될 수 있습니다. 범위 지시어가 없는 경우 _local_일 수도 있습니다. 예:
 
 ```logtalk
 :- object(scopes).
@@ -81,7 +76,7 @@ Encapsulation is enforced. A predicate can be declared _public_, _protected_, or
 :- end_object.
 ```
 
-Assuming the object is saved in a `scopes.lgt` file:
+객체가 `scopes.lgt` 파일에 저장되어 있다고 가정합니다:
 
 ```logtalk
 ?- {scopes}.
@@ -102,7 +97,7 @@ Error = error(
 yes
 ```
 
-When the predicate in a message is unknown for the object (the role it plays determines the lookup procedures), we also get an error. For example:
+메시지의 술어가 객체에 대해 알려지지 않은 경우(객체가 수행하는 역할이 조회 절차를 결정함)에도 오류가 발생합니다. 예:
 
 ```logtalk
 ?- catch(scopes::unknown, Error, true).
@@ -113,11 +108,11 @@ Error = error(
 yes
 ```
 
-A subtle point is that predicate scope directives specify predicate _calling_ semantics, not _definition_ semantics. For example, if an object playing the role of a class declares a predicate private, the predicate can be defined in subclasses and instances *but* can only be called in its instances _from_ the class.
+미묘한 점은 술어 범위 지시어는 술어 _호출_ 의미를 지정하며 _정의_ 의미가 아니라는 것입니다. 예를 들어, 클래스 역할을 하는 객체가 술어를 private으로 선언하면, 해당 술어는 서브클래스와 인스턴스에서 정의될 수 있지만, 해당 인스턴스에서는 클래스 _에서만_ 호출할 수 있습니다.
 
-# Defining and implementing a protocol
+# 프로토콜 정의 및 구현
 
-Protocols contain predicate declarations that can be implemented by any number of objects and categories:
+프로토콜에는 여러 객체 및 카테고리에서 구현할 수 있는 술어 선언이 포함됩니다:
 
 ```logtalk
 :- protocol(listp).
@@ -136,7 +131,7 @@ Protocols contain predicate declarations that can be implemented by any number o
 :- end_object.
 ```
 
-The scope of the protocol predicates can be restricted using protected or private implementation. For example:
+프로토콜 술어의 범위는 protected 또는 private 구현을 사용하여 제한할 수 있습니다. 예:
 
 ```logtalk
 :- object(stack,
@@ -145,14 +140,14 @@ The scope of the protocol predicates can be restricted using protected or privat
 :- end_object.
 ```
 
-In fact, all entity relations (in an entity opening directive) can be qualified as public (the default), protected, or private.
+실제로 모든 엔티티 관계(엔티티 열기 지시어에서)는 public(기본값), protected 또는 private으로 한정될 수 있습니다.
 
-# Prototypes
+# 프로토타입
 
-An object without an _instantiation_ or _specialization_ relation with another object plays the role of a prototype. A prototype can _extend_ another object, its parent prototype.
+다른 객체와 _인스턴스화_ 또는 _특수화_ 관계가 없는 객체는 프로토타입 역할을 합니다. 프로토타입은 다른 객체, 즉 부모 프로토타입을 _확장_할 수 있습니다.
 
 ```logtalk
-% clyde, our prototypical elephant
+% 우리의 프로토타입 코끼리, clyde
 :- object(clyde).
 
 	:- public(color/1).
@@ -163,7 +158,7 @@ An object without an _instantiation_ or _specialization_ relation with another o
 
 :- end_object.
 
-% fred, another elephant, is like clyde, except that he's white
+% 또 다른 코끼리 fred는 clyde와 같지만 흰색입니다.
 :- object(fred,
 	extends(clyde)).
 
@@ -172,7 +167,7 @@ An object without an _instantiation_ or _specialization_ relation with another o
 :- end_object.
 ```
 
-When answering a message sent to an object playing the role of a prototype, we validate the message and look for an answer first in the prototype itself and, if not found, we delegate to the prototype parents if any:
+프로토타입 역할을 하는 객체로 전송된 메시지에 응답할 때, 우리는 메시지를 확인하고 먼저 프로토타입 자체에서 답을 찾고, 찾지 못하면 부모 프로토타입에 위임합니다:
 
 ```logtalk
 ?- fred::number_of_legs(N).
@@ -184,7 +179,7 @@ C = white
 yes
 ```
 
-A message is valid if the corresponding predicate is declared (and the sender is within scope) but it will fail, rather then throwing an error, if the predicate is not defined. This is called the _closed-world assumption_. For example, consider the following object, saved in a `foo.lgt` file:
+해당 술어가 선언되고(송신자가 범위 내에 있는 경우) 메시지가 유효하지만, 술어가 정의되지 않은 경우 오류를 발생시키는 대신 실패합니다. 이것을 _폐쇄 세계 가정_이라고 합니다. 예를 들어, `foo.lgt` 파일에 저장된 다음 객체를 고려하십시오:
 
 ```logtalk
 :- object(foo).
@@ -194,7 +189,7 @@ A message is valid if the corresponding predicate is declared (and the sender is
 :- end_object.
 ```
 
-Loading the file and trying to call the `bar/0` predicate fails as expected. Note that this is different from calling an _unknown_ predicate, which results in an error:
+파일을 로드하고 `bar/0` 술어를 호출하려고 하면 예상대로 실패합니다. 이것은 _알려지지 않은_ 술어를 호출하는 것과는 다르며, 오류가 발생합니다:
 
 ```logtalk
 ?- {foo}.
@@ -211,12 +206,12 @@ Error = error(
 yes
 ```
 
-# Classes and instances
+# 클래스와 인스턴스
 
-In order to define objects playing the role of classes and/or instances, an object must have at least an instantiation or a specialization relation with another object. Objects playing the role of meta-classes can be used when we need to see a class also as an instance. We use the following example to also illustrate how to dynamically create new objects at runtime:
+클래스 및/또는 인스턴스 역할을 하는 객체를 정의하려면, 객체는 다른 객체와 최소한 하나의 인스턴스화 또는 특수화 관계를 가져야 합니다. 클래스를 인스턴스로도 봐야 할 때 메타클래스 역할을 하는 객체를 사용할 수 있습니다. 다음 예제를 사용하여 런타임에 새 객체를 동적으로 생성하는 방법을 설명합니다:
 
 ```logtalk
-% a simple, generic, metaclass defining a new/2 predicate for its instances
+% 인스턴스에 대한 new/2 술어를 정의하는 간단하고 일반적인 메타클래스
 :- object(metaclass,
 	instantiates(metaclass)).
 
@@ -227,7 +222,7 @@ In order to define objects playing the role of classes and/or instances, an obje
 
 :- end_object.
 
-% a simple class defining age/1 and name/1 predicate for its instances
+% 인스턴스에 대한 age/1 및 name/1 술어를 정의하는 간단한 클래스
 :- object(person,
 	instantiates(metaclass)).
 
@@ -235,12 +230,12 @@ In order to define objects playing the role of classes and/or instances, an obje
 		age/1, name/1
 	]).
 
-	% a default value for age/1
+	% age/1의 기본값
 	age(42).
 
 :- end_object.
 
-% a static instance of the class person
+% person 클래스의 정적 인스턴스
 :- object(john,
 	instantiates(person)).
 
@@ -250,7 +245,7 @@ In order to define objects playing the role of classes and/or instances, an obje
 :- end_object.
 ```
 
-When answering a message sent to an object playing the role of an instance, we validate the message by starting in its class and going up to its class superclasses if necessary. Assuming that the message is valid, then we look for an answer starting in the instance itself:
+인스턴스 역할을 하는 객체로 전송된 메시지에 응답할 때, 클래스에서 시작하여 필요한 경우 클래스 슈퍼클래스까지 올라가서 메시지를 확인합니다. 메시지가 유효하다고 가정하면, 인스턴스 자체에서 시작하여 답을 찾습니다:
 
 ```logtalk
 ?- person::new(Instance, [name(paulo)]).
@@ -270,12 +265,12 @@ Age = 12
 yes
 ```
 
-# Categories
+# 카테고리
 
-A category is a fine grained unit of code reuse, used to encapsulate a _cohesive_ set of predicate declarations and definitions, implementing a _single_ functionality, that can be imported into any object. A category can thus be seen as the dual concept of a protocol. In the following example, we define categories representing car engines and then import them into car objects:
+카테고리는 모든 객체로 가져올 수 있는 _단일_ 기능을 구현하는 _응집력 있는_ 술어 선언 및 정의 집합을 캡슐화하는 데 사용되는 세분화된 코드 재사용 단위입니다. 따라서 카테고리는 프로토콜의 이중 개념으로 볼 수 있습니다. 다음 예에서는 자동차 엔진을 나타내는 카테고리를 정의한 다음 자동차 객체로 가져옵니다:
 
 ```logtalk
-% a protocol describing engine characteristics
+% 엔진 특성을 설명하는 프로토콜
 :- protocol(carenginep).
 
 	:- public([
@@ -289,7 +284,7 @@ A category is a fine grained unit of code reuse, used to encapsulate a _cohesive
 
 :- end_protocol.
 
-% a typical engine defined as a category
+% 카테고리로 정의된 일반적인 엔진
 :- category(classic,
 	implements(carenginep)).
 
@@ -302,19 +297,19 @@ A category is a fine grained unit of code reuse, used to encapsulate a _cohesive
 
 :- end_category.
 
-% a souped up version of the previous engine
+% 이전 엔진의 개조 버전
 :- category(sport,
 	extends(classic)).
 
 	reference('M180.941').
 	horsepower_rpm(HP, RPM) :-
-		^^horsepower_rpm(ClassicHP, ClassicRPM),	% "super" call
+		^^horsepower_rpm(ClassicHP, ClassicRPM),	% "super" 호출
 		HP is truncate(ClassicHP*1.23),
 		RPM is truncate(ClassicRPM*0.762).
 
 :- end_category.
 
-% with engines (and other components), we may start "assembling" some cars
+% 엔진(및 기타 구성 요소)으로 일부 자동차 "조립"을 시작할 수 있습니다.
 :- object(sedan,
 	imports(classic)).
 
@@ -326,7 +321,7 @@ A category is a fine grained unit of code reuse, used to encapsulate a _cohesive
 :- end_object.
 ```
 
-Categories are independently compiled and thus allow importing objects to be updated by simple updating the imported categories without requiring object recompilation. Categories also provide _runtime transparency_. I.e. the category protocol adds to the protocol of the objects importing the category:
+카테고리는 독립적으로 컴파일되므로 객체 재컴파일 없이 가져온 카테고리를 간단히 업데이트하여 가져오는 객체를 업데이트할 수 있습니다. 카테고리는 또한 _런타임 투명성_을 제공합니다. 즉, 카테고리 프로토콜은 카테고리를 가져오는 객체의 프로토콜에 추가됩니다:
 
 ```logtalk
 ?- sedan::current_predicate(Predicate).
@@ -339,9 +334,9 @@ Predicate = fuel/1
 yes
 ```
 
-# Hot patching
+# 핫 패치
 
-Categories can be also be used for hot-patching objects. A category can add new predicates to an object and/or replace object predicate definitions. For example, consider the following object:
+카테고리는 객체를 핫 패치하는 데에도 사용할 수 있습니다. 카테고리는 객체에 새 술어를 추가하거나 객체 술어 정의를 대체할 수 있습니다. 예를 들어, 다음 객체를 고려하십시오:
 
 ```logtalk
 :- object(buggy).
@@ -352,7 +347,7 @@ Categories can be also be used for hot-patching objects. A category can add new 
 :- end_object.
 ```
 
-Assume that the object prints the wrong string when sent the message `p/0`:
+객체가 `p/0` 메시지를 받았을 때 잘못된 문자열을 인쇄한다고 가정합니다:
 
 ```logtalk
 ?- {buggy}.
@@ -363,19 +358,19 @@ foo
 yes
 ```
 
-If the object source code is not available and we need to fix an application running the object code, we can simply define a category that fixes the buggy predicate:
+객체 소스 코드를 사용할 수 없고 객체 코드를 실행하는 애플리케이션을 수정해야 하는 경우, 버그가 있는 술어를 수정하는 카테고리를 간단히 정의할 수 있습니다:
 
 ```logtalk
 :- category(patch,
 	complements(buggy)).
 
-	% fixed p/0 def
+	% 수정된 p/0 정의
 	p :- write(bar).
 
 :- end_category.
 ```
 
-After compiling and loading the category into the running application we will now get:
+실행 중인 애플리케이션에 카테고리를 컴파일하고 로드한 후에는 다음을 얻게 됩니다:
 
 ```logtalk
 ?- set_logtalk_flag(complements, allow).
@@ -389,11 +384,11 @@ bar
 yes
 ```
 
-As hot-patching forcefully breaks encapsulation, the `complements` compiler flag can be set (globally or on a per-object basis) to allow, restrict, or prevent it.
+핫 패치는 캡슐화를 강제로 깨뜨리므로, `complements` 컴파일러 플래그를 (전역적으로 또는 객체별로) 설정하여 허용, 제한 또는 방지할 수 있습니다.
 
-# Parametric objects and categories
+# 매개변수 객체 및 카테고리
 
-Objects and categories can be parameterized by using as identifier a compound term instead of an atom. Object and category parameters are _logical variables_ shared with all encapsulated predicates. An example with geometric circles:
+객체 및 카테고리는 식별자로 원자 대신 복합 항을 사용하여 매개변수화할 수 있습니다. 객체 및 카테고리 매개변수는 모든 캡슐화된 술어와 공유되는 _논리 변수_입니다. 기하학적 원에 대한 예:
 
 ```logtalk
 :- object(circle(_Radius, _Color)).
@@ -413,7 +408,7 @@ Objects and categories can be parameterized by using as identifier a compound te
 :- end_object.
 ```
 
-Parametric objects are used just as any other object, usually providing values for the parameters when sending a message:
+매개변수 객체는 다른 객체와 마찬가지로 사용되며, 일반적으로 메시지를 보낼 때 매개변수 값을 제공합니다:
 
 ```logtalk
 ?- circle(1.23, blue)::area(Area).
@@ -421,7 +416,7 @@ Area = 4.75291
 yes
 ```
 
-Parametric objects also provide a simple way of associating a set of predicates with a plain Prolog predicate. Prolog facts can be interpreted as _parametric object proxies_ when they have the same functor and arity as the identifiers of parametric objects. Handy syntax is provided to for working with proxies. For example, assuming the following clauses for a `circle/2` predicate:
+매개변수 객체는 또한 술어 집합을 일반 Prolog 술어와 연결하는 간단한 방법을 제공합니다. Prolog 사실은 매개변수 객체의 식별자와 동일한 함자 및 인수를 가질 때 _매개변수 객체 프록시_로 해석될 수 있습니다. 프록시 작업을 위한 편리한 구문이 제공됩니다. 예를 들어, `circle/2` 술어에 대한 다음 절을 가정합니다:
 
 ```logtalk
 circle(1.23, blue).
@@ -431,7 +426,7 @@ circle(5.74, black).
 circle(8.32, cyan).
 ```
 
-With these clauses loaded, we can easily compute for example a list with the areas of all the circles:
+이러한 절이 로드되면, 모든 원의 면적 목록을 쉽게 계산할 수 있습니다:
 
 ```logtalk
 ?- findall(Area, {circle(_, _)}::area(Area), Areas).
@@ -439,15 +434,15 @@ Areas = [4.75291, 43.2412, 0.477836, 103.508, 217.468]
 yes
 ```
 
-The `{Goal}::Message` construct proves `Goal`, possibly instantiating any variables in it, and sends `Message` to the resulting term.
+`{Goal}::Message` 구문은 `Goal`을 증명하고(아마도 그 안의 변수를 인스턴스화함), 결과 항에 `Message`를 보냅니다.
 
-# Events and monitors
+# 이벤트와 모니터
 
-Logtalk supports _event-driven programming_ by allowing defining events and monitors for those events. An event is simply the sending of a message to an object. Interpreting message sending as an atomic activity, a _before_ event and an _after_ event are recognized. Event monitors define event handler predicates, `before/3` and `after/3`, and can query, register, and delete a system-wide event registry that associates events with monitors. For example, a simple tracer for any message being sent using the `::/2` control construct can be defined as:
+Logtalk는 이벤트와 해당 이벤트에 대한 모니터를 정의하여 _이벤트 기반 프로그래밍_을 지원합니다. 이벤트는 단순히 객체에 메시지를 보내는 것입니다. 메시지 보내기를 원자적 활동으로 해석하면 _before_ 이벤트와 _after_ 이벤트가 인식됩니다. 이벤트 모니터는 이벤트 핸들러 술어 `before/3` 및 `after/3`을 정의하고, 이벤트를 모니터와 연결하는 시스템 전체 이벤트 레지스트리를 쿼리, 등록 및 삭제할 수 있습니다. 예를 들어, `::/2` 제어 구문을 사용하여 전송되는 모든 메시지에 대한 간단한 추적기는 다음과 같이 정의할 수 있습니다:
 
 ```logtalk
 :- object(tracer,
-	implements(monitoring)).    % built-in protocol for event handlers
+	implements(monitoring)).    % 이벤트 핸들러를 위한 내장 프로토콜
 
 	:- initialization(define_events(_, _, _, _, tracer)).
 
@@ -462,7 +457,7 @@ Logtalk supports _event-driven programming_ by allowing defining events and moni
 :- end_object.
 ```
 
-Assuming that the `tracer` object and the `list` object defined earlier are compiled and loaded, we can observe the event handlers in action by sending a message:
+앞서 정의한 `tracer` 객체와 `list` 객체가 컴파일되고 로드되었다고 가정하면, 메시지를 보내 이벤트 핸들러의 동작을 관찰할 수 있습니다:
 
 ```logtalk
 ?- set_logtalk_flag(events, allow).
@@ -480,13 +475,13 @@ X = 3
 yes
 ```
 
-Events can be set and deleted dynamically at runtime by calling the `define_events/5` and `abolish_events/5` built-in predicates.
+`define_events/5` 및 `abolish_events/5` 내장 술어를 호출하여 런타임에 이벤트를 동적으로 설정하고 삭제할 수 있습니다.
 
-Event-driven programming can be seen as a form of _computational reflection_. But note that events are only generated when using the `::/2` message-sending control construct.
+이벤트 기반 프로그래밍은 _계산적 리플렉션_의 한 형태로 볼 수 있습니다. 그러나 이벤트는 `::/2` 메시지 전송 제어 구문을 사용할 때만 생성된다는 점에 유의하십시오.
 
-# Lambda expressions
+# 람다 표현식
 
-Logtalk supports lambda expressions. Lambda parameters are represented using a list with the `(>>)/2` infix operator connecting them to the lambda. Some simple examples using library `meta`:
+Logtalk는 람다 표현식을 지원합니다. 람다 매개변수는 `(>>)/2` 중위 연산자를 사용하여 람다에 연결된 목록을 사용하여 표현됩니다. 라이브러리 `meta`를 사용한 몇 가지 간단한 예:
 
 ```logtalk
 ?- {meta(loader)}.
@@ -497,7 +492,7 @@ Ys = [2,4,6]
 yes
 ```
 
-Currying is also supported:
+커링도 지원됩니다:
 
 ```logtalk
 ?- meta::map([X]>>([Y]>>(Y is 2*X)), [1,2,3], Ys).
@@ -505,11 +500,11 @@ Ys = [2,4,6]
 yes
 ```
 
-Lambda free variables can be expressed using the extended syntax `{Free1, ...}/[Parameter1, ...]>>Lambda`.
+람다 자유 변수는 확장된 구문 `{Free1, ...}/[Parameter1, ...]>>Lambda`를 사용하여 표현할 수 있습니다.
 
-# Macros
+# 매크로
 
-Terms and goals in source files can be _expanded_ at compile time by specifying a _hook object_ that defines term-expansion and goal-expansion rules. For example, consider the following simple object, saved in a `source.lgt` file:
+소스 파일의 항과 목표는 텀 확장 및 목표 확장 규칙을 정의하는 _후크 객체_를 지정하여 컴파일 타임에 _확장_될 수 있습니다. 예를 들어, `source.lgt` 파일에 저장된 다음 간단한 객체를 고려하십시오:
 
 ```logtalk
 :- object(source).
@@ -522,21 +517,21 @@ Terms and goals in source files can be _expanded_ at compile time by specifying 
 :- end_object.
 ```
 
-Assume the following hook object, saved in a `my_macros.lgt` file, that expands clauses and calls to the `foo/1` local predicate:
+`foo/1` 로컬 술어에 대한 절과 호출을 확장하는 `my_macros.lgt` 파일에 저장된 다음 후크 객체를 가정합니다:
 
 ```logtalk
 :- object(my_macros,
-	implements(expanding)).    % built-in protocol for expanding predicates
+	implements(expanding)).    % 술어 확장을 위한 내장 프로토콜
 
 	term_expansion(foo(Char), baz(Code)) :-
-		char_code(Char, Code). % standard built-in predicate
+		char_code(Char, Code). % 표준 내장 술어
 
 	goal_expansion(foo(X), baz(X)).
 
 :- end_object.
 ```
 
-After loading the macros file, we can then expand our source file with it using the `hook` compiler flag:
+매크로 파일을 로드한 후, `hook` 컴파일러 플래그를 사용하여 소스 파일을 확장할 수 있습니다:
 
 ```logtalk
 ?- logtalk_load(my_macros), logtalk_load(source, [hook(my_macros)]).
@@ -549,8 +544,8 @@ X = 99
 true
 ```
 
-The Logtalk library provides support for combining hook objects using different workflows (for example, defining a pipeline of expansions).
+Logtalk 라이브러리는 다른 워크플로를 사용하여 후크 객체를 결합하는 지원을 제공합니다(예: 확장 파이프라인 정의).
 
-# Further information
+# 추가 정보
 
-Visit the [Logtalk website](http://logtalk.org) for more information.
+자세한 내용은 [Logtalk 웹사이트](http://logtalk.org)를 방문하십시오.

--- a/ko/lolcode.md
+++ b/ko/lolcode.md
@@ -1,5 +1,3 @@
-# lolcode.md (번역)
-
 ---
 name: LOLCODE
 filename: learnLOLCODE.lol
@@ -7,55 +5,54 @@ contributors:
     - ["abactel", "https://github.com/abactel"]
 ---
 
-LOLCODE is an esoteric programming language designed to resemble the speech of [lolcats](https://upload.wikimedia.org/wikipedia/commons/a/ab/Lolcat_in_folder.jpg?1493656347257).
+LOLCODE는 [롤캣](https://upload.wikimedia.org/wikipedia/commons/a/ab/Lolcat_in_folder.jpg?1493656347257)의 말투를 닮도록 설계된 난해한 프로그래밍 언어입니다.
 
 ```
-BTW This is an inline comment
-BTW All code must begin with `HAI <language version>` and end with `KTHXBYE`
+BTW 이건 한 줄 주석임
+BTW 모든 코드는 `HAI <언어 버전>`으로 시작해서 `KTHXBYE`로 끝나야 함
 
 HAI 1.3
-CAN HAS STDIO? BTW Importing standard headers
+CAN HAS STDIO? BTW 표준 헤더 가져오는 중
 
 OBTW
      ==========================================================================
-     ================================= BASICS =================================
+     ================================= 기초 ===================================
      ==========================================================================
 TLDR
 
-BTW Displaying text:
+BTW 텍스트 표시하기:
 VISIBLE "HELLO WORLD"
 
-BTW Declaring variables:
+BTW 변수 선언하기:
 I HAS A MESSAGE ITZ "CATZ ARE GOOD"
 VISIBLE MESSAGE
 
 OBTW
-    (This is a codeblock.) Variables are dynamically typed so you don't need to
-    declare their type. A variable's type matches its content. These are the
-    types:
+    (이건 코드 블록임.) 변수는 동적 타입이라서 타입을 선언할 필요 없음.
+    변수 타입은 내용에 따라 정해짐. 타입 종류는 다음과 같음:
 TLDR
 
-I HAS A STRING  ITZ "DOGZ ARE GOOOD" BTW type is YARN
-I HAS A INTEGER ITZ 42               BTW type is NUMBR
-I HAS A FLOAT   ITZ 3.1415           BTW type is NUMBAR
-I HAS A BOOLEAN ITZ WIN              BTW type is TROOF
-I HAS A UNTYPED                      BTW type is NOOB
+I HAS A STRING  ITZ "DOGZ ARE GOOOD" BTW 타입은 YARN (실)
+I HAS A INTEGER ITZ 42               BTW 타입은 NUMBR (숫자)
+I HAS A FLOAT   ITZ 3.1415           BTW 타입은 NUMBAR (소수)
+I HAS A BOOLEAN ITZ WIN              BTW 타입은 TROOF (진실)
+I HAS A UNTYPED                      BTW 타입은 NOOB (뉴비)
 
-BTW Accepting user input:
+BTW 사용자 입력 받기:
 I HAS A AGE
 GIMMEH AGE
-BTW The variable is stored as a YARN. To convert it into NUMBR:
+BTW 변수는 YARN으로 저장됨. NUMBR로 바꾸려면:
 AGE IS NOW A NUMBR
 
 OBTW
      ==========================================================================
-     ================================== MATH ==================================
+     ================================== 수학 ==================================
      ==========================================================================
 TLDR
 
-BTW LOLCODE uses polish notation style math.
+BTW LOLCODE는 폴란드 표기법 스타일의 수학을 씀.
 
-BTW Basic mathematical notation:
+BTW 기본 수학 표기법:
 
 SUM OF 21 AN 33         BTW 21 + 33
 DIFF OF 90 AN 10        BTW 90 - 10
@@ -65,19 +62,19 @@ MOD OF 43 AN 64         BTW 43 modulo 64
 BIGGR OF 23 AN 53       BTW max(23, 53)
 SMALLR OF 53 AN 45      BTW min(53, 45)
 
-BTW Binary notation:
+BTW 2진 표기법:
 
-BOTH OF WIN AN WIN           BTW and: WIN if x=WIN, y=WIN
-EITHER OF FAIL AN WIN        BTW or: FAIL if x=FAIL, y=FAIL
-WON OF WIN AN FAIL           BTW xor: FAIL if x=y
-NOT FAIL                     BTW unary negation: WIN if x=FAIL
-ALL OF WIN AN WIN MKAY   BTW infinite arity AND
-ANY OF WIN AN FAIL MKAY  BTW infinite arity OR
+BOTH OF WIN AN WIN           BTW 그리고: x=WIN, y=WIN이면 WIN
+EITHER OF FAIL AN WIN        BTW 또는: x=FAIL, y=FAIL이면 FAIL
+WON OF WIN AN FAIL           BTW xor: x=y이면 FAIL
+NOT FAIL                     BTW 단항 부정: x=FAIL이면 WIN
+ALL OF WIN AN WIN MKAY   BTW 무한 인수 AND
+ANY OF WIN AN FAIL MKAY  BTW 무한 인수 OR
 
-BTW Comparison:
+BTW 비교:
 
-BOTH SAEM "CAT" AN "DOG"             BTW WIN if x == y
-DIFFRINT 732 AN 184                  BTW WIN if x != y
+BOTH SAEM "CAT" AN "DOG"             BTW x == y 이면 WIN
+DIFFRINT 732 AN 184                  BTW x != y 이면 WIN
 BOTH SAEM 12 AN BIGGR OF 12 AN 4     BTW x >= y
 BOTH SAEM 43 AN SMALLR OF 43 AN 56   BTW x <= y
 DIFFRINT 64 AN SMALLR OF 64 AN 2     BTW x > y
@@ -85,41 +82,41 @@ DIFFRINT 75 AN BIGGR OF 75 AN 643    BTW x < y
 
 OBTW
      ==========================================================================
-     ============================== FLOW CONTROL ==============================
+     ============================== 흐름 제어 ==============================
      ==========================================================================
 TLDR
 
-BTW If/then statement:
+BTW If/then 문:
 I HAS A ANIMAL
 GIMMEH ANIMAL
 BOTH SAEM ANIMAL AN "CAT", O RLY?
     YA RLY
-        VISIBLE "YOU HAV A CAT"
+        VISIBLE "고양이가 있군요"
     MEBBE BOTH SAEM ANIMAL AN "MAUS"
-        VISIBLE "NOM NOM NOM. I EATED IT."
+        VISIBLE "냠냠냠. 내가 먹었음."
     NO WAI
-        VISIBLE "AHHH IS A WOOF WOOF"
+        VISIBLE "으악 멍멍이다"
 OIC
 
-BTW Case statement:
+BTW Case 문:
 I HAS A COLOR
 GIMMEH COLOR
 COLOR, WTF?
     OMG "R"
-        VISIBLE "RED FISH"
+        VISIBLE "빨간 물고기"
         GTFO
     OMG "Y"
-        VISIBLE "YELLOW FISH"
-        BTW Since there is no `GTFO` the next statements will also be tested
+        VISIBLE "노란 물고기"
+        BTW `GTFO`가 없어서 다음 문장도 테스트될 거임
     OMG "G"
     OMG "B"
-        VISIBLE "FISH HAS A FLAVOR"
+        VISIBLE "물고기는 맛이 있음"
         GTFO
     OMGWTF
-        VISIBLE "FISH IS TRANSPARENT OHNO WAT"
+        VISIBLE "물고기가 투명해 오노 왓"
 OIC
 
-BTW For loop:
+BTW For 반복문:
 I HAS A TEMPERATURE
 GIMMEH TEMPERATURE
 TEMPERATURE IS NOW A NUMBR
@@ -127,61 +124,61 @@ IM IN YR LOOP UPPIN YR ITERATOR TIL BOTH SAEM ITERATOR AN TEMPERATURE
     VISIBLE ITERATOR
 IM OUTTA YR LOOP
 
-BTW While loop:
+BTW While 반복문:
 IM IN YR LOOP NERFIN YR ITERATOR WILE DIFFRINT ITERATOR AN -10
     VISIBLE ITERATOR
 IM OUTTA YR LOOP
 
 OBTW
      =========================================================================
-     ================================ Strings ================================
+     =============================== 문자열 ================================
      =========================================================================
 TLDR
 
-BTW Linebreaks:
-VISIBLE "FIRST LINE :) SECOND LINE"
+BTW 줄바꿈:
+VISIBLE "첫 번째 줄 :) 두 번째 줄"
 
-BTW Tabs:
-VISIBLE ":>SPACES ARE SUPERIOR"
+BTW 탭:
+VISIBLE ":>공백이 최고임"
 
-BTW Bell (goes beep):
-VISIBLE "NXT CUSTOMER PLS :o"
+BTW 벨 (삑 소리 남):
+VISIBLE "다음 손님 오세요 :o"
 
-BTW Literal double quote:
-VISIBLE "HE SAID :"I LIKE CAKE:""
+BTW 리터럴 큰따옴표:
+VISIBLE "그가 말했음 :"나는 케이크를 좋아해:""
 
-BTW Literal colon:
-VISIBLE "WHERE I LIVE:: CYBERSPACE"
+BTW 리터럴 콜론:
+VISIBLE "내가 사는 곳:: 사이버 공간"
 
 OBTW
      =========================================================================
-     =============================== FUNCTIONS ===============================
+     =============================== 함수 ===============================
      =========================================================================
 TLDR
 
-BTW Declaring a new function:
-HOW IZ I SELECTMOVE YR MOVE BTW `MOVE` is an argument
+BTW 새 함수 선언하기:
+HOW IZ I SELECTMOVE YR MOVE BTW `MOVE`는 인수임
     BOTH SAEM MOVE AN "ROCK", O RLY?
         YA RLY
-            VISIBLE "YOU HAV A ROCK"
+            VISIBLE "바위가 있군요"
         NO WAI
-            VISIBLE "OH NO IS A SNIP-SNIP"
+            VISIBLE "오노 가위-가위다"
     OIC
-    GTFO BTW This returns NOOB
+    GTFO BTW 이건 NOOB를 반환함
 IF U SAY SO
 
-BTW Declaring a function and returning a value:
+BTW 함수 선언하고 값 반환하기:
 HOW IZ I IZYELLOW
     FOUND YR "YELLOW"
 IF U SAY SO
 
-BTW Calling a function:
+BTW 함수 호출하기:
 I IZ IZYELLOW MKAY
 
 KTHXBYE
 ```
 
-## Further reading:
+## 더 읽을거리:
 
-- [LCI compiler](https://github.com/justinmeza/lci)
-- [Official spec](https://github.com/justinmeza/lolcode-spec/blob/master/v1.2/lolcode-spec-v1.2.md)
+- [LCI 컴파일러](https://github.com/justinmeza/lci)
+- [공식 사양](https://github.com/justinmeza/lolcode-spec/blob/master/v1.2/lolcode-spec-v1.2.md)

--- a/ko/m.md
+++ b/ko/m.md
@@ -1,5 +1,3 @@
-# m.md (번역)
-
 ---
 name: M (MUMPS)
 contributors:
@@ -7,111 +5,97 @@ contributors:
 filename: LEARNM.m
 ---
 
-M, or MUMPS (Massachusetts General Hospital Utility Multi-Programming System) is
-a procedural language with a built-in NoSQL database. Or, it’s a database with
-an integrated language optimized for accessing and manipulating that database.
-A key feature of M is that accessing local variables in memory and persistent
-storage use the same basic syntax, so there's no separate query
-language to remember. This makes it fast to program with, especially for
-beginners. M's syntax was designed to be concise in an era where
-computer memory was expensive and limited. This concise style means that a lot
-more fits on one screen without scrolling.
+M 또는 MUMPS(Massachusetts General Hospital Utility Multi-Programming System)는 내장 NoSQL 데이터베이스가 있는 절차적 언어입니다. 또는 데이터베이스에 접근하고 조작하는 데 최적화된 통합 언어가 있는 데이터베이스입니다. M의 주요 특징은 메모리의 지역 변수와 영구 저장소에 접근하는 데 동일한 기본 구문을 사용하므로 별도의 쿼리 언어를 기억할 필요가 없다는 것입니다. 이로 인해 특히 초보자에게 프로그래밍이 빠릅니다. M의 구문은 컴퓨터 메모리가 비싸고 제한적이었던 시대에 간결하게 설계되었습니다. 이 간결한 스타일은 스크롤 없이 한 화면에 더 많은 내용을 담을 수 있다는 것을 의미합니다.
 
-The M database is a hierarchical key-value store designed for high-throughput
-transaction processing. The database is organized into tree structures called
-"globals", (for global variables) which are sparse data structures with parallels
-to modern formats like JSON.
+M 데이터베이스는 높은 처리량의 트랜잭션 처리를 위해 설계된 계층적 키-값 저장소입니다. 데이터베이스는 "글로벌"(전역 변수용)이라는 트리 구조로 구성되며, 이는 JSON과 같은 최신 형식과 유사한 희소 데이터 구조입니다.
 
-Originally designed in 1966 for the healthcare applications, M continues to be
-used widely by healthcare systems and financial institutions for high-throughput
-real-time applications.
+원래 1966년 의료 애플리케이션을 위해 설계된 M은 의료 시스템 및 금융 기관에서 높은 처리량의 실시간 애플리케이션을 위해 계속 널리 사용되고 있습니다.
 
-### Example
+### 예제
 
-Here's an example M program using expanded syntax to calculate the Fibonacci series:
+다음은 확장된 구문을 사용하여 피보나치 수열을 계산하는 M 프로그램의 예입니다:
 
 ```
-fib ; compute the first few Fibonacci terms
+fib ; 첫 몇 개의 피보나치 항 계산
     new i,a,b,sum
-    set (a,b)=1 ; Initial conditions
+    set (a,b)=1 ; 초기 조건
     for i=1:1 do  quit:sum>1000
     . set sum=a+b
     . write !,sum
     . set a=b,b=sum
 ```
 
-### Comments
-Comments in M need at least one space before the comment marker of semicolon.
-Comments that start with at least two semicolons (;;) are guaranteed to be accessible
-within a running program.
+### 주석
+M의 주석은 세미콜론 주석 마커 앞에 최소 한 칸의 공백이 필요합니다.
+최소 두 개의 세미콜론(;;)으로 시작하는 주석은 실행 중인 프로그램 내에서 접근할 수 있음이 보장됩니다.
 
 ```
- ;   Comments start with a semicolon (;)
+ ;   주석은 세미콜론(;)으로 시작합니다.
 ```
 
-### Data Types
+### 데이터 타입
 
-M has one data type (String) and three interpretations of that string.:
+M에는 하나의 데이터 타입(문자열)과 해당 문자열에 대한 세 가지 해석이 있습니다.:
 
 ```
-;   Strings - Characters enclosed in double quotes.
-;       "" is the null string. Use "" within a string for "
-;       Examples: "hello", "Scrooge said, ""Bah, Humbug!"""
+;   문자열 - 큰따옴표로 묶인 문자.
+;       ""는 null 문자열입니다. 문자열 내에서 "를 사용하려면 ""를 사용하십시오.
+;       예: "hello", "Scrooge said, ""Bah, Humbug!"""
 ;
-;   Numbers - no commas, leading and trailing 0 removed.
-;       Scientific notation with 'E'.  (not 'e')
-;       Numbers with at least with IEEE 754 double-precision values (guaranteed 15 digits of precision)
-;       Examples: 20 (stored as 20) , 1e3 (stored as 1000), 0500.20 (stored as 500.2),
-;                 the US National Debt AT sometime on 12-OCT-2020 retrieved from http://www.usdebt.org is 27041423576201.15)
-;                     (required to be stored as at least 27041422576201.10 but most implementations store as 27041432576201.15)
+;   숫자 - 쉼표 없음, 앞뒤 0 제거.
+;       'E'를 사용한 과학적 표기법 ('e'가 아님).
+;       최소 IEEE 754 배정밀도 값을 가짐(15자리 정밀도 보장).
+;       예: 20 (20으로 저장됨), 1e3 (1000으로 저장됨), 0500.20 (500.2로 저장됨),
+;                 2020년 10월 12일 http://www.usdebt.org에서 검색한 미국 국가 부채는 27041423576201.15입니다)
+;                     (최소 27041422576201.10으로 저장되어야 하지만 대부분의 구현에서는 27041432576201.15로 저장합니다)
 ;
-;   Truthvalues - String interpreted as 0  is used for false and any string interpreted as non-zero (such as 1) for true.
+;   진리값 - 0으로 해석되는 문자열은 false로 사용되고, 0이 아닌 값(예: 1)으로 해석되는 모든 문자열은 true로 사용됩니다.
 ```
 
-### Commands
+### 명령어
 
-Commands are case insensitive, and have full form, and a shortened abbreviation, often the first letter. Commands have zero or more arguments,depending on the command. This page includes programs written in this terse syntax. M is whitespace-aware. Spaces are treated as a delimiter between commands and arguments. Each command is separated from its arguments by 1 space. Commands with zero arguments are followed by 2 spaces. (technically these are called argumentless commands)
+명령어는 대소문자를 구분하지 않으며, 전체 형식과 종종 첫 글자로 된 축약형이 있습니다. 명령어는 명령어에 따라 0개 이상의 인수를 가집니다. 이 페이지에는 이 간결한 구문으로 작성된 프로그램이 포함되어 있습니다. M은 공백을 인식합니다. 공백은 명령어와 인수 사이의 구분 기호로 처리됩니다. 각 명령어는 인수와 1개의 공백으로 구분됩니다. 인수가 없는 명령어 뒤에는 2개의 공백이 옵니다. (기술적으로 이것을 인수 없는 명령어라고 합니다)
 
-#### Common Commands from all National and International Standards of M
+#### 모든 국내 및 국제 M 표준의 공통 명령어
 
-#### Write (abbreviated as W)
+#### Write (W로 축약)
 
-Print data to the current device.
+현재 장치에 데이터 인쇄.
 
 ```
 WRITE !,"hello world"
 ```
 
-Output Formatting characters:
+출력 서식 문자:
 
- The ! character is syntax for a new line.
- The # character is syntax for a new page.
- The sequence of the ? character and then a numeric expression is syntax for output of spaces until the number'th colum is printed.
+ ! 문자는 새 줄에 대한 구문입니다.
+ # 문자는 새 페이지에 대한 구문입니다.
+ ? 문자와 숫자 표현식의 시퀀스는 해당 숫자 열이 인쇄될 때까지 공백을 출력하는 구문입니다.
 
-Multiple statements can be provided as additional arguments before the space separators to the next command:
+다음 명령어로 가기 전 공백 구분자 앞에 여러 문장을 추가 인수로 제공할 수 있습니다:
 
 ```
 w !,"foo bar"," ","baz"
 ```
 
-#### Read (abbreviated as R)
+#### Read (R로 축약)
 
-Retrieve input from the user
+사용자로부터 입력 검색
 
 ```
 READ var
-r !,"Wherefore art thou Romeo? ",why
+r !,"로미오, 왜 그대는 로미오인가요? ",why
 ```
 
-As with all M commands, multiple arguments can be passed to a read command. Constants like quoted strings, numbers, and formatting characters are output directly. Values for both global variables and local variables are retrieved from the user. The terminal waits for the user to enter the first variable before displaying the second prompt.
+모든 M 명령어와 마찬가지로 read 명령어에도 여러 인수를 전달할 수 있습니다. 따옴표로 묶인 문자열, 숫자, 서식 문자와 같은 상수는 직접 출력됩니다. 전역 변수와 지역 변수의 값은 모두 사용자로부터 검색됩니다. 터미널은 사용자가 첫 번째 변수를 입력할 때까지 기다렸다가 두 번째 프롬프트를 표시합니다.
 
 ```
-r !,"Better one, or two? ",lorem," Better two, or three? ",ipsum
+r !,"첫 번째가 낫나요, 두 번째가 낫나요? ",lorem," 두 번째가 낫나요, 세 번째가 낫나요? ",ipsum
 ```
 
-#### Set (abbreviated as S)
+#### Set (S로 축약)
 
-Assign a value to a variable
+변수에 값 할당
 
 ```
 SET name="Benjamin Franklin"
@@ -122,23 +106,23 @@ w !,centi,!,micro
 ;.00001
 ```
 
-#### Kill (abbreviated as K)
+#### Kill (K로 축약)
 
-Remove a variable from memory or remove a database entry from disk.
-A database node (global variable) is killed depending on the variable name being prefixed by the caret character (^).
-If it is not, then the local variable is removed from memory.
-If KILLed, automatic garbage collection occurs.
+메모리에서 변수를 제거하거나 디스크에서 데이터베이스 항목을 제거합니다.
+데이터베이스 노드(전역 변수)는 변수 이름 앞에 캐럿 문자(^)가 붙는지 여부에 따라 제거됩니다.
+그렇지 않으면 지역 변수가 메모리에서 제거됩니다.
+KILL되면 자동 가비지 수집이 발생합니다.
 
 ```
 KILL centi
 k micro
 ```
 
-### Globals and Arrays
+### 전역 변수와 배열
 
-In addition to local variables, M has persistent, shared variables that are the built-in database of M.  They are stored to disk and called _globals_. Global names must start with a __caret__ (__^__).
+지역 변수 외에도 M에는 M의 내장 데이터베이스인 영구 공유 변수가 있습니다. 이들은 디스크에 저장되며 _글로벌_이라고 합니다. 전역 이름은 반드시 __캐럿__(__^__)으로 시작해야 합니다.
 
-Any variable (local or global) can be an array with the assignment of a _subscript_. Arrays are sparse and do not have a predefined size. Only if data is stored will a value use memory. Arrays should be visualized like trees, where subscripts are branches and assigned values are leaves. Not all nodes in an array need to have a value.
+모든 변수(지역 또는 전역)는 _아래 첨자_를 할당하여 배열이 될 수 있습니다. 배열은 희소하며 미리 정의된 크기가 없습니다. 데이터가 저장된 경우에만 값이 메모리를 사용합니다. 배열은 아래 첨자가 분기이고 할당된 값이 잎인 트리처럼 시각화해야 합니다. 배열의 모든 노드에 값이 있어야 하는 것은 아닙니다.
 
 ```
 s ^cars=20
@@ -149,91 +133,91 @@ s ^cars("Tesla",2,"Doors")=5
 w !,^cars
 ; 20
 w !,^cars("Tesla")
-; null value - there's no value assigned to this node but it has children
+; null 값 - 이 노드에는 값이 할당되지 않았지만 자식이 있습니다.
 w !,^cars("Tesla",1,"Name")
 ; Model 3
 ```
 
-The index values of Arrays are automatically sorted in order. There is a catchphrase of "MUMPS means never having to say you are sorting". Take advantage of the built-in sorting by setting your value of interest as the last child subscript of an array rather than its value, and then storing an empty string for that node.
+배열의 인덱스 값은 자동으로 정렬됩니다. "MUMPS는 정렬한다고 말할 필요가 없다는 것을 의미한다"는 캐치프레이즈가 있습니다. 관심 있는 값을 값 대신 배열의 마지막 자식 아래 첨자로 설정한 다음 해당 노드에 빈 문자열을 저장하여 내장 정렬을 활용하십시오.
 
 ```
-; A log of temperatures by date and time
+; 날짜 및 시간별 온도 기록
 s ^TEMPS("11/12","0600",32)=""
 s ^TEMPS("11/12","1030",48)=""
 s ^TEMPS("11/12","1400",49)=""
 s ^TEMPS("11/12","1700",43)=""
 ```
 
-### Operators
+### 연산자
 
 ```
-; Assignment:       =
-; Unary:            +   Convert a string value into a numeric value.
-; Arthmetic:
-;                   +   addition
-;                   -   subtraction
-;                   *   multiplication
-;                   /   floating-point division
-;                   \   integer division
-;                   #   modulo
-;                   **  exponentiation
-; Logical:
+; 할당:       =
+; 단항:            +   문자열 값을 숫자 값으로 변환합니다.
+; 산술:
+;                   +   덧셈
+;                   -   뺄셈
+;                   *   곱셈
+;                   /   부동 소수점 나눗셈
+;                   \   정수 나눗셈
+;                   #   모듈로
+;                   **  거듭제곱
+; 논리:
 ;                   &   and
 ;                   !   or
 ;                   '   not
-; Comparison:
-;                   =   equal
-;                   '=  not equal
-;                   >   greater than
-;                   <   less than
-;                   '>  not greater / less than or equal to
-;                   '<  not less / greater than or equal to
-; String operators:
-;                   _   concatenate
-;                   [   contains ­          a contains b
-;                   ]]  sorts after  ­      a comes after b
-;                   '[  does not contain
-;                   ']] does not sort after
+; 비교:
+;                   =   같음
+;                   '=  같지 않음
+;                   >   보다 큼
+;                   <   보다 작음
+;                   '>  크지 않음 / 작거나 같음
+;                   '<  작지 않음 / 크거나 같음
+; 문자열 연산자:
+;                   _   연결
+;                   [   포함           a는 b를 포함
+;                   ]]  정렬 후         a는 b 뒤에 옴
+;                   '[  포함하지 않음
+;                   ']] 정렬 후가 아님
 ```
 
-#### Order of operations
+#### 연산 순서
 
-Operations in M are _strictly_ evaluated left to right. No operator has precedence over any other.
-For example, there is NO order of operations where multiply is evaluated before addition.
-To change this order, just use parentheses to group expressions to be evaluated first.
+M의 연산은 _엄격하게_ 왼쪽에서 오른쪽으로 평가됩니다. 다른 연산자보다 우선 순위가 높은 연산자는 없습니다.
+예를 들어, 덧셈보다 곱셈이 먼저 평가되는 연산 순서는 없습니다.
+이 순서를 변경하려면 괄호를 사용하여 먼저 평가할 표현식을 그룹화하면 됩니다.
 
 ```
 w 5+3*20
 ;160
-;You probably wanted 65
+;아마 65를 원했을 것입니다.
 write 5+(3*20)
 ```
 
-### Flow Control, Blocks, & Code Structure
+### 흐름 제어, 블록 및 코드 구조
 
-A single M file is called a _routine_. Within a given routine, you can break your code up into smaller chunks with _tags_. The tag starts in column 1 and the commands pertaining to that tag are indented.
+단일 M 파일을 _루틴_이라고 합니다. 주어진 루틴 내에서 코드를 _태그_를 사용하여 더 작은 덩어리로 나눌 수 있습니다. 태그는 1열에서 시작하고 해당 태그에 관련된 명령어는 들여쓰기됩니다.
 
-A tag can accept parameters and return a value, this is a function. A function is called with '$$':
+태그는 매개변수를 받고 값을 반환할 수 있으며, 이것이 함수입니다. 함수는 '$$'로 호출됩니다:
 
 ```
-; Execute the 'tag' function, which has two parameters, and write the result.
+; 'tag' 함수를 실행하고, 두 개의 매개변수를 가지며, 결과를 씁니다.
 w !,$$tag^routine(a,b)
 ```
 
-M has an execution stack. When all levels of the stack have returned, the program ends. Levels are added to the stack with _do_ commands and removed with _quit_ commands.
+M에는 실행 스택이 있습니다. 스택의 모든 수준이 반환되면 프로그램이 종료됩니다. 수준은 _do_ 명령어로 스택에 추가되고 _quit_ 명령어로 제거됩니다.
 
-#### Do (abbreviated as D)
+#### Do (D로 축약)
 
-With an argument: execute a block of code & add a level to the stack.
+인수 사용: 코드 블록을 실행하고 스택에 수준을 추가합니다.
 
 ```
-d ^routine    ;run a routine from the beginning.
-;             ;routines are identified by a caret.
-d tag         ;run a tag in the current routine
-d tag^routine ;run a tag in different routine
+d ^routine    ;루틴을 처음부터 실행합니다.
+;             ;루틴은 캐럿으로 식별됩니다.
+d tag         ;현재 루틴에서 태그를 실행합니다.
+d tag^routine ;다른 루틴에서 태그를 실행합니다.
 ```
 
-Argumentless do: used to create blocks of code. The block is indented with a period for each level of the block:
+인수 없는 do: 코드 블록을 만드는 데 사용됩니다. 블록은 블록의 각 수준에 대해 마침표로 들여쓰기됩니다:
 
 ```
 set a=1
@@ -245,61 +229,61 @@ if a=1 do
 w "hello"
 ```
 
-#### Quit (abbreviated as Q)
-Stop executing this block and return to the previous stack level.
-Quit can return a value, following the comamnd with a single space.
-Quit can stop a loop. remember to follow with two spaces.
-Quit outside a loop will return from the current subroutine followed by two spaces or a linefeed
+#### Quit (Q로 축약)
+이 블록 실행을 중지하고 이전 스택 수준으로 돌아갑니다.
+Quit는 명령어 뒤에 단일 공백을 붙여 값을 반환할 수 있습니다.
+Quit는 루프를 중지할 수 있습니다. 두 개의 공백을 붙이는 것을 잊지 마십시오.
+루프 외부의 Quit는 현재 서브루틴에서 반환되며 두 개의 공백이나 개행 문자가 뒤따릅니다.
 
-#### New (abbreviated as N)
-Hide with a cleared value a given variable's value _for just this stack level_. Useful for preventing side effects.
+#### New (N로 축약)
+주어진 변수의 값을 _이 스택 수준에서만_ 지워진 값으로 숨깁니다. 부작용을 방지하는 데 유용합니다.
 
-Putting all this together, we can create a full example of an M routine:
+이 모든 것을 종합하여 M 루틴의 전체 예를 만들 수 있습니다:
 
 ```
-; RECTANGLE - a routine to deal with rectangle math
-    q ; quit if a specific tag is not called
+; RECTANGLE - 사각형 수학을 다루는 루틴
+    q ; 특정 태그가 호출되지 않으면 종료
 
 main
-    n length,width ; New length and width so any previous value doesn't persist
-    w !,"Welcome to RECTANGLE. Enter the dimensions of your rectangle."
-    r !,"Length? ",length,!,"Width? ",width
-    d area(length,width)            ;Do/Call subroutine using a tag
-    s per=$$perimeter(length,width)      ;Get the value of a function
-    w !,"Perimeter: ",per
+    n length,width ; 이전 값이 유지되지 않도록 새 길이와 너비
+    w !,"RECTANGLE에 오신 것을 환영합니다. 사각형의 치수를 입력하십시오."
+    r !,"길이? ",length,!,"너비? ",width
+    d area(length,width)            ;태그를 사용하여 서브루틴 호출/실행
+    s per=$$perimeter(length,width)      ;함수 값 가져오기
+    w !,"둘레: ",per
     quit
 
-area(length,width)  ; This is a tag that accepts parameters.
-                    ; It's not a function since it quits with no value.
-    w !, "Area: ",length*width
-    q  ; Quit: return to the previous level of the stack.
+area(length,width)  ; 매개변수를 받는 태그입니다.
+                    ; 값이 없이 종료되므로 함수가 아닙니다.
+    w !, "면적: ",length*width
+    q  ; 종료: 스택의 이전 수준으로 돌아갑니다.
 
 perimeter(length,width)
-    q 2*(length+width) ; Returns a value using Quit ; this is a function
+    q 2*(length+width) ; Quit를 사용하여 값을 반환합니다. ; 이것은 함수입니다.
 ```
 
 
 
-### Conditionals, Looping and $Order()
+### 조건문, 반복문 및 $Order()
 
-F(or) loops can follow a few different patterns:
+F(or) 루프는 몇 가지 다른 패턴을 따를 수 있습니다:
 
 ```jinja
-;Finite loop with counter
+;카운터가 있는 유한 루프
 ;f var=start:increment:stop
 
 f i=0:5:25 w i," "
 ;0 5 10 15 20 25
 
-; Infinite loop with counter
-; The counter will keep incrementing forever. Use a conditional with Quit to get out of the loop.
+; 카운터가 있는 무한 루프
+; 카운터는 영원히 증가합니다. 루프를 빠져나가려면 조건부 Quit를 사용하십시오.
 ;f var=start:increment
 
 f j=1:1 w j," " i j>1E3 q
-; Print 1-1000 separated by a space
+; 공백으로 구분된 1-1000 인쇄
 
-;Argumentless for - infinite loop. Use a conditional with Quit.
-;   Also read as "forever" - f or for followed by two spaces.
+;인수 없는 for - 무한 루프. 조건부 Quit를 사용하십시오.
+;   "영원히"로도 읽습니다 - f 또는 for 뒤에 두 개의 공백.
 s var=""
 f  s var=var_"%" w !,var i var="%%%%%%%%%%" q
 ; %
@@ -314,94 +298,94 @@ f  s var=var_"%" w !,var i var="%%%%%%%%%%" q
 ; %%%%%%%%%%
 ```
 
-#### I(f), E(lse), Postconditionals
+#### I(f), E(lse), 후조건
 
-M has an if/else construct for conditional evaluation, but any command can be conditionally executed without an extra if statement using a _postconditional_. This is a condition that occurs immediately after the command, separated with a colon (:).
+M에는 조건부 평가를 위한 if/else 구조가 있지만, 모든 명령어는 _후조건_을 사용하여 추가 if 문 없이 조건부로 실행될 수 있습니다. 이것은 명령어 바로 뒤에 콜론(:)으로 구분되어 나타나는 조건입니다.
 
 ```jinja
-; Conditional using traditional if/else
-r "Enter a number: ",num
-i num>100 w !,"huge"
-e i num>10 w !,"big"
-e w !,"small"
+;전통적인 if/else를 사용한 조건문
+r "숫자 입력: ",num
+i num>100 w !,"엄청 큼"
+e i num>10 w !,"큼"
+e w !,"작음"
 
-; Postconditionals are especially useful in a for loop.
-; This is the dominant for loop construct:
-;   a 'for' statement
-;   that tests for a 'quit' condition with a postconditional
-;   then 'do'es an indented block for each iteration
+; 후조건은 for 루프에서 특히 유용합니다.
+; 이것이 지배적인 for 루프 구조입니다:
+;   'for' 문
+;   후조건으로 'quit' 조건을 테스트하는
+;   그런 다음 각 반복에 대해 들여쓰기된 블록을 'do'합니다.
 
 s var=""
-f  s var=var_"%" q:var="%%%%%%%%%%" d  ;Read as "Quit if var equals "%%%%%%%%%%"
+f  s var=var_"%" q:var="%%%%%%%%%%" d  ;"var가 "%%%%%%%%%%"이면 종료"로 읽습니다.
 . w !,var
 
-;Bonus points - the $L(ength) built-in function makes this even terser
+;보너스 포인트 - $L(ength) 내장 함수를 사용하면 훨씬 더 간결해집니다.
 
 s var=""
 f  s var=var_"%" q:$L(var)>10  d  ;
 . w !,var
 ```
 
-#### Array Looping - $Order
-As we saw in the previous example, M has built-in functions called with a single $, compared to user-defined functions called with $$. These functions have shortened abbreviations, like commands.
-One of the most useful is __$Order()__ / $O(). When given an array subscript, $O returns the next subscript in that array. When it reaches the last subscript, it returns "".
+#### 배열 반복 - $Order
+이전 예에서 보았듯이 M에는 $$로 호출되는 사용자 정의 함수와 비교하여 단일 $로 호출되는 내장 함수가 있습니다. 이 함수들은 명령어처럼 축약형이 있습니다.
+가장 유용한 것 중 하나는 __$Order()__ / $O()입니다. 배열 아래 첨자를 주면 $O는 해당 배열의 다음 아래 첨자를 반환합니다. 마지막 아래 첨자에 도달하면 ""를 반환합니다.
 
 ```jinja
-;Let's call back to our ^TEMPS global from earlier:
-; A log of temperatures by date and time
+;이전의 ^TEMPS 전역 변수를 다시 호출해 봅시다:
+; 날짜 및 시간별 온도 기록
 s ^TEMPS("11/12","0600",32)=""
 s ^TEMPS("11/12","0600",48)=""
 s ^TEMPS("11/12","1400",49)=""
 s ^TEMPS("11/12","1700",43)=""
-; Some more
+; 일부 추가
 s ^TEMPS("11/16","0300",27)=""
 s ^TEMPS("11/16","1130",32)=""
 s ^TEMPS("11/16","1300",47)=""
 
-;Here's a loop to print out all the dates we have temperatures for:
-n date,time ; Initialize these variables with ""
+;온도가 있는 모든 날짜를 인쇄하는 루프입니다:
+n date,time ; 이 변수들을 ""로 초기화합니다.
 
-; This line reads: forever; set date as the next date in ^TEMPS.
-; If date was set to "", it means we're at the end, so quit.
-; Do the block below
+; 이 줄은 다음과 같이 읽습니다: 영원히; date를 ^TEMPS의 다음 날짜로 설정합니다.
+; date가 ""로 설정되면 끝에 도달했음을 의미하므로 종료합니다.
+; 아래 블록을 실행합니다.
 f  s date=$ORDER(^TEMPS(date)) q:date="" d
 . w !,date
 
-; Add in times too:
+; 시간도 추가합니다:
 f  s date=$ORDER(^TEMPS(date)) q:date=""  d
-. w !,"Date: ",date
+. w !,"날짜: ",date
 . f  s time=$O(^TEMPS(date,time)) q:time=""  d
-. . w !,"Time: ",time
+. . w !,"시간: ",time
 
-; Build an index that sorts first by temperature -
-; what dates and times had a given temperature?
+; 온도를 기준으로 먼저 정렬하는 인덱스를 만듭니다 -
+; 특정 온도였던 날짜와 시간은?
 n date,time,temp
 f  s date=$ORDER(^TEMPS(date)) q:date=""  d
 . f  s time=$O(^TEMPS(date,time)) q:time=""  d
 . . f  s temp=$O(^TEMPS(date,time,temp)) q:temp=""  d
 . . . s ^TEMPINDEX(temp,date,time)=""
 
-;This will produce a global like
+;이것은 다음과 같은 전역 변수를 생성합니다.
 ^TEMPINDEX(27,"11/16","0300")
 ^TEMPINDEX(32,"11/12","0600")
 ^TEMPINDEX(32,"11/16","1130")
 ```
 
-## Further Reading
+## 더 읽을거리
 
-There's lots more to learn about M. A great short tutorial comes from the University of Northern Iowa and  Professor Kevin O'Kane's [Introduction to the MUMPS Language][1] presentation.  More about M using VistA is at
+M에 대해 배울 것이 훨씬 더 많습니다. 북부 아이오와 대학의 Kevin O'Kane 교수의 [MUMPS 언어 소개][1] 프레젠테이션에서 훌륭한 짧은 튜토리얼을 제공합니다. VistA를 사용한 M에 대한 자세한 내용은
 
-Intersystems has some products which are a super-set of the M programming language.
+Intersystems에는 M 프로그래밍 언어의 상위 집합인 일부 제품이 있습니다.
 
-* [Iris Description Page][5]
-* [Cache Description Page][6]
+* [Iris 설명 페이지][5]
+* [Cache 설명 페이지][6]
 
-To install an M interpreter / database on your computer, try a [YottaDB Docker image][2].
+컴퓨터에 M 인터프리터 / 데이터베이스를 설치하려면 [YottaDB Docker 이미지][2]를 사용해 보십시오.
 
-YottaDB and its precursor, GT.M, have thorough documentation on all the language features including database transactions, locking, and replication:
+YottaDB와 그 전신인 GT.M은 데이터베이스 트랜잭션, 잠금 및 복제를 포함한 모든 언어 기능에 대한 철저한 문서를 가지고 있습니다:
 
-* [YottaDB Programmer's Guide][3]
-* [GT.M Programmer's Guide][4]
+* [YottaDB 프로그래머 가이드][3]
+* [GT.M 프로그래머 가이드][4]
 
 [1]: https://www.cs.uni.edu/~okane/source/MUMPS-MDH/MumpsTutorial.pdf
 [2]: https://yottadb.com/product/get-started/

--- a/ko/matlab.md
+++ b/ko/matlab.md
@@ -1,5 +1,3 @@
-# matlab.md (번역)
-
 ---
 name: MATLAB
 filename: learnmatlab.m
@@ -10,177 +8,176 @@ contributors:
     - ["Claudson Martins", "http://github.com/claudsonm"]
 ---
 
-MATLAB stands for MATrix LABoratory. It is a powerful numerical computing language commonly used in engineering and mathematics.
+MATLAB은 MATrix LABoratory의 약자입니다. 공학 및 수학에서 일반적으로 사용되는 강력한 수치 계산 언어입니다.
 
 ```matlab
-%% Code sections start with two percent signs. Section titles go on the same line.
-% Comments start with a percent sign.
+%% 코드 섹션은 두 개의 퍼센트 기호로 시작합니다. 섹션 제목은 같은 줄에 씁니다.
+% 주석은 퍼센트 기호로 시작합니다.
 
 %{
-Multi line comments look
-something
-like
-this
+여러 줄 주석은
+다음과
+같습니다
 %}
 
-% Two percent signs denote the start of a new code section
-% Individual code sections can be run by moving the cursor to the section followed by
-% either clicking the "Run Section" button
-% or     using Ctrl+Shift+Enter (Windows) or Cmd+Shift+Return (macOS)
+% 두 개의 퍼센트 기호는 새 코드 섹션의 시작을 나타냅니다
+% 개별 코드 섹션은 커서를 섹션으로 이동한 다음
+% "섹션 실행" 버튼을 클릭하거나
+% 또는 Ctrl+Shift+Enter(Windows) 또는 Cmd+Shift+Return(macOS)을 사용하여 실행할 수 있습니다.
 
-%% This is the start of a code section
-%  One way of using sections is to separate expensive but unchanging start-up code like loading data
+%% 이것은 코드 섹션의 시작입니다
+%  섹션을 사용하는 한 가지 방법은 데이터 로드와 같이 비용이 많이 들지만 변경되지 않는 시작 코드를 분리하는 것입니다.
 load myFile.mat y
 
-%% This is another code section
-%  This section can be edited and run repeatedly on its own, and is helpful for exploratory programming and demos
+%% 이것은 또 다른 코드 섹션입니다
+%  이 섹션은 자체적으로 반복적으로 편집하고 실행할 수 있으며, 탐색적 프로그래밍 및 데모에 유용합니다.
 A = A * 2;
 plot(A);
 
-%% Code sections are also known as code cells or cell mode (not to be confused with cell arrays)
+%% 코드 섹션은 코드 셀 또는 셀 모드라고도 합니다(셀 배열과 혼동하지 마십시오).
 
 
-% commands can span multiple lines, using '...':
+% 명령어는 '...'을 사용하여 여러 줄에 걸쳐 작성할 수 있습니다:
  a = 1 + 2 + ...
  + 4
 
-% commands can be passed to the operating system
+% 명령어를 운영 체제에 전달할 수 있습니다
 !ping google.com
 
-who          % Displays all variables in memory
-whos         % Displays all variables in memory, with their types
-clear        % Erases all your variables from memory
-clear('A')   % Erases a particular variable
-openvar('A') % Open variable in variable editor
+who          % 메모리의 모든 변수를 표시합니다
+whos         % 메모리의 모든 변수를 유형과 함께 표시합니다
+clear        % 메모리에서 모든 변수를 지웁니다
+clear('A')   % 특정 변수를 지웁니다
+openvar('A') % 변수 편집기에서 변수를 엽니다
 
-clc    % Erases the writing on your Command Window
-diary  % Toggle writing Command Window text to file
-ctrl-c % Abort current computation
+clc    % 명령 창의 내용을 지웁니다
+diary  % 명령 창 텍스트를 파일에 쓰는 것을 토글합니다
+ctrl-c % 현재 계산을 중단합니다
 
-edit('myfunction.m') % Open function/script in editor
-type('myfunction.m') % Print the source of function/script to Command Window
+edit('myfunction.m') % 편집기에서 함수/스크립트를 엽니다
+type('myfunction.m') % 함수/스크립트의 소스를 명령 창에 인쇄합니다
 
-profile on     % turns on the code profiler
-profile off    % turns off the code profiler
-profile viewer % Open profiler
+profile on     % 코드 프로파일러를 켭니다
+profile off    % 코드 프로파일러를 끕니다
+profile viewer % 프로파일러를 엽니다
 
-help command         % Displays documentation for command in Command Window
-doc command          % Displays documentation for command in Help Window
-lookfor command      % Searches for command in the first commented line of all functions
-lookfor command -all % searches for command in all functions
+help command         % 명령 창에 명령어에 대한 문서를 표시합니다
+doc command          % 도움말 창에 명령어에 대한 문서를 표시합니다
+lookfor command      % 모든 함수의 첫 번째 주석 줄에서 명령어를 검색합니다
+lookfor command -all % 모든 함수에서 명령어를 검색합니다
 
 
-% Output formatting
-format short    % 4 decimals in a floating number
-format long     % 15 decimals
-format bank     % only two digits after decimal point - for financial calculations
-fprintf('text') % print "text" to the screen
-disp('text')    % print "text" to the screen
+% 출력 서식
+format short    % 부동 소수점 수에서 소수점 4자리
+format long     % 소수점 15자리
+format bank     % 소수점 뒤 두 자리만 - 금융 계산용
+fprintf('text') % 화면에 "text"를 인쇄합니다
+disp('text')    % 화면에 "text"를 인쇄합니다
 
-% Variables & Expressions
-myVariable = 4  % Notice Workspace pane shows newly created variable
-myVariable = 4; % Semi colon suppresses output to the Command Window
+% 변수 및 표현식
+myVariable = 4  % 작업 공간 창에 새로 생성된 변수가 표시됩니다
+myVariable = 4; % 세미콜론은 명령 창에 출력을 억제합니다
 4 + 6           % ans = 10
 8 * myVariable  % ans = 32
 2 ^ 3           % ans = 8
 a = 2; b = 3;
 c = exp(a)*sin(pi/2) % c = 7.3891
 
-% Calling functions can be done in either of two ways:
-% Standard function syntax:
-load('myFile.mat', 'y') % arguments within parentheses, separated by commas
-% Command syntax:
-load myFile.mat y       % no parentheses, and spaces instead of commas
-% Note the lack of quote marks in command form: inputs are always passed as
-% literal text - cannot pass variable values. Also, can't receive output:
-[V,D] = eig(A);  % this has no equivalent in command form
-[~,D] = eig(A);  % if you only want D and not V
+% 함수 호출은 두 가지 방법 중 하나로 수행할 수 있습니다:
+% 표준 함수 구문:
+load('myFile.mat', 'y') % 괄호 안에 인수를 쉼표로 구분하여 전달합니다
+% 명령어 구문:
+load myFile.mat y       % 괄호 없음, 쉼표 대신 공백 사용
+% 명령어 형식에서는 따옴표가 없음에 유의하십시오: 입력은 항상
+% 리터럴 텍스트로 전달됩니다 - 변수 값을 전달할 수 없습니다. 또한 출력을 받을 수 없습니다:
+[V,D] = eig(A);  % 이것은 명령어 형식에 해당하는 것이 없습니다
+[~,D] = eig(A);  % V가 아닌 D만 원하는 경우
 
 
 
-% Logicals
+% 논리
 1 > 5 % ans = 0
 10 >= 10 % ans = 1
-3 ~= 4 % Not equal to -> ans = 1
-3 == 3 % equal to -> ans = 1
+3 ~= 4 % 같지 않음 -> ans = 1
+3 == 3 % 같음 -> ans = 1
 3 > 1 && 4 > 1 % AND -> ans = 1
 3 > 1 || 4 > 1 % OR -> ans = 1
 ~1 % NOT -> ans = 0
 
-% Logicals can be applied to matrices:
+% 논리는 행렬에 적용될 수 있습니다:
 A > 5
-% for each element, if condition is true, that element is 1 in returned matrix
+% 각 요소에 대해 조건이 참이면 반환된 행렬에서 해당 요소는 1입니다
 A( A > 5 )
-% returns a vector containing the elements in A for which condition is true
+% 조건이 참인 A의 요소를 포함하는 벡터를 반환합니다
 
-% Strings
+% 문자열
 a = 'MyString'
 length(a) % ans = 8
 a(2) % ans = y
 [a,a] % ans = MyStringMyString
 
 
-% Cells
+% 셀
 a = {'one', 'two', 'three'}
-a(1) % ans = 'one' - returns a cell
-char(a(1)) % ans = one - returns a string
+a(1) % ans = 'one' - 셀을 반환합니다
+char(a(1)) % ans = one - 문자열을 반환합니다
 
-% Structures
+% 구조체
 A.b = {'one','two'};
 A.c = [1 2];
 A.d.e = false;
 
-% Vectors
+% 벡터
 x = [4 32 53 7 1]
-x(2) % ans = 32, indices in MATLAB start 1, not 0
+x(2) % ans = 32, MATLAB의 인덱스는 0이 아닌 1부터 시작합니다
 x(2:3) % ans = 32 53
 x(2:end) % ans = 32 53 7 1
 
-x = [4; 32; 53; 7; 1] % Column vector
+x = [4; 32; 53; 7; 1] % 열 벡터
 
 x = [1:10] % x = 1 2 3 4 5 6 7 8 9 10
-x = [1:2:10] % Increment by 2, i.e. x = 1 3 5 7 9
+x = [1:2:10] % 2씩 증가, 즉 x = 1 3 5 7 9
 
-% Matrices
+% 행렬
 A = [1 2 3; 4 5 6; 7 8 9]
-% Rows are separated by a semicolon; elements are separated with space or comma
+% 행은 세미콜론으로 구분됩니다. 요소는 공백이나 쉼표로 구분됩니다.
 % A =
 
 %     1     2     3
 %     4     5     6
 %     7     8     9
 
-A(2,3) % ans = 6, A(row, column)
+A(2,3) % ans = 6, A(행, 열)
 A(6) % ans = 8
-% (implicitly concatenates columns into vector, then indexes into that)
+% (암시적으로 열을 벡터로 연결한 다음 해당 벡터를 인덱싱합니다)
 
 
-A(2,3) = 42 % Update row 2 col 3 with 42
+A(2,3) = 42 % 2행 3열을 42로 업데이트합니다
 % A =
 
 %     1     2     3
 %     4     5     42
 %     7     8     9
 
-A(2:3,2:3) % Creates a new matrix from the old one
+A(2:3,2:3) % 이전 행렬에서 새 행렬을 만듭니다
 %ans =
 
 %     5     42
 %     8     9
 
-A(:,1) % All rows in column 1
+A(:,1) % 1열의 모든 행
 %ans =
 
 %     1
 %     4
 %     7
 
-A(1,:) % All columns in row 1
+A(1,:) % 1행의 모든 열
 %ans =
 
 %     1     2     3
 
-[A ; A] % Concatenation of matrices (vertically)
+[A ; A] % 행렬 연결 (수직)
 %ans =
 
 %     1     2     3
@@ -190,11 +187,11 @@ A(1,:) % All columns in row 1
 %     4     5    42
 %     7     8     9
 
-% this is the same as
+% 이것은 다음과 같습니다
 vertcat(A,A);
 
 
-[A , A] % Concatenation of matrices (horizontally)
+[A , A] % 행렬 연결 (수평)
 
 %ans =
 
@@ -202,11 +199,11 @@ vertcat(A,A);
 %     4     5    42     4     5    42
 %     7     8     9     7     8     9
 
-% this is the same as
+% 이것은 다음과 같습니다
 horzcat(A,A);
 
 
-A(:, [3 1 2]) % Rearrange the columns of original matrix
+A(:, [3 1 2]) % 원본 행렬의 열을 재정렬합니다
 %ans =
 
 %     3     1     2
@@ -215,174 +212,175 @@ A(:, [3 1 2]) % Rearrange the columns of original matrix
 
 size(A) % ans = 3 3
 
-A(1, :) =[] % Delete the first row of the matrix
-A(:, 1) =[] % Delete the first column of the matrix
+A(1, :) =[] % 행렬의 첫 번째 행을 삭제합니다
+A(:, 1) =[] % 행렬의 첫 번째 열을 삭제합니다
 
-transpose(A) % Transpose the matrix, which is the same as:
-A.' % Concise version of transpose (without taking complex conjugate)
-ctranspose(A) % Hermitian transpose the matrix, which is the same as:
-A'  % Concise version of complex transpose
-    % (the transpose, followed by taking complex conjugate of each element)
-
-
+transpose(A) % 행렬을 전치합니다. 다음과 같습니다:
+A.' % 전치의 간결한 버전 (복소 공액을 취하지 않음)
+ctranspose(A) % 행렬을 에르미트 전치합니다. 다음과 같습니다:
+A'  % 복소 전치의 간결한 버전
+    % (전치 후 각 요소의 복소 공액을 취함)
 
 
 
-% Element by Element Arithmetic vs. Matrix Arithmetic
-% On their own, the arithmetic operators act on whole matrices. When preceded
-% by a period, they act on each element instead. For example:
-A * B % Matrix multiplication
-A .* B % Multiply each element in A by its corresponding element in B
-
-% There are several pairs of functions, where one acts on each element, and
-% the other (whose name ends in m) acts on the whole matrix.
-exp(A) % exponentiate each element
-expm(A) % calculate the matrix exponential
-sqrt(A) % take the square root of each element
-sqrtm(A) %  find the matrix whose square is A
 
 
-% Plotting
-x = 0:.10:2*pi; % Creates a vector that starts at 0 and ends at 2*pi with increments of .1
+% 요소별 산술 대 행렬 산술
+% 산술 연산자는 자체적으로 전체 행렬에 작용합니다. 앞에
+% 마침표가 있으면 대신 각 요소에 작용합니다. 예:
+A * B % 행렬 곱셈
+A .* B % A의 각 요소를 B의 해당 요소와 곱합니다
+
+% 여러 쌍의 함수가 있으며, 하나는 각 요소에 작용하고
+% 다른 하나(이름이 m으로 끝남)는 전체 행렬에 작용합니다.
+exp(A) % 각 요소를 지수화합니다
+expm(A) % 행렬 지수를 계산합니다
+sqrt(A) % 각 요소의 제곱근을 취합니다
+sqrtm(A) %  제곱이 A인 행렬을 찾습니다
+
+
+% 플로팅
+x = 0:.10:2*pi; % 0에서 시작하여 2*pi에서 끝나고 .1씩 증가하는 벡터를 만듭니다
 y = sin(x);
 plot(x,y)
-xlabel('x axis')
-ylabel('y axis')
-title('Plot of y = sin(x)')
-axis([0 2*pi -1 1]) % x range from 0 to 2*pi, y range from -1 to 1
+xlabel('x 축')
+ylabel('y 축')
+title('y = sin(x)의 플롯')
+axis([0 2*pi -1 1]) % x 범위는 0에서 2*pi, y 범위는 -1에서 1
 
-plot(x,y1,'-',x,y2,'--',x,y3,':') % For multiple functions on one plot
-legend('Line 1 label', 'Line 2 label') % Label curves with a legend
+plot(x,y1,'-',x,y2,'--',x,y3,':') % 한 플롯에 여러 함수를 표시합니다
+legend('선 1 레이블', '선 2 레이블') % 범례로 곡선에 레이블을 지정합니다
 
-% Alternative method to plot multiple functions in one plot.
-% while 'hold' is on, commands add to existing graph rather than replacing it
+% 한 플롯에 여러 함수를 표시하는 다른 방법.
+% 'hold'가 켜져 있는 동안 명령어는 기존 그래프를 대체하는 대신 추가됩니다.
 plot(x, y)
 hold on
 plot(x, z)
 hold off
 
-loglog(x, y) % A log-log plot
-semilogx(x, y) % A plot with logarithmic x-axis
-semilogy(x, y) % A plot with logarithmic y-axis
+loglog(x, y) % 로그-로그 플롯
+semilogx(x, y) % x축이 로그 스케일인 플롯
+semilogy(x, y) % y축이 로그 스케일인 플롯
 
-fplot (@(x) x^2, [2,5]) % plot the function x^2 from x=2 to x=5
+fplot (@(x) x^2, [2,5]) % x=2에서 x=5까지 함수 x^2를 플로팅합니다
 
-grid on % Show grid; turn off with 'grid off'
-axis square % Makes the current axes region square
-axis equal % Set aspect ratio so data units are the same in every direction
+grid on % 그리드 표시; 'grid off'로 끕니다
+axis square % 현재 축 영역을 정사각형으로 만듭니다
+axis equal % 데이터 단위가 모든 방향에서 동일하도록 가로세로 비율을 설정합니다
 
-scatter(x, y); % Scatter-plot
-hist(x); % Histogram
-stem(x); % Plot values as stems, useful for displaying discrete data
-bar(x); % Plot bar graph
+scatter(x, y); % 산점도
+hist(x); % 히스토그램
+stem(x); % 값을 줄기로 플로팅하여 이산 데이터를 표시하는 데 유용합니다
+bar(x); % 막대 그래프
 
 z = sin(x);
-plot3(x,y,z); % 3D line plot
+plot3(x,y,z); % 3D 선 플롯
 
-pcolor(A) % Heat-map of matrix: plot as grid of rectangles, coloured by value
-contour(A) % Contour plot of matrix
-mesh(A) % Plot as a mesh surface
+pcolor(A) % 행렬의 히트맵: 값에 따라 색상이 지정된 사각형 그리드로 플로팅합니다
+contour(A) % 행렬의 등고선 플롯
+mesh(A) % 메시 표면으로 플로팅합니다
 
-h = figure % Create new figure object, with handle h
-figure(h) % Makes the figure corresponding to handle h the current figure
-close(h) % close figure with handle h
-close all % close all open figure windows
-close % close current figure window
+h = figure % 핸들 h를 사용하여 새 그림 객체를 만듭니다
+figure(h) % 핸들 h에 해당하는 그림을 현재 그림으로 만듭니다
+close(h) % 핸들 h를 사용하여 그림을 닫습니다
+close all % 모든 열린 그림 창을 닫습니다
+close % 현재 그림 창을 닫습니다
 
-shg % bring an existing graphics window forward, or create new one if needed
-clf clear % clear current figure window, and reset most figure properties
+shg % 기존 그래픽 창을 앞으로 가져오거나 필요한 경우 새 창을 만듭니다
+clf clear % 현재 그림 창을 지우고 대부분의 그림 속성을 재설정합니다
 
-% Properties can be set and changed through a figure handle.
-% You can save a handle to a figure when you create it.
-% The function get returns a handle to the current figure
-h = plot(x, y); % you can save a handle to a figure when you create it
+% 속성은 그림 핸들을 통해 설정하고 변경할 수 있습니다.
+% 그림을 만들 때 핸들을 저장할 수 있습니다.
+% get 함수는 현재 그림에 대한 핸들을 반환합니다
+h = plot(x, y); % 그림을 만들 때 핸들을 저장할 수 있습니다
 set(h, 'Color', 'r')
-% 'y' yellow; 'm' magenta, 'c' cyan, 'r' red, 'g' green, 'b' blue, 'w' white, 'k' black
+% 'y' 노란색; 'm' 자홍색, 'c' 청록색, 'r' 빨간색, 'g' 녹색, 'b' 파란색, 'w' 흰색, 'k' 검은색
 set(h, 'LineStyle', '--')
- % '--' is solid line, '---' dashed, ':' dotted, '-.' dash-dot, 'none' is no line
+ % '--'는 실선, '---' 파선, ':' 점선, '-.' 파선-점선, 'none'은 선 없음
 get(h, 'LineStyle')
 
 
-% The function gca returns a handle to the axes for the current figure
-set(gca, 'XDir', 'reverse'); % reverse the direction of the x-axis
+% gca 함수는 현재 그림의 축에 대한 핸들을 반환합니다
+set(gca, 'XDir', 'reverse'); % x축의 방향을 반전시킵니다
 
-% To create a figure that contains several axes in tiled positions, use subplot
-subplot(2,3,1); % select the first position in a 2-by-3 grid of subplots
-plot(x1); title('First Plot') % plot something in this position
-subplot(2,3,2); % select second position in the grid
-plot(x2); title('Second Plot') % plot something there
-
-
-% To use functions or scripts, they must be on your path or current directory
-path % display current path
-addpath /path/to/dir % add to path
-rmpath /path/to/dir % remove from path
-cd /path/to/move/into % change directory
+% 타일 위치에 여러 축을 포함하는 그림을 만들려면 subplot을 사용하십시오
+subplot(2,3,1); % 2x3 서브플롯 그리드의 첫 번째 위치를 선택합니다
+plot(x1); title('첫 번째 플롯') % 이 위치에 무언가를 플로팅합니다
+subplot(2,3,2); % 그리드의 두 번째 위치를 선택합니다
+plot(x2); title('두 번째 플롯') % 거기에 무언가를 플로팅합니다
 
 
-% Variables can be saved to .mat files
-save('myFileName.mat') % Save the variables in your Workspace
-load('myFileName.mat') % Load saved variables into Workspace
+% 함수나 스크립트를 사용하려면 경로 또는 현재 디렉토리에 있어야 합니다
+path % 현재 경로 표시
+addpath /path/to/dir % 경로에 추가
+rmpath /path/to/dir % 경로에서 제거
+cd /path/to/move/into % 디렉토리 변경
 
-% M-file Scripts
-% A script file is an external file that contains a sequence of statements.
-% They let you avoid repeatedly typing the same code in the Command Window
-% Have .m extensions
 
-% M-file Functions
-% Like scripts, and have the same .m extension
-% But can accept input arguments and return an output
-% Also, they have their own workspace (ie. different variable scope).
-% Function name should match file name (so save this example as double_input.m).
-% 'help double_input.m' returns the comments under line beginning function
+% 변수는 .mat 파일에 저장할 수 있습니다
+save('myFileName.mat') % 작업 공간의 변수를 저장합니다
+load('myFileName.mat') % 저장된 변수를 작업 공간으로 로드합니다
+
+% M-파일 스크립트
+% 스크립트 파일은 일련의 문장을 포함하는 외부 파일입니다.
+% 명령 창에서 동일한 코드를 반복적으로 입력하는 것을 피할 수 있습니다
+% .m 확장자를 가집니다
+
+% M-파일 함수
+% 스크립트와 같고 동일한 .m 확장자를 가집니다
+% 그러나 입력 인수를 받고 출력을 반환할 수 있습니다
+% 또한 자체 작업 공간(즉, 다른 변수 범위)을 가집니다.
+% 함수 이름은 파일 이름과 일치해야 합니다(따라서 이 예제를 double_input.m으로 저장하십시오).
+% 'help double_input.m'은 함수 시작 줄 아래의 주석을 반환합니다
 function output = double_input(x)
-  %double_input(x) returns twice the value of x
+  %double_input(x)은 x 값의 두 배를 반환합니다
   output = 2*x;
 end
 double_input(6) % ans = 12
 
 
-% You can also have subfunctions and nested functions.
-% Subfunctions are in the same file as the primary function, and can only be
-% called by functions in the file. Nested functions are defined within another
-% functions, and have access to both its workspace and their own workspace.
+% 하위 함수 및 중첩 함수도 가질 수 있습니다.
+% 하위 함수는 기본 함수와 동일한 파일에 있으며 파일의 함수에서만
+% 호출할 수 있습니다. 중첩 함수는 다른 함수 내에 정의되며
+% 해당 작업 공간과 자체 작업 공간 모두에 액세스할 수 있습니다.
 
-% If you want to create a function without creating a new file you can use an
-% anonymous function. Useful when quickly defining a function to pass to
-% another function (eg. plot with fplot, evaluate an indefinite integral
-% with quad, find roots with fzero, or find minimum with fminsearch).
-% Example that returns the square of its input, assigned to the handle sqr:
+% 새 파일을 만들지 않고 함수를 만들고 싶다면
+% 익명 함수를 사용할 수 있습니다. 다른 함수에 전달할 함수를
+% 빠르게 정의할 때 유용합니다(예: fplot으로 플로팅, quad로 부정적분 평가,
+% fzero로 근 찾기 또는 fminsearch로 최소값 찾기).
+% 입력의 제곱을 반환하는 예제, 핸들 sqr에 할당됨:
 sqr = @(x) x.^2;
 sqr(10) % ans = 100
-doc function_handle % find out more
+doc function_handle % 자세히 알아보기
 
-% User input
-a = input('Enter the value: ')
+% 사용자 입력
+a = input('값을 입력하십시오: ')
 
-% Stops execution of file and gives control to the keyboard: user can examine
-% or change variables. Type 'return' to continue execution, or 'dbquit' to exit
+% 파일 실행을 중지하고 키보드에 제어권을 부여합니다: 사용자는
+% 변수를 검사하거나 변경할 수 있습니다. 실행을 계속하려면 'return'을 입력하고
+% 종료하려면 'dbquit'를 입력하십시오
 keyboard
 
-% Reading in data (also xlsread/importdata/imread for excel/CSV/image files)
+% 데이터 읽기 (excel/CSV/이미지 파일의 경우 xlsread/importdata/imread도 사용)
 fopen(filename)
 
-% Output
-disp(a) % Print out the value of variable a
-disp('Hello World') % Print out a string
-fprintf % Print to Command Window with more control
+% 출력
+disp(a) % 변수 a의 값을 인쇄합니다
+disp('Hello World') % 문자열을 인쇄합니다
+fprintf % 더 많은 제어로 명령 창에 인쇄합니다
 
-% Conditional statements (the parentheses are optional, but good style)
+% 조건문 (괄호는 선택 사항이지만 좋은 스타일입니다)
 if (a > 23)
-  disp('Greater than 23')
+  disp('23보다 큼')
 elseif (a == 23)
-  disp('a is 23')
+  disp('a는 23입니다')
 else
-  disp('neither condition met')
+  disp('두 조건 모두 충족되지 않음')
 end
 
-% Looping
-% NB. looping over elements of a vector/matrix is slow!
-% Where possible, use functions that act on whole vector/matrix at once
+% 반복
+% NB. 벡터/행렬의 요소를 반복하는 것은 느립니다!
+% 가능한 경우 한 번에 전체 벡터/행렬에 작용하는 함수를 사용하십시오
 for k = 1:5
   disp(k)
 end
@@ -392,25 +390,25 @@ while (k < 5)
   k = k + 1;
 end
 
-% Timing code execution: 'toc' prints the time since 'tic' was called
+% 코드 실행 시간 측정: 'toc'는 'tic'이 호출된 이후의 시간을 인쇄합니다
 tic
 A = rand(1000);
 A*A*A*A*A*A*A;
 toc
 
-% Connecting to a MySQL Database
+% MySQL 데이터베이스에 연결
 dbname = 'database_name';
 username = 'root';
 password = 'root';
 driver = 'com.mysql.jdbc.Driver';
 dburl = ['jdbc:mysql://localhost:8889/' dbname];
-javaclasspath('mysql-connector-java-5.1.xx-bin.jar'); %xx depends on version, download available at http://dev.mysql.com/downloads/connector/j/
+javaclasspath('mysql-connector-java-5.1.xx-bin.jar'); %xx는 버전에 따라 다름, http://dev.mysql.com/downloads/connector/j/에서 다운로드 가능
 conn = database(dbname, username, password, driver, dburl);
-sql = ['SELECT * from table_name where id = 22'] % Example sql statement
-a = fetch(conn, sql) %a will contain your data
+sql = ['SELECT * from table_name where id = 22'] % 예제 sql 문
+a = fetch(conn, sql) %a에 데이터가 포함됩니다
 
 
-% Common math functions
+% 일반적인 수학 함수
 sin(x)
 cos(x)
 tan(x)
@@ -421,140 +419,140 @@ exp(x)
 sqrt(x)
 log(x)
 log10(x)
-abs(x) %If x is complex, returns magnitude
+abs(x) %x가 복소수이면 크기를 반환합니다
 min(x)
 max(x)
 ceil(x)
 floor(x)
 round(x)
 rem(x)
-rand % Uniformly distributed pseudorandom numbers
-randi % Uniformly distributed pseudorandom integers
-randn % Normally distributed pseudorandom numbers
+rand % 균일하게 분포된 의사 난수
+randi % 균일하게 분포된 의사 난수 정수
+randn % 정규 분포된 의사 난수
 
-%Complex math operations
-abs(x)   % Magnitude of complex variable x
-phase(x) % Phase (or angle) of complex variable x
-real(x)  % Returns the real part of x (i.e returns a if x = a +jb)
-imag(x)  % Returns the imaginary part of x (i.e returns b if x = a+jb)
-conj(x)  % Returns the complex conjugate
+%복소수 수학 연산
+abs(x)   % 복소 변수 x의 크기
+phase(x) % 복소 변수 x의 위상(또는 각도)
+real(x)  % x의 실수부를 반환합니다 (즉, x = a +jb이면 a를 반환)
+imag(x)  % x의 허수부를 반환합니다 (즉, x = a+jb이면 b를 반환)
+conj(x)  % 복소 공액을 반환합니다
 
 
-% Common constants
+% 일반적인 상수
 pi
 NaN
 inf
 
-% Solving matrix equations (if no solution, returns a least squares solution)
-% The \ and / operators are equivalent to the functions mldivide and mrdivide
-x=A\b % Solves Ax=b. Faster and more numerically accurate than using inv(A)*b.
-x=b/A % Solves xA=b
+% 행렬 방정식 풀기 (해가 없으면 최소 제곱 해를 반환)
+% \ 및 / 연산자는 mldivide 및 mrdivide 함수와 동일합니다
+x=A\b % Ax=b를 풉니다. inv(A)*b를 사용하는 것보다 빠르고 수치적으로 더 정확합니다.
+x=b/A % xA=b를 풉니다
 
-inv(A) % calculate the inverse matrix
-pinv(A) % calculate the pseudo-inverse
+inv(A) % 역행렬 계산
+pinv(A) % 유사 역행렬 계산
 
-% Common matrix functions
-zeros(m,n) % m x n matrix of 0's
-ones(m,n) % m x n matrix of 1's
-diag(A) % Extracts the diagonal elements of a matrix A
-diag(x) % Construct a matrix with diagonal elements listed in x, and zeroes elsewhere
-eye(m,n) % Identity matrix
-linspace(x1, x2, n) % Return n equally spaced points, with min x1 and max x2
-inv(A) % Inverse of matrix A
-det(A) % Determinant of A
-eig(A) % Eigenvalues and eigenvectors of A
-trace(A) % Trace of matrix - equivalent to sum(diag(A))
-isempty(A) % Tests if array is empty
-all(A) % Tests if all elements are nonzero or true
-any(A) % Tests if any elements are nonzero or true
-isequal(A, B) % Tests equality of two arrays
-numel(A) % Number of elements in matrix
-triu(x) % Returns the upper triangular part of x
-tril(x) % Returns the lower triangular part of x
-cross(A,B) %  Returns the cross product of the vectors A and B
-dot(A,B) % Returns scalar product of two vectors (must have the same length)
-transpose(A) % Returns the transpose of A
-fliplr(A) % Flip matrix left to right
-flipud(A) % Flip matrix up to down
+% 일반적인 행렬 함수
+zeros(m,n) % 0으로 채워진 m x n 행렬
+ones(m,n) % 1로 채워진 m x n 행렬
+diag(A) % 행렬 A의 대각선 요소를 추출합니다
+diag(x) % 대각선 요소가 x에 나열되고 다른 곳은 0인 행렬을 구성합니다
+eye(m,n) % 단위 행렬
+linspace(x1, x2, n) % 최소 x1, 최대 x2로 n개의 등간격 점을 반환합니다
+inv(A) % 행렬 A의 역행렬
+det(A) % A의 행렬식
+eig(A) % A의 고유값 및 고유 벡터
+trace(A) % 행렬의 트레이스 - sum(diag(A))와 동일
+isempty(A) % 배열이 비어 있는지 테스트합니다
+all(A) % 모든 요소가 0이 아니거나 참인지 테스트합니다
+any(A) % 요소 중 0이 아니거나 참인 것이 있는지 테스트합니다
+isequal(A, B) % 두 배열의 동등성을 테스트합니다
+numel(A) % 행렬의 요소 수
+triu(x) % x의 상삼각 부분을 반환합니다
+tril(x) % x의 하삼각 부분을 반환합니다
+cross(A,B) %  벡터 A와 B의 외적을 반환합니다
+dot(A,B) % 두 벡터의 스칼라 곱을 반환합니다 (길이가 같아야 함)
+transpose(A) % A의 전치를 반환합니다
+fliplr(A) % 행렬을 왼쪽에서 오른쪽으로 뒤집습니다
+flipud(A) % 행렬을 위에서 아래로 뒤집습니다
 
-% Matrix Factorisations
-[L, U, P] = lu(A) % LU decomposition: PA = LU,L is lower triangular, U is upper triangular, P is permutation matrix
-[P, D] = eig(A) % eigen-decomposition: AP = PD, P's columns are eigenvectors and D's diagonals are eigenvalues
-[U,S,V] = svd(X) % SVD: XV = US, U and V are unitary matrices, S has non-negative diagonal elements in decreasing order
+% 행렬 분해
+[L, U, P] = lu(A) % LU 분해: PA = LU, L은 하삼각, U는 상삼각, P는 순열 행렬
+[P, D] = eig(A) % 고유값 분해: AP = PD, P의 열은 고유 벡터, D의 대각선은 고유값
+[U,S,V] = svd(X) % SVD: XV = US, U와 V는 유니터리 행렬, S는 감소 순서로 음이 아닌 대각선 요소를 가짐
 
-% Common vector functions
-max     % largest component
-min     % smallest component
-length  % length of a vector
-sort    % sort in ascending order
-sum     % sum of elements
-prod    % product of elements
-mode    % modal value
-median  % median value
-mean    % mean value
-std     % standard deviation
-perms(x) % list all permutations of elements of x
-find(x) % Finds all non-zero elements of x and returns their indexes, can use comparison operators,
-        % i.e. find( x == 3 ) returns indexes of elements that are equal to 3
-        % i.e. find( x >= 3 ) returns indexes of elements greater than or equal to 3
+% 일반적인 벡터 함수
+max     % 가장 큰 구성 요소
+min     % 가장 작은 구성 요소
+length  % 벡터의 길이
+sort    % 오름차순 정렬
+sum     % 요소의 합
+prod    % 요소의 곱
+mode    % 최빈값
+median  % 중앙값
+mean    % 평균값
+std     % 표준 편차
+perms(x) % x 요소의 모든 순열 나열
+find(x) % x의 모든 0이 아닌 요소를 찾아 인덱스를 반환하며, 비교 연산자를 사용할 수 있습니다.
+        % 즉, find( x == 3 )은 3과 같은 요소의 인덱스를 반환합니다
+        % 즉, find( x >= 3 )은 3보다 크거나 같은 요소의 인덱스를 반환합니다
 
 
-% Classes
-% MATLAB can support object-oriented programming.
-% Classes must be put in a file of the class name with a .m extension.
-% To begin, we create a simple class to store GPS waypoints.
-% Begin WaypointClass.m
-classdef WaypointClass % The class name.
-  properties % The properties of the class behave like Structures
+% 클래스
+% MATLAB은 객체 지향 프로그래밍을 지원할 수 있습니다.
+% 클래스는 .m 확장자를 가진 클래스 이름의 파일에 넣어야 합니다.
+% 시작하려면 GPS 웨이포인트를 저장하는 간단한 클래스를 만듭니다.
+% WaypointClass.m 시작
+classdef WaypointClass % 클래스 이름.
+  properties % 클래스의 속성은 구조체처럼 작동합니다
     latitude
     longitude
   end
   methods
-    % This method that has the same name of the class is the constructor.
+    % 클래스와 이름이 같은 이 메서드는 생성자입니다.
     function obj = WaypointClass(lat, lon)
       obj.latitude = lat;
       obj.longitude = lon;
     end
 
-    % Other functions that use the Waypoint object
+    % Waypoint 객체를 사용하는 다른 함수
     function r = multiplyLatBy(obj, n)
       r = n*[obj.latitude];
     end
 
-    % If we want to add two Waypoint objects together without calling
-    % a special function we can overload MATLAB's arithmetic like so:
+    % 특수 함수를 호출하지 않고 두 Waypoint 객체를 더하고 싶다면
+    % 다음과 같이 MATLAB의 산술을 오버로드할 수 있습니다:
     function r = plus(o1,o2)
       r = WaypointClass([o1.latitude] +[o2.latitude], ...
                         [o1.longitude]+[o2.longitude]);
     end
   end
 end
-% End WaypointClass.m
+% WaypointClass.m 끝
 
-% We can create an object of the class using the constructor
+% 생성자를 사용하여 클래스의 객체를 만들 수 있습니다
 a = WaypointClass(45.0, 45.0)
 
-% Class properties behave exactly like MATLAB Structures.
+% 클래스 속성은 MATLAB 구조체와 똑같이 작동합니다.
 a.latitude = 70.0
 a.longitude = 25.0
 
-% Methods can be called in the same way as functions
+% 메서드는 함수와 같은 방식으로 호출할 수 있습니다
 ans = multiplyLatBy(a,3)
 
-% The method can also be called using dot notation. In this case, the object
-% does not need to be passed to the method.
+% 메서드는 점 표기법을 사용하여 호출할 수도 있습니다. 이 경우 객체를
+% 메서드에 전달할 필요가 없습니다.
 ans = a.multiplyLatBy(1/3)
 
-% MATLAB functions can be overloaded to handle objects.
-% In the method above, we have overloaded how MATLAB handles
-% the addition of two Waypoint objects.
+% MATLAB 함수는 객체를 처리하도록 오버로드될 수 있습니다.
+% 위 메서드에서 MATLAB이 두 Waypoint 객체의
+% 덧셈을 처리하는 방법을 오버로드했습니다.
 b = WaypointClass(15.0, 32.0)
 c = a + b
 ```
 
-## More on MATLAB
+## MATLAB에 대해 더 알아보기
 
-* [The official website](http://www.mathworks.com/products/matlab/)
-* [The official MATLAB Answers forum](http://www.mathworks.com/matlabcentral/answers/)
+* [공식 웹사이트](http://www.mathworks.com/products/matlab/)
+* [공식 MATLAB 답변 포럼](http://www.mathworks.com/matlabcentral/answers/)
 * [Loren on the Art of MATLAB](http://blogs.mathworks.com/loren/)
 * [Cleve's Corner](http://blogs.mathworks.com/cleve/)

--- a/ko/mercury.md
+++ b/ko/mercury.md
@@ -1,114 +1,110 @@
-# mercury.md (번역)
-
 ---
 name: Mercury
 contributors:
     - ["Julian Fondren", "https://mercury-in.space/"]
 ---
 
-Mercury is a strict, pure functional/logic programming language, with
-influences from Prolog, ML, and Haskell.
+Mercury는 Prolog, ML, Haskell의 영향을 받은 엄격하고 순수한 함수형/논리형 프로그래밍 언어입니다.
 
 ```prolog
-% Percent sign starts a one-line comment.
+% 퍼센트 기호는 한 줄 주석을 시작합니다.
 
     % foo(Bar, Baz)
     %
-    % Documentation comments are indented before what they describe.
+    % 문서 주석은 설명하는 내용 앞에 들여쓰기됩니다.
 :- pred foo(bar::in, baz::out) is det.
 
-% All toplevel syntax elements end with a '.' -- a full stop.
+% 모든 최상위 구문 요소는 '.'(마침표)로 끝납니다.
 
-% Mercury terminology comes from predicate logic. Very roughly:
+% Mercury 용어는 술어 논리에서 유래했습니다. 대략적으로:
 
 % | Mercury               | C                            |
 % |                       |                              |
-% | Goal                  | statement                    |
-% | expression            | expression                   |
-% | predicate rule        | void function                |
-% | function rule         | function                     |
-% | head (of a rule)      | function name and parameters |
-% | body (of a rule)      | function body                |
-% | fact                  | (rule without a body)        |
-% | pred/func declaration | function signature           |
-% | A, B  (conjunction)   | A && B                       |
-% | A ; B (disjunction)   | if (A) {} else if (B) {}     |
+% | Goal (목표)           | statement (문장)             |
+% | expression (표현식)   | expression (표현식)          |
+% | predicate rule (술어 규칙) | void function (void 함수) |
+% | function rule (함수 규칙) | function (함수)              |
+% | head (of a rule) (헤드) | function name and parameters |
+% | body (of a rule) (본문) | function body (함수 본문)    |
+% | fact (사실)           | (rule without a body) (본문 없는 규칙) |
+% | pred/func declaration | function signature (함수 시그니처) |
+% | A, B (논리곱)         | A && B                       |
+% | A ; B (논리합)        | if (A) {} else if (B) {}     |
 
-% some facts:
-man(socrates).  % "it is a fact that Socrates is a man"
+% 몇 가지 사실:
+man(socrates).  % "소크라테스는 사람이라는 사실입니다"
 man(plato).
 man(aristotle).
 
-% a rule:
-mortal(X) :- man(X).  % "It is a rule that X is a mortal if X is a man."
-%            ^^^^^^-- the body of the rule
-%         ^^-- an arrow <--, pointing to the head from the body
-%^^^^^^^^-- the head of the rule
-% this is also a single clause that defines the rule.
+% 규칙:
+mortal(X) :- man(X).  % "X가 사람이면 X는 필멸자라는 규칙입니다."
+%            ^^^^^^-- 규칙의 본문
+%         ^^-- 화살표 <--, 본문에서 헤드를 가리킴
+%^^^^^^^^-- 규칙의 헤드
+% 이것은 또한 규칙을 정의하는 단일 절입니다.
 
-% that X is capitalized is how you know it's a variable.
-% that socrates is uncapitalized is how you know it's a term.
+% X가 대문자라는 것으로 변수임을 알 수 있습니다.
+% socrates가 소문자라는 것으로 항임을 알 수 있습니다.
 
-% it's an error for 'socrates' to be undefined. It must have a type:
+% 'socrates'가 정의되지 않으면 오류입니다. 타입을 가져야 합니다:
 
-% declarations begin with ':-'
+% 선언은 ':-'로 시작합니다.
 :- type people
     --->    socrates
     ;       plato
     ;       aristotle
     ;       hermes.
-    %<--first tab stop (using 4-space tabs)
-            %<--third tab stop (first after --->)
+    %<--첫 번째 탭 정지 (4칸 탭 사용)
+            %<--세 번째 탭 정지 (---> 다음 첫 번째)
 
-:- pred man(people).  % rules and facts also require types
+:- pred man(people).  % 규칙과 사실도 타입이 필요합니다.
 
-% a rule's modes tell you how it can be used.
-:- mode man(in) is semidet.  % man(plato) succeeds. man(hermes) fails.
-:- mode man(out) is multi.   % man(X) binds X to one of socrates ; plato ; aristotle
+% 규칙의 모드는 사용 방법을 알려줍니다.
+:- mode man(in) is semidet.  % man(plato)는 성공합니다. man(hermes)는 실패합니다.
+:- mode man(out) is multi.   % man(X)는 X를 socrates, plato, aristotle 중 하나에 바인딩합니다.
 
-% a semidet predicate is like a test. It doesn't return a value, but
-% it can succeed or fail, triggering backtracking or the other side of
-% a disjunction or conditional.
+% semidet 술어는 테스트와 같습니다. 값을 반환하지는 않지만
+% 성공하거나 실패할 수 있으며, 백트래킹이나 논리합 또는
+% 조건문의 다른 쪽을 트리거합니다.
 
-% 'is semidet' provides the determinism of a mode. Other determinisms:
-% | Can fail? | 0 solutions | 1       | more than 1 |
-% |           |             |         |             |
-% | no        | erroneous   | det     | multi       |
-% | yes       | failure     | semidet | nondet      |
+% 'is semidet'은 모드의 결정성을 제공합니다. 다른 결정성:
+% | 실패할 수 있는가? | 해 없음     | 1개      | 1개 이상    |
+% |                   |             |          |             |
+% | 아니요            | 오류        | det      | multi       |
+% | 예                | 실패        | semidet  | nondet      |
 
-:- pred mortal(people::in) is semidet.  % type/mode in one declaration
+:- pred mortal(people::in) is semidet.  % 하나의 선언에 타입/모드
 
-% this rule's body consists of two conjunctions: A, B, C
-% this rule is true if A, B, and C are all true.
-% if age(P) returns 16, it fails.
-% if alive(P) fails, it fails.
+% 이 규칙의 본문은 두 개의 논리곱 A, B, C로 구성됩니다.
+% 이 규칙은 A, B, C가 모두 참일 때 참입니다.
+% age(P)가 16을 반환하면 실패합니다.
+% alive(P)가 실패하면 실패합니다.
 :- type voter(people::in) is semidet.
 voter(P) :-
     alive(P),
     registered(P, locale(P)),
-    age(P) >= 18.  % age/1 is a function; int.>= is a function used as an operator
+    age(P) >= 18.  % age/1은 함수이고, int.>=는 연산자로 사용되는 함수입니다.
 
-% "a P is a voter if it is alive, is registered in P's locale, and if
-% P's age is 18 or older."
+% "P는 살아있고, P의 지역에 등록되어 있으며, P의 나이가
+% 18세 이상이면 유권자입니다."
 
-% the >= used here is provided by the 'int' module, which isn't
-% imported by default. Mercury has a very small 'Prelude' (the
-% 'builtin' module). You even need to import the 'list' module if
-% you're going to use list literals.
+% 여기에 사용된 >=는 기본적으로 가져오지 않는 'int' 모듈에서 제공됩니다.
+% Mercury는 매우 작은 'Prelude'('builtin' 모듈)를 가지고 있습니다.
+% 리스트 리터럴을 사용하려면 'list' 모듈도 가져와야 합니다.
 ```
 
-Complete runnable example. File in 'types.m'; compile with 'mmc --make types'.
+완전한 실행 가능 예제. 'types.m' 파일에 있으며 'mmc --make types'로 컴파일합니다.
 
 ```prolog
 :- module types.
 :- interface.
-:- import_module io.  % required for io.io types in...
-% main/2 is usually 'det'. threading and exceptions require 'cc_multi'
-:- pred main(io::di, io::uo) is cc_multi.  % program entry point
+:- import_module io.  % io.io 타입에 필요...
+% main/2는 보통 'det'입니다. 스레딩 및 예외는 'cc_multi'가 필요합니다.
+:- pred main(io::di, io::uo) is cc_multi.  % 프로그램 진입점
 :- implementation.
 :- import_module int, float, string, list, bool, map, exception.
 
-% enum.
+% 열거형.
 :- type days
     --->    sunday
     ;       monday
@@ -118,11 +114,11 @@ Complete runnable example. File in 'types.m'; compile with 'mmc --make types'.
     ;       friday
     ;       saturday.
 
-% discriminated union, like datatype in ML.
+% 식별 합집합, ML의 데이터 타입과 유사.
 :- type payment_method
     --->    cash(int)
     ;       credit_card(
-                name :: string,         % named fields
+                name :: string,         % 이름 있는 필드
                 cc_number :: string,
                 cvv :: int,
                 expiration :: string
@@ -131,15 +127,15 @@ Complete runnable example. File in 'types.m'; compile with 'mmc --make types'.
 
 :- type coin_type
     --->    etherium
-    ;       monero.  % "other coins are available"
+    ;       monero.  % "다른 코인도 사용 가능"
 
-% type aliases.
+% 타입 별칭.
 :- type wallet == string.
 :- type amount == int.
 
-% !IO is the pair of io.io arguments
-% pass it to anything doing I/O, in order to perform I/O.
-% many otherwise-impure functions can 'attach to the I/O state' by taking !IO
+% !IO는 io.io 인수의 쌍입니다.
+% I/O를 수행하기 위해 I/O를 수행하는 모든 것에 전달하십시오.
+% 그렇지 않으면 순수하지 않은 많은 함수가 !IO를 사용하여 'I/O 상태에 연결'할 수 있습니다.
 main(!IO) :-
     Ints = [
         3,
@@ -147,89 +143,89 @@ main(!IO) :-
         8 - 1,
         10 * 2,
         35 / 5,
-        5 / 2,      % truncating division
-        int.div(5, 2),  % floored division
-        div(5, 2),  % (module is unambiguous due to types)
-        5 `div` 2,  % (any binary function can be an operator with ``)
-        7 `mod` 3,  % modulo of floored division
-        7 `rem` 3,  % remainder of truncating division
-        2 `pow` 4,  % 2 to the 4th power
-        (1 + 3) * 2,    % parens have their usual meaning
+        5 / 2,      % 절단 나눗셈
+        int.div(5, 2),  % 내림 나눗셈
+        div(5, 2),  % (타입으로 인해 모호하지 않음)
+        5 `div` 2,  % (모든 이진 함수는 ``를 사용하여 연산자가 될 수 있음)
+        7 `mod` 3,  % 내림 나눗셈의 모듈로
+        7 `rem` 3,  % 절단 나눗셈의 나머지
+        2 `pow` 4,  % 2의 4제곱
+        (1 + 3) * 2,    % 괄호는 일반적인 의미를 가짐
 
-        2 >> 3,     % bitwise right shift
-        128 << 3,   % bitwise left shift
-        \ 0,        % bitwise complement
-        5 /\ 1,     % bitwise and
-        5 \/ 1,     % bitwise or
-        5 `xor` 3,  % bitwise xor
+        2 >> 3,     % 비트 단위 오른쪽 시프트
+        128 << 3,   % 비트 단위 왼쪽 시프트
+        \ 0,        % 비트 단위 보수
+        5 /\ 1,     % 비트 단위 AND
+        5 \/ 1,     % 비트 단위 OR
+        5 `xor` 3,  % 비트 단위 XOR
 
         max_int,
         min_int,
 
-        5 `min` 3,  % ( if 5 > 3 then 3 else 5 )
+        5 `min` 3,  % ( 5 > 3 이면 3 아니면 5 )
         5 `max` 3
     ],
     Bools = [
         yes,
         no
-        % bools are much less important in Mercury because control flow goes by
-        % semidet goals instead of boolean expressions.
+        % Mercury에서는 제어 흐름이 불리언 표현식 대신
+        % semidet 목표에 의해 이루어지므로 불리언은 훨씬 덜 중요합니다.
     ],
     Strings = [
-        "this is a string",
-        "strings can have "" embedded doublequotes via doubling",
-        "strings support \u4F60\u597D the usual escapes\n",
-        % no implicit concatenation of strings: "concat:" "together"
-        "but you can " ++ " use the string.++ operator",
+        "이것은 문자열입니다",
+        "문자열은 이중화를 통해 \"\" 포함된 큰따옴표를 가질 수 있습니다",
+        "문자열은 일반적인 이스케이프 \u4F60\u597D\n을 지원합니다",
+        % 문자열의 암시적 연결 없음: "concat:" "together"
+        "하지만 string.++ 연산자 " ++ "를 사용할 수 있습니다",
 
-        % second param is a list(string.poly_type)
-        % s/1 is a function that takes a string and returns a poly_type
-        % i/1 takes an int. f/1 takes a float. c/1 takes a char.
-        string.format("Hello, %d'th %s\n", [i(45), s("World")])
+        % 두 번째 매개변수는 list(string.poly_type)입니다.
+        % s/1은 문자열을 받아 poly_type을 반환하는 함수입니다.
+        % i/1은 int를, f/1은 float를, c/1은 char를 받습니다.
+        string.format("안녕하세요, %d번째 %s\n", [i(45), s("세상")])
     ],
 
-    % start with purely functional types like 'map' and 'list'!
-    % arrays and hash tables are available too, but using them
-    % requires knowing a lot more about Mercury
+    % 'map'과 'list'와 같은 순수 함수형 타입으로 시작하십시오!
+    % 배열과 해시 테이블도 사용할 수 있지만, 사용하려면
+    % Mercury에 대해 훨씬 더 많이 알아야 합니다.
     get_map1(Map1),
     get_map2(Map2),
 
-    % list.foldl has *many* variations
-    % this one calls io.print_line(X, !IO) for each X of the list
+    % list.foldl에는 *많은* 변형이 있습니다.
+    % 이것은 리스트의 각 X에 대해 io.print_line(X, !IO)를 호출합니다.
     foldl(io.print_line, Ints, !IO),
     foldl(io.print_line, Bools, !IO),
     foldl(io.print_line, Strings, !IO),
     io.print_line(Map1, !IO),
-    % ( if Cond then ThenGoal else ElseGoal )
-    % I/O not allowed in Cond: I/O isn't allowed to fail!
+    % ( Cond 이면 ThenGoal 아니면 ElseGoal )
+    % Cond에서 I/O 허용 안 됨: I/O는 실패할 수 없습니다!
     ( if Map2^elem(42) = Elem then
         io.print_line(Elem, !IO)
-    else % always required
-        true  % do nothing, successfully (vs. 'fail')
+    else % 항상 필요
+        true  % 아무것도 하지 않고 성공 ('fail'과 반대)
     ),
 
-    % exception handling:
-    ( try [io(!IO)] ( % io/1 param required or no I/O allowed here
+    % 예외 처리:
+    ( try [io(!IO)] ( % io/1 매개변수 필요, 그렇지 않으면 여기서 I/O 허용 안 됨
         io.print_line(received(cash(1234)), !IO),
         io.print_line(received(crypto(monero, "invalid", 123)), !IO)
     ) then
-        io.write_string("all payments accepted\n", !IO) % never reached
-    catch "monero not yet supported" -> % extremely specific catch!
-        io.write_string("monero payment failed\n", !IO)
+        io.write_string("모든 결제 수락됨\n", !IO) % 절대 도달하지 않음
+    catch "monero not yet supported" -> % 매우 구체적인 catch!
+        io.write_string("monero 결제 실패\n", !IO)
     ).
 
 :- pred get_map1(map(string, int)::out) is det.
-get_map1(!:Map) :-  % !:Map in the head is the final (free, unbound) Map
-    !:Map = init,   % !:Map in the body is the next Map
-    det_insert("hello", 1, !Map),  % pair of Map vars
+get_map1(!:Map) :-  % 헤드의 !:Map은 최종 (자유, 바인딩되지 않은) Map입니다.
+    !:Map = init,   % 본문의 !:Map은 다음 Map입니다.
+    det_insert("hello", 1, !Map),  % Map 변수 쌍
     det_insert("world", 2, !Map),
 
-    % debug print of current (bound) Map
-    % other [Params] can make it optional per runtime or compiletime flags
+    % 현재 (바인딩된) Map의 디버그 인쇄
+    % 다른 [Params]는 런타임 또는 컴파일 타임 플래그에 따라 선택 사항으로 만들 수 있습니다.
     trace [io(!IO)] (io.print_line(!.Map, !IO)),
 
     det_insert_from_corresponding_lists(K, V, !Map),
-    % this code is reordered so that K and V and defined prior to their use
+    % 이 코드는 K와 V가 사용되기 전에 정의되도록 재정렬되었습니다.
     K = ["more", "words", "here"],
     V = [3, 4, 5].
 
@@ -238,28 +234,28 @@ get_map2(Map) :-
     det_insert(42, yes, map.init, Map).
 
 :- func received(payment_method) = string.
-received(cash(N)) = string.format("received %d dollars", [i(N)]).
-received(credit_card(_, _, _, _)) = "received credit card".  % _ is throwaway
-received(crypto(Type, _Wallet, Amount)) = S :-  % _Wallet is named throwaway
-    ( % case/switch structure
+received(cash(N)) = string.format("%d달러 받음", [i(N)]).
+received(credit_card(_, _, _, _)) = "신용카드 받음".  % _는 버리는 값
+received(crypto(Type, _Wallet, Amount)) = S :-  % _Wallet은 이름 있는 버리는 값
+    ( % case/switch 구조
         Type = etherium,
-        S = string.format("receiving %d ETH", [i(Amount)])
+        S = string.format("%d ETH 받는 중", [i(Amount)])
     ;
         Type = monero,
-        throw("monero not yet supported")  % exception with string as payload
+        throw("monero는 아직 지원되지 않음")  % 문자열을 페이로드로 사용하는 예외
     ).
 ```
 
-## That was quick! Want more?
+## 빠르네요! 더 원하시나요?
 
-### More Tutorials
+### 추가 튜토리얼
 
-* [Mercury Tutorial](https://mercurylang.org/documentation/papers/book.pdf) (pdf link) - a more traditional tutorial with a more relaxed pace
-* [Mercury Crash Course](https://mercury-in.space/crash.html) - a dense example-driven tutorial with Q&A format
-* [GitHub Wiki Tutorial](https://github.com/Mercury-Language/mercury/wiki/Tutorial)
-* [Getting Started with Mercury](https://bluishcoder.co.nz/2019/06/23/getting-started-with-mercury.html) - installation and your first steps
+* [Mercury 튜토리얼](https://mercurylang.org/documentation/papers/book.pdf) (pdf 링크) - 더 여유로운 속도의 더 전통적인 튜토리얼
+* [Mercury Crash Course](https://mercury-in.space/crash.html) - Q&A 형식의 밀도 높은 예제 중심 튜토리얼
+* [GitHub Wiki 튜토리얼](https://github.com/Mercury-Language/mercury/wiki/Tutorial)
+* [Getting Started with Mercury](https://bluishcoder.co.nz/2019/06/23/getting-started-with-mercury.html) - 설치 및 첫 단계
 
-### Documentation
+### 문서
 
-* Language manual, user's guide, and library reference are all at
+* 언어 매뉴얼, 사용자 가이드, 라이브러리 참조는 모두 다음에 있습니다.
   [mercurylang.org](https://mercurylang.org/documentation/documentation.html)

--- a/ko/messagepack.md
+++ b/ko/messagepack.md
@@ -1,5 +1,3 @@
-# messagepack.md (번역)
-
 ---
 category: framework
 name: MessagePack
@@ -8,12 +6,12 @@ contributors:
   - ["Gabriel Chuan", "https://github.com/gczh"]
 ---
 
-MessagePack is an efficient binary serialization format. It lets you exchange data among multiple languages like JSON. The benefits over other formats is that it's faster and smaller.
+MessagePack은 효율적인 바이너리 직렬화 형식입니다. JSON처럼 여러 언어 간에 데이터를 교환할 수 있습니다. 다른 형식에 비해 더 빠르고 작다는 장점이 있습니다.
 
-In MessagePack, small integers are encoded into a single byte, and typical short strings require only one extra byte in addition to the strings themselves. This makes MessagePack useful for efficient transmission over wire.
+MessagePack에서는 작은 정수가 단일 바이트로 인코딩되고, 일반적인 짧은 문자열은 문자열 자체 외에 추가로 1바이트만 필요합니다. 이로 인해 MessagePack은 유선으로 효율적인 전송에 유용합니다.
 
 ```
-# 0. Understanding The Structure ====
+# 0. 구조 이해하기 ====
 
 JSON, 40 Bytes UTF-8
 
@@ -49,7 +47,7 @@ MessagePack, 27 Bytes UTF-8
 
 # 1. JAVA ====
 
-""" Installing with Maven
+""" Maven으로 설치하기
 """
 
 <dependencies>
@@ -63,24 +61,24 @@ MessagePack, 27 Bytes UTF-8
 </dependencies>
 
 
-""" Simple Serialization/Deserialization
+""" 간단한 직렬화/역직렬화
 """
 
-// Create serialize objects.
+// 직렬화 객체 생성.
 List<String> src = new ArrayList<String>();
 src.add("msgpack");
 src.add("kumofs");
 
 MessagePack msgpack = new MessagePack();
-// Serialize
+// 직렬화
 byte[] raw = msgpack.write(src);
 
-// Deserialize directly using a template
+// 템플릿을 사용하여 직접 역직렬화
 List<String> dst1 = msgpack.read(raw, Templates.tList(Templates.TString));
 System.out.println(dst1.get(0));
 System.out.println(dst1.get(1));
 
-// Or, Deserialze to Value then convert type.
+// 또는, 값으로 역직렬화한 다음 타입 변환.
 Value dynamic = msgpack.read(raw);
 List<String> dst2 = new Converter(dynamic)
     .read(Templates.tList(Templates.TString));
@@ -90,23 +88,23 @@ System.out.println(dst2.get(1));
 
 # 2. RUBY ====
 
-""" Installing the Gem
+""" Gem 설치하기
 """
 
 gem install msgpack
 
-""" Streaming API
+""" 스트리밍 API
 """
 
-# serialize a 2-element array [e1, e2]
+# 2개 요소 배열 [e1, e2] 직렬화
 pk = MessagePack::Packer.new(io)
 pk.write_array_header(2).write(e1).write(e2).flush
 
-# deserialize objects from an IO
+# IO에서 객체 역직렬화
 u = MessagePack::Unpacker.new(io)
 u.each { |obj| ... }
 
-# event-driven deserialization
+# 이벤트 기반 역직렬화
 def on_read(data)
   @u ||= MessagePack::Unpacker.new
   @u.feed_each(data) { |obj| ... }
@@ -114,15 +112,15 @@ end
 
 # 3. NODE.JS ====
 
-""" Installing with NPM
+""" NPM으로 설치하기
 """
 
 npm install msgpack5 --save
 
-""" Using in Node
+""" Node에서 사용하기
 """
 
-var msgpack = require('msgpack5')() // namespace our extensions
+var msgpack = require('msgpack5')() // 우리 확장 기능의 네임스페이스
   , a       = new MyType(2, 'a')
   , encode  = msgpack.encode
   , decode  = msgpack.decode
@@ -166,7 +164,7 @@ function mytipeDecode(data) {
 ```
 
 
-# References
+# 참조
 
 - [MessagePack](http://msgpack.org/index.html)
 - [MsgPack vs. JSON: Cut your client-server exchange traffic by 50% with one line of code](http://indiegamr.com/cut-your-data-exchange-traffic-by-up-to-50-with-one-line-of-code-msgpack-vs-json/)

--- a/ko/miniscript.md
+++ b/ko/miniscript.md
@@ -1,5 +1,3 @@
-# miniscript.md (번역)
-
 ---
 name: MiniScript
 contributors:
@@ -7,64 +5,64 @@ contributors:
 filename: miniscript.ms
 ---
 
-**MiniScript** is a simple scripting language designed to be easily embedded in games and other software. It can also be used on the command line, or as a cross-platform game development environment via [Soda](https://github.com/JoeStrout/soda) or [Mini Micro](https://miniscript.org/MiniMicro).
+**MiniScript**는 게임 및 기타 소프트웨어에 쉽게 내장되도록 설계된 간단한 스크립팅 언어입니다. 명령줄에서 사용하거나 [Soda](https://github.com/JoeStrout/soda) 또는 [Mini Micro](https://miniscript.org/MiniMicro)를 통해 크로스 플랫폼 게임 개발 환경으로 사용할 수도 있습니다.
 
-An easy way to get started with MiniScript is on the [Try-It! page](https://miniscript.org/tryit/), which runs MiniScript code on the server. Note however that the code on this page is limited to 2000 characters. (The tutorial scripts below are broken up into blocks 2048 characters or less so they will run on the Try-It! page.)
+MiniScript를 시작하는 쉬운 방법은 서버에서 MiniScript 코드를 실행하는 [Try-It! 페이지](https://miniscript.org/tryit/)를 이용하는 것입니다. 그러나 이 페이지의 코드는 2000자로 제한됩니다. (아래 튜토리얼 스크립트는 Try-It! 페이지에서 실행되도록 2048자 이하의 블록으로 나뉘어 있습니다.)
 
-Once you are ready to go beyond the Try-It! page, your next stop should probably be to download [Mini Micro](https://miniscript.org/MiniMicro), a free virtual computer that uses MiniScript both on the command line and in programs. In that environment, enter **edit** at the prompt to edit code, then click the Run button in the editor to run it.
+Try-It! 페이지를 넘어설 준비가 되면, 다음 단계는 명령줄과 프로그램 모두에서 MiniScript를 사용하는 무료 가상 컴퓨터인 [Mini Micro](https://miniscript.org/MiniMicro)를 다운로드하는 것입니다. 해당 환경에서 프롬프트에 **edit**를 입력하여 코드를 편집한 다음, 편집기에서 실행 버튼을 클릭하여 실행하십시오.
 
 ```
 print "Hello world"
 
-// MiniScript is very syntax-light. Notice that no parentheses are
-// needed on the print statement above. Comments begin with //, and
-// extend to the end of the line. MiniScript is case-sensitive.
+// MiniScript는 매우 구문이 가볍습니다. 위 print 문에 괄호가
+// 필요하지 않다는 점에 유의하십시오. 주석은 //로 시작하여
+// 줄 끝까지 이어집니다. MiniScript는 대소문자를 구분합니다.
 
-// CONTROL FLOW
-// Use if blocks to do different things depending on some condition.
-// Include zero or more else if blocks, and one optional else block.
+// 흐름 제어
+// 어떤 조건에 따라 다른 작업을 수행하려면 if 블록을 사용하십시오.
+// 0개 이상의 else if 블록과 선택적인 else 블록 하나를 포함할 수 있습니다.
 if 2+2 == 4 then
-   print "math works!"
+   print "수학이 작동합니다!"
 else if pi > 3 then
-   print "pi is tasty"
+   print "파이는 맛있습니다"
 else if "a" < "b" then
-   print "I can sort"
+   print "정렬할 수 있습니다"
 else
-   print "last chance"
+   print "마지막 기회"
 end if
 
-// LOOPING
-// MiniScript has only two loop constructs: while loops and for loops.
-// Use a while block to loop as long as a condition is true.
+// 반복
+// MiniScript에는 while 루프와 for 루프 두 가지 반복 구문만 있습니다.
+// 조건이 참인 동안 반복하려면 while 블록을 사용하십시오.
 s = "Spam"
 while s.len < 50
     s = s + ", spam"
 end while
 print s + " and spam!"
 
-// A for loop can loop over any list, including ones easily created
-// with the range function.
+// for 루프는 range 함수로 쉽게 만들 수 있는 리스트를 포함하여
+// 모든 리스트를 반복할 수 있습니다.
 for i in range(10, 1)
     print i + "..."
 end for
-print "Liftoff!"
+print "발사!"
 
-// Two additional keywords are useful inside loops. The break statement
-// jumps out of the nearest while or for loop. The continue statement
-// jumps to the top of the loop, skipping the rest of the current iteration.
+// 루프 내에서 유용한 두 가지 추가 키워드가 있습니다. break 문은
+// 가장 가까운 while 또는 for 루프를 빠져나옵니다. continue 문은
+// 현재 반복의 나머지 부분을 건너뛰고 루프의 맨 위로 점프합니다.
 for i in range(1,100)
-    if i % 3 == 0 then continue  // skip multiples of 3
-    if i^2 > 200 then break  // stop when i^2 is over 200
-    print i + " squared is " + i^2
+    if i % 3 == 0 then continue  // 3의 배수 건너뛰기
+    if i^2 > 200 then break  // i^2이 200을 초과하면 중지
+    print i + "의 제곱은 " + i^2
 end for
 ```
 
-### Numbers
+### 숫자
 
 ```
-// All numbers are stored in full-precision format. Numbers also
-// represent true (1) and false (0), and there are built-in keywords
-// (true and false) for those.
+// 모든 숫자는 전체 정밀도 형식으로 저장됩니다. 숫자는 또한
+// 참(1)과 거짓(0)을 나타내며, 이에 대한 내장 키워드
+// (true 및 false)가 있습니다.
 a = 7
 b = 3
 ultimateAnswer = 42
@@ -73,79 +71,79 @@ n = true
 m = false
 print ultimateAnswer + ", " + pi + ", " + n + ", " + m
 
-// Numbers support the following operators:
-print "Basic math:"
-print a + b     // addition
-print a - b     // subtraction
-print a * b     // multiplication
-print a / b     // division
-print a % b     // modulo (remainder)
-print a ^ b     // power
+// 숫자는 다음 연산자를 지원합니다:
+print "기본 수학:"
+print a + b     // 덧셈
+print a - b     // 뺄셈
+print a * b     // 곱셈
+print a / b     // 나눗셈
+print a % b     // 모듈로 (나머지)
+print a ^ b     // 거듭제곱
 
-print "Logic:"
-print n and m   // logical "and"
-print n or m    // logical "or"
-print not n     // logical negation
+print "논리:"
+print n and m   // 논리 "and"
+print n or m    // 논리 "or"
+print not n     // 논리 부정
 
-print "Comparisons:"
-print a == b    // equality test (note == rather than = here!)
-print a != b    // inequality
-print a > b     // greater than
-print a >= b    // greater than or equal
-print a < b     // less than
-print a <= b    // less than or equal
+print "비교:"
+print a == b    // 동등성 테스트 (여기서는 =가 아닌 ==에 유의!)
+print a != b    // 부등
+print a > b     // 보다 큼
+print a >= b    // 보다 크거나 같음
+print a < b     // 보다 작음
+print a <= b    // 보다 작거나 같음
 ```
 
-### Strings
+### 문자열
 
 ```
-// Text is stored in strings of Unicode characters. Write strings
-// by surrounding them with quotes. If you need to include a
-// quotation mark in a string, type it twice.
+// 텍스트는 유니코드 문자의 문자열로 저장됩니다. 따옴표로
+// 둘러싸서 문자열을 작성합니다. 문자열에 인용 부호를 포함해야
+// 하는 경우 두 번 입력하십시오.
 print "Hello, ""Bob""."
 a = "Hello"
 b = "Spam"
 
-// Strings support the following operators:
-print "String ""math"":"
-print a + b     // string concatenation
-print b - "m"   // string subtraction (chop)
-print b * 4     // string replication
-print a / 2     // string division
+// 문자열은 다음 연산자를 지원합니다:
+print "문자열 ""수학"":"
+print a + b     // 문자열 연결
+print b - "m"   // 문자열 빼기 (자르기)
+print b * 4     // 문자열 복제
+print a / 2     // 문자열 나누기
 
-print "Comparisons:"
-print a == b    // equality test (note == rather than = here!)
-print a != b    // inequality
-print a > b     // greater than
-print a >= b    // greater than or equal
-print a < b     // less than
-print a <= b    // less than or equal
+print "비교:"
+print a == b    // 동등성 테스트 (여기서는 =가 아닌 ==에 유의!)
+print a != b    // 부등
+print a > b     // 보다 큼
+print a >= b    // 보다 크거나 같음
+print a < b     // 보다 작음
+print a <= b    // 보다 작거나 같음
 
-// Indexing and slicing in a string is done with an index (or two)
-// in square brackets. Use a 0-based index to count from the front,
-// or a negative index to count from the end. Get a slice (substring)
-// with two indices, separated by a colon. Either one may be omitted
-// to extend the slice to the beginning or end of the string.
-print "Indexing and slicing:"
-print a[0]      // get a character, starting with 0 ("H")
-print a[1]      // get second character ("e")
-print a[-1]     // negative numbers count from the end ("o")
-print a[1:4]    // get slice from 1 up to (but not including) 4 ("ell")
-print a[1:-1]   // same as above, but using a negative index
-print a[1:]     // get slice from 1 to the end ("ello")
-print a[:2]     // get slice from beginning up to 2 ("He")
+// 문자열의 인덱싱 및 슬라이싱은 대괄호 안에 인덱스(또는 두 개)를
+// 사용하여 수행됩니다. 앞에서부터 세려면 0부터 시작하는 인덱스를 사용하고,
+// 뒤에서부터 세려면 음수 인덱스를 사용합니다. 콜론으로 구분된
+// 두 개의 인덱스로 슬라이스(부분 문자열)를 가져옵니다. 둘 중 하나를 생략하여
+// 슬라이스를 문자열의 시작 또는 끝까지 확장할 수 있습니다.
+print "인덱싱 및 슬라이싱:"
+print a[0]      // 0부터 시작하는 문자 가져오기 ("H")
+print a[1]      // 두 번째 문자 가져오기 ("e")
+print a[-1]     // 음수는 뒤에서부터 셉니다 ("o")
+print a[1:4]    // 1부터 4 미만까지 슬라이스 가져오기 ("ell")
+print a[1:-1]   // 위와 같지만 음수 인덱스 사용
+print a[1:]     // 1부터 끝까지 슬라이스 가져오기 ("ello")
+print a[:2]     // 처음부터 2 미만까지 슬라이스 가져오기 ("He")
 
-// Note that strings in MiniScript are immutable. You can't reach
-// into a string and change what characters it contains (but you can
-// always create a new string with different characters).
+// MiniScript의 문자열은 불변입니다. 문자열에 접근하여
+// 포함된 문자를 변경할 수는 없지만(항상 다른 문자로
+// 새 문자열을 만들 수는 있습니다).
 ```
 
-### Lists
+### 리스트
 
 ```
-// A list is an ordered sequence of values of any type. You can
-// iterate over a list with a for loop, or iterate over the indexes
-// using .indexes.
+// 리스트는 모든 유형의 값으로 구성된 순서 있는 시퀀스입니다.
+// for 루프로 리스트를 반복하거나 .indexes를 사용하여
+// 인덱스를 반복할 수 있습니다.
 x = ["alpha", "beta", "gamma", "delta"]
 for item in x
     print item
@@ -154,85 +152,83 @@ for i in x.indexes
     print "x[" + i + "] is " + x[i]
 end for
 
-// Indexing and slicing in a list is exactly like a string: use a
-// 0-based index to count from the front, or a negative number to
-// count from the end. Get a slice (subset) of a list with two
-// indices, separated by a colon. Either one may be omitted
-// to extend the slice to the beginning or end of the list.
+// 리스트의 인덱싱 및 슬라이싱은 문자열과 정확히 같습니다.
+// 앞에서부터 세려면 0부터 시작하는 인덱스를 사용하고, 뒤에서부터
+// 세려면 음수를 사용합니다. 콜론으로 구분된 두 개의 인덱스로
+// 리스트의 슬라이스(부분 집합)를 가져옵니다. 둘 중 하나를 생략하여
+// 슬라이스를 리스트의 시작 또는 끝까지 확장할 수 있습니다.
 print x[0]      // alpha
 print x[-1]     // delta
 print x[1:3]    // [beta, gamma]
 print x[2:]     // [gamma, delta]
 print x[:-1]    // [alpha, beta, gamma]
 
-// Lists support the following operators:
+// 리스트는 다음 연산자를 지원합니다:
 y = ["a", "be", "ce", "de"]
-print "List ""math"":"
-print x + y     // list concatenation
-print y * 3     // list replication
-print x / 2     // list division
+print "리스트 ""수학"":"
+print x + y     // 리스트 연결
+print y * 3     // 리스트 복제
+print x / 2     // 리스트 나누기
 
-print "Comparisons:"
-print x == y    // equality test (note == rather than = here!)
-print x != y    // inequality
+print "비교:"
+print x == y    // 동등성 테스트 (여기서는 =가 아닌 ==에 유의!)
+print x != y    // 부등
 ```
 
-### Maps
+### 맵
 
 ```
-// A map is a set of values associated with unique keys. Maps
-// are an extremely powerful and versatile data type, used to
-// represent data records, objects, sparse arrays, and much more.
-// Create a map with curly braces; get or set a single value
-// with square brackets. Keys and values may be any type.
-// ("Key" and "index" mean the same thing in the context of a map.)
+// 맵은 고유한 키와 연관된 값의 집합입니다. 맵은
+// 데이터 레코드, 객체, 희소 배열 등을 나타내는 데 사용되는
+// 매우 강력하고 다재다능한 데이터 유형입니다.
+// 중괄호로 맵을 만들고 대괄호로 단일 값을 가져오거나
+// 설정합니다. 키와 값은 모든 유형이 될 수 있습니다.
+// (맵의 컨텍스트에서 "키"와 "인덱스"는 같은 의미입니다.)
 m = {1:"one", 2:"two"}
 print m[1]      // one
-m[2] = "dos"    // change the value associated with index 2
+m[2] = "dos"    // 인덱스 2와 연관된 값 변경
 print m[2]      // dos
 
-// In the special case where the key (index) is a string that
-// would be a valid variable name, there is an alternate to the
-// square-bracket syntax called dot syntax. Just put the key,
-// without quotes, after the map and a dot (period).
-m.pi = 3.14     // equivalent to: m["pi"] = 3.14
+// 키(인덱스)가 유효한 변수 이름이 되는 문자열인 특수한 경우,
+// 대괄호 구문 대신 점 구문이 있습니다. 맵과 점(마침표) 뒤에
+// 따옴표 없이 키를 넣으십시오.
+m.pi = 3.14     // m["pi"] = 3.14와 동일
 print m["pi"]   // 3.14
-m["e"] = 2.72   // equivalent to: m.e = 2.72
+m["e"] = 2.72   // m.e = 2.72와 동일
 print m.e       // 2.72
 
-// Maps support only the + operator, which combines all the key/value
-// pairs from two maps into one.
+// 맵은 + 연산자만 지원하며, 두 맵의 모든 키/값 쌍을
+// 하나로 결합합니다.
 m1 = {1:"one", 2:"two"}
 m2 = {2:"dos", 3:"tres"}
-print m1 + m2   // map concatenation
+print m1 + m2   // 맵 연결
 
-// You can iterate over the key/value pairs in a map with a for loop.
-// On each iteration, the variable will be itself a little map with
-// "key" and "value" indexes.
+// for 루프로 맵의 키/값 쌍을 반복할 수 있습니다.
+// 각 반복에서 변수는 "key"와 "value" 인덱스가 있는
+// 작은 맵이 됩니다.
 for kv in m1+m2
     print kv.key + " -> " + kv.value
 end for
 
-// Note that the order of key/value pairs in a map is undefined.
-// You should never rely on them appearing in a particular order
-// when you print or iterate over a map.
+// 맵의 키/값 쌍 순서는 정의되지 않습니다.
+// 맵을 인쇄하거나 반복할 때 특정 순서로 나타날 것이라고
+// 가정해서는 안 됩니다.
 ```
 
-### Functions
+### 함수
 
 ```
-// Create a function in miniscript with a function...end function
-// block. In most cases you will assign the result to a variable
-// so you can call it later. If a function needs to return a
-// a result, do that with the return keyword.
+// miniscript에서 함수는 function...end function 블록으로 만듭니다.
+// 대부분의 경우 나중에 호출할 수 있도록 결과를 변수에 할당합니다.
+// 함수가 결과를 반환해야 하는 경우 return 키워드로 수행합니다.
 rollDie = function
-    return ceil(rnd * 6)  // return a random number from 1-6
+    return ceil(rnd * 6)  // 1-6 사이의 난수 반환
 end function
 print rollDie
 print rollDie
 
-// If it needs parameters, put them after function keyword inside
-// parentheses. Parameters may have default values.
+// 매개변수가 필요한 경우 function 키워드 뒤에 괄호 안에 넣습니다.
+// 매개변수는 기본값을 가질 수 있습니다.
 roll = function(numberOfDice, sides=6)
     sum = 0
     for i in range(1, numberOfDice)
@@ -240,21 +236,18 @@ roll = function(numberOfDice, sides=6)
     end for
     return sum
 end function
-print roll(2)     // roll two 6-sided dice
-print roll(2,20)  // roll two 20-sided dice
+print roll(2)     // 6면체 주사위 2개 굴리기
+print roll(2,20)  // 20면체 주사위 2개 굴리기
 
-// Variables are always local by default in MiniScript. The
-// variables i and sum in the function above are not accessible
-// outside the function, and disappear as soon as the function
-// returns. (We'll talk more about variable scope later.)
+// 변수는 MiniScript에서 기본적으로 항상 지역 변수입니다.
+// 위 함수의 변수 i와 sum은 함수 외부에서 액세스할 수 없으며
+// 함수가 반환되는 즉시 사라집니다. (변수 범위에 대해서는 나중에 자세히 설명합니다.)
 
-// Parentheses are needed only if (1) you're passing arguments
-// (parameter values) to the function, and (2) you're using the
-// result as part of some larger statement. Notice how the first
-// example above, rollDie did not need any parentheses because we
-// weren't passing any arguments. Here's an example of a function
-// that, like the built-in print function, is used as a statement
-// by itself, and so does not need parentheses.
+// 괄호는 (1) 함수에 인수(매개변수 값)를 전달하고 있고
+// (2) 결과를 더 큰 문의 일부로 사용하는 경우에만 필요합니다.
+// 위의 첫 번째 예제에서 rollDie는 인수를 전달하지 않았기 때문에
+// 괄호가 필요하지 않았습니다. 다음은 내장 print 함수와 같이
+// 그 자체로 문으로 사용되어 괄호가 필요하지 않은 함수의 예입니다.
 doRoll = function(numberOfDice, sides=6)
     print "Rolling " + numberOfDice + "d" + sides + "..."
     sum = 0
@@ -265,92 +258,88 @@ doRoll = function(numberOfDice, sides=6)
     end for
     print "Your total is: " + sum
 end function
-doRoll 3         // roll 3d6 -- note no parentheses needed
-doRoll 3, 8      // same here, but rolling 3d6
+doRoll 3         // 3d6 굴리기 -- 괄호 필요 없음
+doRoll 3, 8      // 여기도 마찬가지지만 3d8 굴리기
 
-// If you ever need to refer to a function without invoking it,
-// you can do so with the @ operator.
-f = @doRoll      // makes f refer to the same function as doRoll
-f 2,4            // rolls 2d4
+// 함수를 호출하지 않고 참조해야 하는 경우 @ 연산자를 사용할 수 있습니다.
+f = @doRoll      // f가 doRoll과 동일한 함수를 참조하도록 함
+f 2,4            // 2d4 굴리기
 ```
 
-### Classes and Objects
+### 클래스와 객체
 
 ```
-// MiniScript uses prototype-based inheritance. A class or object
-// is just a map with a special __isa entry that points to the
-// parent class. This is set automatically when you use the new
-// operator.
-Shape = {}            // make a base class
-Shape.sides = 0       // give it 0 sides by default
+// MiniScript는 프로토타입 기반 상속을 사용합니다. 클래스나 객체는
+// 부모 클래스를 가리키는 특수 __isa 항목이 있는 맵일 뿐입니다.
+// 이것은 new 연산자를 사용할 때 자동으로 설정됩니다.
+Shape = {}            // 기본 클래스 만들기
+Shape.sides = 0       // 기본적으로 0개의 변을 가짐
 
-Square = new Shape    // make a subclass of Shape called Square
-Square.sides = 4      // override the number of sides
+Square = new Shape    // Shape의 서브클래스 Square 만들기
+Square.sides = 4      // 변의 수 재정의
 
-x = new Square        // create an instance of the Square class
-print x.sides         // 4, because x is a Square and Square.sides is 4
+x = new Square        // Square 클래스의 인스턴스 만들기
+print x.sides         // 4, x는 Square이고 Square.sides는 4이므로
 
-// A method is just a function stored in a class (map). These
-// are inherited through the __isa chain, just like other values.
-// Within a method, the keyword self refers to the object on which
-// the method was invoked (using dot syntax). This is how you
-// refer to data or methods on the object.
+// 메서드는 클래스(맵)에 저장된 함수일 뿐입니다. 이들은
+// 다른 값과 마찬가지로 __isa 체인을 통해 상속됩니다.
+// 메서드 내에서 self 키워드는 메서드가 호출된 객체(점 구문 사용)를
+// 참조합니다. 이것이 객체의 데이터나 메서드를 참조하는 방법입니다.
 Shape.describe = function
     print
     print "This is a " + self.sides + "-sided shape."
 end function
 x.describe            // This is a 4-sided shape.
 
-// Methods may be overridden (again just like values). In a
-// subclass/instance method, you may use super to invoke the next
-// version of the method up the inheritance chain, while still
-// keeping self bound to the object this method was called on.
+// 메서드는 (다시 값처럼) 재정의될 수 있습니다. 서브클래스/인스턴스
+// 메서드에서 super를 사용하여 상속 체인의 다음 버전 메서드를
+// 호출하면서도 self를 이 메서드가 호출된 객체에 바인딩된 상태로
+// 유지할 수 있습니다.
 Square.describe = function
-    super.describe    // first, do the standard description
-    print "It looks very squarish."  // then add this
+    super.describe    // 먼저 표준 설명 수행
+    print "It looks very squarish."  // 그런 다음 이것을 추가
 end function
 x.describe
 ```
 
-### More on Variable Scope
+### 변수 범위에 대한 추가 정보
 
 ```
-// Variables assignments in MiniScript always create or update
-// a local variable, i.e., one that exists only within the function
-// containing the assignment, unless dot syntax is used to specify
-// some other scope.
-x = 42      // here's a global variable called x
+// MiniScript의 변수 할당은 항상 지역 변수, 즉
+// 할당을 포함하는 함수 내에서만 존재하는 변수를 만들거나
+// 업데이트합니다. 단, 점 구문을 사용하여 다른 범위를 지정하는 경우는
+// 예외입니다.
+x = 42      // x라는 전역 변수
 f = function
-    x = 1234   // make a local variable, also called x
+    x = 1234   // x라는 지역 변수 만들기
     print "Inside the function, x is now " + x
 end function
 f
 print "Outside the function, x is " + x
 
-// In the example above, the assignment to x inside the function
-// has no effect on the global value of x, even though they happen
-// to have the same name. (This is a Good Thing because it helps
-// you avoid unintended side-effects in your code.)  Global variables
-// are generally discouraged, but if you must update one inside
-// a function, you can use a "globals." prefix to do so.
+// 위 예에서 함수 내의 x에 대한 할당은
+// 우연히 같은 이름을 가졌음에도 불구하고 전역 x 값에
+// 영향을 미치지 않습니다. (이것은 의도하지 않은 부작용을
+// 피하는 데 도움이 되므로 좋은 점입니다.) 전역 변수는
+// 일반적으로 권장되지 않지만, 함수 내에서 업데이트해야 하는 경우
+// "globals." 접두사를 사용하여 그렇게 할 수 있습니다.
 f = function
     print "Using the globals prefix..."
-    globals.x = 1234   // update the global variable x
+    globals.x = 1234   // 전역 변수 x 업데이트
     print "Inside the function, x is now " + x
 end function
 f
 print "Outside the function, x is " + x
 
-// This is very similar to the "self." prefix used with
-// class methods; in both cases, you are giving a more specific
-// scope to a variable (which is really just specifying a map
-// to index into with dot syntax).
+// 이것은 클래스 메서드와 함께 사용되는 "self." 접두사와 매우 유사합니다.
+// 두 경우 모두 변수에 더 구체적인 범위를 제공합니다(실제로는
+// 점 구문으로 인덱싱할 맵을 지정하는 것일 뿐입니다).
 
-// However there is an important difference: when READING (not
-// assigning to) a variable, if the variable name is not found
-// among the local variables, MiniScript will automatically look
-// for a global variable of that name. Thus no "globals." prefix
-// is needed when reading a variable, but only when assigning it.
+// 그러나 중요한 차이점이 있습니다. 변수를 할당하는 것이 아니라
+// 읽을 때, 변수 이름이 지역 변수 중에서 발견되지 않으면
+// MiniScript는 자동으로 해당 이름의 전역 변수를 찾습니다.
+// 따라서 변수를 읽을 때는 "globals." 접두사가 필요하지 않지만
+// 할당할 때는 필요합니다.
 count = 0
 addToCount = function(amount=1)
     globals.count = count + amount
@@ -359,66 +348,64 @@ addToCount
 addToCount
 print "count is now: " + count
 
-// In the addToCount function above, note how we need the globals
-// prefix on the left-hand side of the assignment, since otherwise
-// it would create a local variable. But we don't need it on the
-// right-hand side, where we are merely reading the global value.
+// 위 addToCount 함수에서 할당의 왼쪽에는 globals 접두사가
+// 필요한 반면, 오른쪽에는 전역 값을 읽기만 하므로
+// 필요하지 않다는 점에 유의하십시오.
 ```
 
-### Handy Intrinsic Methods
+### 유용한 내장 메서드
 
 ```
-// Intrinsic methods are ones that are built into MiniScript or its
-// environment. Particular MiniScript environments (e.g. Mini Micro,
-// Soda, command-line MiniScript, some game using MiniScript as an
-// embedded language, etc.) will probably add additional intrinsics.
-// But there is a core of about 50 intrinsics that should always be
-// available.
+// 내장 메서드는 MiniScript나 그 환경에 내장된 메서드입니다.
+// 특정 MiniScript 환경(예: Mini Micro, Soda, 명령줄 MiniScript,
+// MiniScript를 내장 언어로 사용하는 일부 게임 등)은 아마도
+// 추가 내장 함수를 추가할 것입니다. 그러나 항상 사용할 수 있어야 하는
+// 약 50개의 핵심 내장 함수가 있습니다.
 
-// Here's a quick demo of some of the most commonly used ones.
-print abs(-42)         // absolute value
-print pi               // get value of pi (yep, this is built in!)
-print cos(pi)          // cosine
-print sqrt(100)        // square root
-print round(pi, 2)     // round (to 2 decimal places)
-print char(65)         // get Unicode character 65
+// 가장 일반적으로 사용되는 몇 가지에 대한 빠른 데모입니다.
+print abs(-42)         // 절대값
+print pi               // 파이 값 가져오기 (예, 내장되어 있습니다!)
+print cos(pi)          // 코사인
+print sqrt(100)        // 제곱근
+print round(pi, 2)     // 반올림 (소수점 2자리까지)
+print char(65)         // 유니코드 문자 65 가져오기
 
 print
 s = "Hello world!"
-print s.upper          // convert to upper case
-print s.len            // get length (number of characters)
-print s.replace("Hello", "Heya")  // string substitution
-print s.split(" ")     // split on spaces to make a list
-print s.remove("l")    // remove first occurrence of "l"
+print s.upper          // 대문자로 변환
+print s.len            // 길이 가져오기 (문자 수)
+print s.replace("Hello", "Heya")  // 문자열 대체
+print s.split(" ")     // 공백으로 분할하여 리스트 만들기
+print s.remove("l")    // "l"의 첫 번째 항목 제거
 
 print
-a = range(2,15,3)      // make a list: 2 through 10, in steps of 3
+a = range(2,15,3)      // 리스트 만들기: 2부터 15까지, 3단계씩
 print "a: " + a
-print "a.len:" + a.len // get length (number of values)
-print "a.sum:" + a.sum // get sum of adding all values together
-print a.pop            // pop off the last value
-print a.pull           // pull off the first value
+print "a.len:" + a.len // 길이 가져오기 (값 수)
+print "a.sum:" + a.sum // 모든 값을 더한 합계 가져오기
+print a.pop            // 마지막 값 꺼내기
+print a.pull           // 첫 번째 값 꺼내기
 print "popped and pulled: " + a
-a.push 99              // push a new item onto the end
-a.insert 0, 101        // insert a new item at index 0
+a.push 99              // 끝에 새 항목 추가
+a.insert 0, 101        // 인덱스 0에 새 항목 삽입
 print "after push and insert: " + a
-a.remove 2             // remove index 2 from the list
+a.remove 2             // 리스트에서 인덱스 2 제거
 print "after remove 2: " + a
-s = a.join("#")        // make a string by joining values with #
+s = a.join("#")        // #으로 값을 결합하여 문자열 만들기
 print s
 
 print
 m = {"one": "uno", "two": "dos", "three": "tres"}
-print m.hasIndex("one") // check whether a key exists
-print m.indexes         // get all the indexes
-print m.values          // get all the values
-m.remove "two"          // remove an index (and its value)
+print m.hasIndex("one") // 키 존재 여부 확인
+print m.indexes         // 모든 인덱스 가져오기
+print m.values          // 모든 값 가져오기
+m.remove "two"          // 인덱스 (및 해당 값) 제거
 print m
 ```
 
-## Further Reading
+## 더 읽을거리
 
-* [MiniScript.org website](https://miniscript.org/) — center of the MiniScript universe
-* [MiniScript Quick Reference](https://miniscript.org/files/MiniScript-QuickRef.pdf) — this tutorial, in one page
-* [MiniScript User's Manual](https://miniscript.org/files/MiniScript-Manual.pdf) — more in-depth documentation
-* [MiniScript Wiki](https://miniscript.org/wiki/) — community-driven documentation
+* [MiniScript.org 웹사이트](https://miniscript.org/) — MiniScript 세계의 중심
+* [MiniScript 빠른 참조](https://miniscript.org/files/MiniScript-QuickRef.pdf) — 이 튜토리얼을 한 페이지로
+* [MiniScript 사용자 매뉴얼](https://miniscript.org/files/MiniScript-Manual.pdf) — 더 심층적인 문서
+* [MiniScript 위키](https://miniscript.org/wiki/) — 커뮤니티 기반 문서

--- a/ko/mips.md
+++ b/ko/mips.md
@@ -1,5 +1,3 @@
-# mips.md (번역)
-
 ---
 name: "MIPS Assembly"
 filename: MIPS.asm
@@ -7,181 +5,169 @@ contributors:
   - ["Stanley Lim", "https://github.com/Spiderpig86"]
 ---
 
-The MIPS (Microprocessor without Interlocked Pipeline Stages) Assembly language
-is designed to work with the MIPS microprocessor paradigm designed by J. L.
-Hennessy in 1981. These RISC processors are used in embedded systems such as
-gateways and routers.
+MIPS(Microprocessor without Interlocked Pipeline Stages) 어셈블리 언어는 1981년 J. L. Hennessy가 설계한 MIPS 마이크로프로세서 패러다임과 함께 작동하도록 설계되었습니다. 이러한 RISC 프로세서는 게이트웨이 및 라우터와 같은 임베디드 시스템에 사용됩니다.
 
-[Read More](https://en.wikipedia.org/wiki/MIPS_architecture)
+[더 읽어보기](https://en.wikipedia.org/wiki/MIPS_architecture)
 
 ```asm
-# Comments are denoted with a '#'
+# 주석은 '#'으로 표시됩니다.
 
-# Everything that occurs after a '#' will be ignored by the assembler's lexer.
+# '#' 뒤에 오는 모든 것은 어셈블러의 렉서에 의해 무시됩니다.
 
-# Programs typically contain a .data and .text sections
+# 프로그램은 일반적으로 .data와 .text 섹션을 포함합니다.
 
-.data # Section where data is stored in memory (allocated in RAM), similar to
-      # variables in higher-level languages
+.data # 데이터가 메모리에 저장되는 섹션(RAM에 할당됨), 상위 수준 언어의
+      # 변수와 유사합니다.
 
-  # Declarations follow a ( label: .type value(s) ) form of declaration
-  hello_world: .asciiz "Hello World\n"      # Declare a null terminated string
-  num1: .word 42                            # Integers are referred to as words
-                                            # (32-bit value)
+  # 선언은 (레이블: .타입 값) 형식의 선언을 따릅니다.
+  hello_world: .asciiz "Hello World\n"      # null로 끝나는 문자열 선언
+  num1: .word 42                            # 정수는 워드(32비트 값)라고 합니다.
 
-  arr1: .word 1, 2, 3, 4, 5                 # Array of words
-  arr2: .byte 'a', 'b'                      # Array of chars (1 byte each)
-  buffer: .space 60                         # Allocates space in the RAM
-                                            # (not cleared to 0)
+  arr1: .word 1, 2, 3, 4, 5                 # 워드 배열
+  arr2: .byte 'a', 'b'                      # 문자 배열 (각 1바이트)
+  buffer: .space 60                         # RAM에 공간을 할당합니다.
+                                            # (0으로 지워지지 않음)
 
-  # Datatype sizes
-  _byte: .byte 'a'                          # 1 byte
-  _halfword: .half 53                       # 2 bytes
-  _word: .word 3                            # 4 bytes
-  _float: .float 3.14                       # 4 bytes
-  _double: .double 7.0                      # 8 bytes
+  # 데이터 타입 크기
+  _byte: .byte 'a'                          # 1바이트
+  _halfword: .half 53                       # 2바이트
+  _word: .word 3                            # 4바이트
+  _float: .float 3.14                       # 4바이트
+  _double: .double 7.0                      # 8바이트
 
-  .align 2                                  # Memory alignment of data, where
-                                            # number indicates byte alignment
-                                            # in powers of 2. (.align 2
-                                            # represents word alignment since
-                                            # 2^2 = 4 bytes)
+  .align 2                                  # 데이터의 메모리 정렬, 여기서
+                                            # 숫자는 2의 거듭제곱으로
+                                            # 바이트 정렬을 나타냅니다.
+                                            # (.align 2는 2^2 = 4바이트이므로
+                                            # 워드 정렬을 나타냅니다)
 
-.text                                       # Section that contains
-                                            # instructions and program logic
-.globl _main                                # Declares an instruction label as
-                                            # global, making it accessible to
-                                            # other files
+.text                                       # 명령어와 프로그램 로직을
+                                            # 포함하는 섹션
+.globl _main                                # 명령어 레이블을 전역으로 선언하여
+                                            # 다른 파일에서 접근할 수 있도록 합니다.
 
-  _main:                                    # MIPS programs execute
-                                            # instructions sequentially, where
-                                            # the code under this label will be
-                                            # executed first
+  _main:                                    # MIPS 프로그램은 명령어를
+                                            # 순차적으로 실행하며, 이 레이블
+                                            # 아래의 코드가 먼저 실행됩니다.
 
-    # Let's print "hello world"
-    la $a0, hello_world                     # Load address of string stored
-                                            # in memory
-    li $v0, 4                               # Load the syscall value (number
-                                            # indicating which syscall to make)
-    syscall                                 # Perform the specified syscall
-                                            # with the given argument ($a0)
+    # "hello world"를 출력해 봅시다
+    la $a0, hello_world                     # 메모리에 저장된 문자열의
+                                            # 주소 로드
+    li $v0, 4                               # 시스템 호출 값 로드 (어떤
+                                            # 시스템 호출을 할지 나타내는 숫자)
+    syscall                                 # 주어진 인수($a0)로 지정된
+                                            # 시스템 호출 수행
 
-    # Registers (used to hold data during program execution)
-    # $t0 - $t9                             # Temporary registers used for
-                                            # intermediate calculations inside
-                                            # subroutines (not saved across
-                                            # function calls)
+    # 레지스터 (프로그램 실행 중 데이터 보관에 사용)
+    # $t0 - $t9                             # 서브루틴 내부의 중간 계산에
+                                            # 사용되는 임시 레지스터
+                                            # (함수 호출 간에 저장되지 않음)
 
-    # $s0 - $s7                             # Saved registers where values are
-                                            # saved across subroutine calls.
-                                            # Typically saved in stack
+    # $s0 - $s7                             # 서브루틴 호출 간에 값이 저장되는
+                                            # 저장 레지스터.
+                                            # 일반적으로 스택에 저장됨
 
-    # $a0 - $a3                             # Argument registers for passing in
-                                            # arguments for subroutines
-    # $v0 - $v1                             # Return registers for returning
-                                            # values to caller function
+    # $a0 - $a3                             # 서브루틴에 인수를 전달하기 위한
+                                            # 인수 레지스터
+    # $v0 - $v1                             # 호출자 함수에 값을 반환하기 위한
+                                            # 반환 레지스터
 
-    # Types of load/store instructions
-    la $t0, label                           # Copy the address of a value in
-                                            # memory specified by the label
-                                            # into register $t0
-    lw $t0, label                           # Copy a word value from memory
-    lw $t1, 4($s0)                          # Copy a word value from an address
-                                            # stored in a register with an
-                                            # offset of 4 bytes (addr + 4)
-    lb $t2, label                           # Copy a byte value to the
-                                            # lower order portion of
-                                            # the register $t2
-    lb $t2, 0($s0)                          # Copy a byte value from the source
-                                            # address in $s0 with offset 0
-    # Same idea with 'lh' for halfwords
+    # 로드/저장 명령어 유형
+    la $t0, label                           # 레이블로 지정된 메모리의 값의
+                                            # 주소를 레지스터 $t0에 복사
+    lw $t0, label                           # 메모리에서 워드 값 복사
+    lw $t1, 4($s0)                          # 4바이트 오프셋이 있는 레지스터에
+                                            # 저장된 주소에서 워드 값 복사
+                                            # (addr + 4)
+    lb $t2, label                           # 바이트 값을 레지스터 $t2의
+                                            # 하위 부분에 복사
+    lb $t2, 0($s0)                          # $s0의 소스 주소에서 오프셋 0으로
+                                            # 바이트 값 복사
+    # 하프워드의 경우 'lh'와 동일한 아이디어
 
-    sw $t0, label                           # Store word value into
-                                            # memory address mapped by label
-    sw $t0, 8($s0)                          # Store word value into address
-                                            # specified in $s0 and offset of
-                                            # 8 bytes
-    # Same idea using 'sb' and 'sh' for bytes and halfwords. 'sa' does not exist
+    sw $t0, label                           # 레이블로 매핑된 메모리 주소에
+                                            # 워드 값 저장
+    sw $t0, 8($s0)                          # $s0에 지정된 주소와 8바이트
+                                            # 오프셋에 워드 값 저장
+    # 바이트와 하프워드의 경우 'sb'와 'sh'를 사용하는 동일한 아이디어. 'sa'는 존재하지 않음
 
-### Math ###
+### 수학 ###
   _math:
-    # Remember to load your values into a register
-    lw $t0, num                             # From the data section
-    li $t0, 5                               # Or from an immediate (constant)
+    # 레지스터에 값을 로드하는 것을 잊지 마십시오
+    lw $t0, num                             # 데이터 섹션에서
+    li $t0, 5                               # 또는 즉시(상수)에서
     li $t1, 6
     add $t2, $t0, $t1                       # $t2 = $t0 + $t1
     sub $t2, $t0, $t1                       # $t2 = $t0 - $t1
     mul $t2, $t0, $t1                       # $t2 = $t0 * $t1
-    div $t2, $t0, $t1                       # $t2 = $t0 / $t1 (Might not be
-                                            # supported in some versions of MARS)
-    div $t0, $t1                            # Performs $t0 / $t1. Get the
-                                            # quotient using 'mflo' and
-                                            # remainder using 'mfhi'
+    div $t2, $t0, $t1                       # $t2 = $t0 / $t1 (일부 MARS
+                                            # 버전에서는 지원되지 않을 수 있음)
+    div $t0, $t1                            # $t0 / $t1을 수행합니다. 'mflo'를
+                                            # 사용하여 몫을, 'mfhi'를 사용하여
+                                            # 나머지를 가져옵니다
 
-    # Bitwise Shifting
-    sll $t0, $t0, 2                         # Bitwise shift to the left with
-                                            # immediate (constant value) of 2
-    sllv $t0, $t1, $t2                      # Shift left by a variable amount
-                                            # in register
-    srl $t0, $t0, 5                         # Bitwise shift to the right (does
-                                            # not sign preserve, sign-extends
-                                            # with 0)
-    srlv $t0, $t1, $t2                      # Shift right by a variable amount
-                                            # in a register
-    sra $t0, $t0, 7                         # Bitwise arithmetic shift to
-                                            # the right (preserves sign)
-    srav $t0, $t1, $t2                      # Shift right by a variable amount
-                                            # in a register
+    # 비트 시프트
+    sll $t0, $t0, 2                         # 2의 즉시(상수 값)로
+                                            # 왼쪽으로 비트 시프트
+    sllv $t0, $t1, $t2                      # 레지스터의 변수 양만큼
+                                            # 왼쪽으로 시프트
+    srl $t0, $t0, 5                         # 오른쪽으로 비트 시프트 (부호를
+                                            # 보존하지 않음, 0으로 부호 확장)
+    srlv $t0, $t1, $t2                      # 레지스터의 변수 양만큼
+                                            # 오른쪽으로 시프트
+    sra $t0, $t0, 7                         # 오른쪽으로 산술 비트 시프트
+                                            # (부호 보존)
+    srav $t0, $t1, $t2                      # 레지스터의 변수 양만큼
+                                            # 오른쪽으로 시프트
 
-    # Bitwise operators
-    and $t0, $t1, $t2                       # Bitwise AND
-    andi $t0, $t1, 0xFFF                    # Bitwise AND with immediate
-    or $t0, $t1, $t2                        # Bitwise OR
-    ori $t0, $t1, 0xFFF                     # Bitwise OR with immediate
-    xor $t0, $t1, $t2                       # Bitwise XOR
-    xori $t0, $t1, 0xFFF                    # Bitwise XOR with immediate
-    nor $t0, $t1, $t2                       # Bitwise NOR
+    # 비트 연산자
+    and $t0, $t1, $t2                       # 비트 AND
+    andi $t0, $t1, 0xFFF                    # 즉시와 비트 AND
+    or $t0, $t1, $t2                        # 비트 OR
+    ori $t0, $t1, 0xFFF                     # 즉시와 비트 OR
+    xor $t0, $t1, $t2                       # 비트 XOR
+    xori $t0, $t1, 0xFFF                    # 즉시와 비트 XOR
+    nor $t0, $t1, $t2                       # 비트 NOR
 
-## BRANCHING ##
+## 분기 ##
   _branching:
-    # The basic format of these branching instructions typically follow <instr>
-    # <reg1> <reg2> <label> where label is the label we want to jump to if the
-    # given conditional evaluates to true
-    # Sometimes it is easier to write the conditional logic backward, as seen
-    # in the simple if statement example below
+    # 이러한 분기 명령어의 기본 형식은 일반적으로 <instr>
+    # <reg1> <reg2> <label>을 따르며, 여기서 label은
+    # 주어진 조건이 참으로 평가될 경우 점프하려는 레이블입니다.
+    # 아래의 간단한 if 문 예제에서 볼 수 있듯이
+    # 조건 논리를 거꾸로 작성하는 것이 더 쉬울 때가 있습니다.
 
-    beq $t0, $t1, reg_eq                    # Will branch to reg_eq if
-                                            # $t0 == $t1, otherwise
-                                            # execute the next line
-    bne $t0, $t1, reg_neq                   # Branches when $t0 != $t1
-    b branch_target                         # Unconditional branch, will
-                                            # always execute
-    beqz $t0, req_eq_zero                   # Branches when $t0 == 0
-    bnez $t0, req_neq_zero                  # Branches when $t0 != 0
-    bgt $t0, $t1, t0_gt_t1                  # Branches when $t0 > $t1
-    bge $t0, $t1, t0_gte_t1                 # Branches when $t0 >= $t1
-    bgtz $t0, t0_gt0                        # Branches when $t0 > 0
-    blt $t0, $t1, t0_gt_t1                  # Branches when $t0 < $t1
-    ble $t0, $t1, t0_gte_t1                 # Branches when $t0 <= $t1
-    bltz $t0, t0_lt0                        # Branches when $t0 < 0
+    beq $t0, $t1, reg_eq                    # $t0 == $t1이면 reg_eq로
+                                            # 분기하고, 그렇지 않으면
+                                            # 다음 줄을 실행합니다.
+    bne $t0, $t1, reg_neq                   # $t0 != $t1일 때 분기
+    b branch_target                         # 무조건 분기, 항상 실행됨
+    beqz $t0, req_eq_zero                   # $t0 == 0일 때 분기
+    bnez $t0, req_neq_zero                  # $t0 != 0일 때 분기
+    bgt $t0, $t1, t0_gt_t1                  # $t0 > $t1일 때 분기
+    bge $t0, $t1, t0_gte_t1                 # $t0 >= $t1일 때 분기
+    bgtz $t0, t0_gt0                        # $t0 > 0일 때 분기
+    blt $t0, $t1, t0_gt_t1                  # $t0 < $t1일 때 분기
+    ble $t0, $t1, t0_gte_t1                 # $t0 <= $t1일 때 분기
+    bltz $t0, t0_lt0                        # $t0 < 0일 때 분기
     slt $s0, $t0, $t1                       # "Set on Less Than"
-                                            # when $t0 < $t1 with result in $s0
-                                            # (1 for true)
+                                            # $t0 < $t1일 때 $s0에 결과
+                                            # (참이면 1)
 
-    # Simple if statement
+    # 간단한 if 문
     # if (i == j)
     #     f = g + h;
     #  f = f - i;
 
-    # Let $s0 = f, $s1 = g, $s2 = h, $s3 = i, $s4 = j
+    # $s0 = f, $s1 = g, $s2 = h, $s3 = i, $s4 = j라고 가정
     bne $s3, $s4, L1 # if (i !=j)
     add $s0, $s1, $s2 # f = g + h
 
     L1:
       sub $s0, $s0, $s3 # f = f - i
 
-    # Below is an example of finding the max of 3 numbers
-    # A direct translation in Java from MIPS logic:
+    # 아래는 3개의 숫자 중 최대값을 찾는 예입니다.
+    # MIPS 논리에서 Java로 직접 번역:
     # if (a > b)
     #   if (a > c)
     #     max = a;
@@ -193,134 +179,133 @@ gateways and routers.
     #   else
     #     max = c;
 
-    # Let $s0 = a, $s1 = b, $s2 = c, $v0 = return register
+    # $s0 = a, $s1 = b, $s2 = c, $v0 = 반환 레지스터라고 가정
     ble $s0, $s1, a_LTE_b                   # if(a <= b) branch(a_LTE_b)
     ble $s0, $s2, max_C                     # if(a > b && a <=c) branch(max_C)
     move $v0, $s0                           # else [a > b && a > c] max = a
-    j done                                  # Jump to the end of the program
+    j done                                  # 프로그램 끝으로 점프
 
-    a_LTE_b:                                # Label for when a <= b
+    a_LTE_b:                                # a <= b일 때의 레이블
       ble $s1, $s2, max_C                   # if(a <= b && b <= c) branch(max_C)
       move $v0, $s1                         # if(a <= b && b > c) max = b
-      j done                                # Jump to done
+      j done                                # done으로 점프
 
     max_C:
       move $v0, $s2                         # max = c
 
-    done:                                   # End of program
+    done:                                   # 프로그램 끝
 
-## LOOPS ##
+## 루프 ##
   _loops:
-    # The basic structure of loops is having an exit condition and a jump
-    # instruction to continue its execution
+    # 루프의 기본 구조는 종료 조건과 실행을 계속하기 위한
+    # 점프 명령어를 갖는 것입니다.
     li $t0, 0
     while:
-      bgt $t0, 9, end_while                 # While $t0 is less than 10,
-                                            # keep iterating
-      #actual loop content would go here
-      addi $t0, $t0, 1                      # Increment the value
-      j while                               # Jump back to the beginning of
-                                            # the loop
+      bgt $t0, 9, end_while                 # $t0이 10보다 작은 동안
+                                            # 계속 반복
+      # 실제 루프 내용은 여기에 들어갑니다.
+      addi $t0, $t0, 1                      # 값 증가
+      j while                               # 루프 시작으로 다시 점프
     end_while:
 
-    # 2D Matrix Traversal
-    # Assume that $a0 stores the address of an integer matrix which is 3 x 3
-    li $t0, 0                               # Counter for i
-    li $t1, 0                               # Counter for j
+    # 2D 행렬 순회
+    # $a0가 3x3 정수 행렬의 주소를 저장한다고 가정
+    li $t0, 0                               # i 카운터
+    li $t1, 0                               # j 카운터
     matrix_row:
       bgt $t0, 3, matrix_row_end
 
       matrix_col:
         bgt $t1, 3, matrix_col_end
 
-        # Do stuff
+        # 작업 수행
 
-        addi $t1, $t1, 1                  # Increment the col counter
+        addi $t1, $t1, 1                  # 열 카운터 증가
       matrix_col_end:
 
-      # Do stuff
+      # 작업 수행
 
       addi $t0, $t0, 1
     matrix_row_end:
 
-## FUNCTIONS ##
+## 함수 ##
   _functions:
-    # Functions are callable procedures that can accept arguments and return
-    # values all denoted with labels, like above
+    # 함수는 위와 같이 레이블로 표시되는 인수와 반환 값을
+    # 받을 수 있는 호출 가능한 프로시저입니다.
 
-    main:                                 # Programs begin with main func
-      jal return_1                        # jal will store the current PC in $ra
-                                          # and then jump to return_1
+    main:                                 # 프로그램은 main 함수로 시작
+      jal return_1                        # jal은 현재 PC를 $ra에 저장한 다음
+                                          # return_1로 점프합니다.
 
-      # What if we want to pass in args?
-      # First we must pass in our parameters to the argument registers
+      # 인수를 전달하려면 어떻게 해야 할까요?
+      # 먼저 매개변수를 인수 레지스터에 전달해야 합니다.
       li $a0, 1
       li $a1, 2
-      jal sum                             # Now we can call the function
+      jal sum                             # 이제 함수를 호출할 수 있습니다.
 
-      # How about recursion?
-      # This is a bit more work since we need to make sure we save and restore
-      # the previous PC in $ra since jal will automatically overwrite
-      # on each call
+      # 재귀는 어떨까요?
+      # jal이 각 호출에서 자동으로 덮어쓰므로
+      # $ra의 이전 PC를 저장하고 복원해야 하므로
+      # 조금 더 작업이 필요합니다.
       li $a0, 3
       jal fact
 
       li $v0, 10
       syscall
 
-    # This function returns 1
+    # 이 함수는 1을 반환합니다.
     return_1:
-      li $v0, 1                           # Load val in return register $v0
-      jr $ra                              # Jump back to old PC to continue exec
+      li $v0, 1                           # 반환 레지스터 $v0에 값 로드
+      jr $ra                              # 이전 PC로 다시 점프하여 실행 계속
 
 
-    # Function with 2 args
+    # 2개의 인수를 갖는 함수
     sum:
       add $v0, $a0, $a1
-      jr $ra                              # Return
+      jr $ra                              # 반환
 
-    # Recursive function to find factorial
+    # 팩토리얼을 찾는 재귀 함수
     fact:
-      addi $sp, $sp, -8                   # Allocate space in stack
-      sw $s0, ($sp)                       # Store reg that holds current num
-      sw $ra, 4($sp)                      # Store previous PC
+      addi $sp, $sp, -8                   # 스택에 공간 할당
+      sw $s0, ($sp)                       # 현재 숫자를 보유하는 레지스터 저장
+      sw $ra, 4($sp)                      # 이전 PC 저장
 
-      li $v0, 1                           # Init return value
-      beq $a0, 0, fact_done               # Finish if param is 0
+      li $v0, 1                           # 반환 값 초기화
+      beq $a0, 0, fact_done               # 매개변수가 0이면 종료
 
-      # Otherwise, continue recursion
-      move $s0, $a0                       # Copy $a0 to $s0
+      # 그렇지 않으면 재귀 계속
+      move $s0, $a0                       # $a0을 $s0에 복사
       sub $a0, $a0, 1
       jal fact
 
-      mul $v0, $s0, $v0                   # Multiplication is done
+      mul $v0, $s0, $v0                   # 곱셈 수행
 
       fact_done:
         lw $s0, ($sp)
-        lw $ra, 4($sp)                     # Restore the PC
+        lw $ra, 4($sp)                     # PC 복원
         addi $sp, $sp, 8
 
         jr $ra
 
-## MACROS ##
+## 매크로 ##
   _macros:
-    # Macros are extremely useful for substituting repeated code blocks with a
-    # single label for better readability
-    # These are in no means substitutes for functions
-    # These must be declared before it is used
+    # 매크로는 반복되는 코드 블록을 가독성을 위해 단일 레이블로
+    # 대체하는 데 매우 유용합니다.
+    # 이것은 결코 함수를 대체하는 것이 아닙니다.
+    # 사용하기 전에 선언해야 합니다.
 
-    # Macro for printing newlines (since these can be very repetitive)
+    # 개행을 출력하는 매크로 (매우 반복적일 수 있으므로)
     .macro println()
-      la $a0, newline                     # New line string stored here
+      la $a0, newline                     # 여기에 저장된 새 줄 문자열
       li $v0, 4
       syscall
     .end_macro
 
-    println()                             # Assembler will copy that block of
-                                          # code here before running
+    println()                             # 어셈블러는 실행 전에 해당 코드 블록을
+                                          # 여기에 복사합니다.
 
-    # Parameters can be passed in through macros.
-    # These are denoted by a '%' sign with any name you choose
+    # 매개변수는 매크로를 통해 전달할 수 있습니다.
+    # 이것은 '%' 기호와 원하는 이름으로 표시됩니다.
     .macro print_int(%num)
       li $v0, 1
       lw $a0, %num
@@ -330,14 +315,14 @@ gateways and routers.
     li $t0, 1
     print_int($t0)
 
-    # We can also pass in immediates for macros
+    # 매크로에 즉시 값을 전달할 수도 있습니다.
     .macro immediates(%a, %b)
       add $t0, %a, %b
     .end_macro
 
     immediates(3, 5)
 
-    # Along with passing in labels
+    # 레이블 전달과 함께
     .macro print(%string)
       la $a0, %string
       li $v0, 4
@@ -346,35 +331,35 @@ gateways and routers.
 
     print(hello_world)
 
-## ARRAYS ##
+## 배열 ##
 .data
-  list: .word 3, 0, 1, 2, 6                 # This is an array of words
-  char_arr: .asciiz "hello"                 # This is a char array
-  buffer: .space 128                        # Allocates a block in memory, does
-                                            # not automatically clear
-                                            # These blocks of memory are aligned
-                                            # next to each other
+  list: .word 3, 0, 1, 2, 6                 # 이것은 워드 배열입니다.
+  char_arr: .asciiz "hello"                 # 이것은 문자 배열입니다.
+  buffer: .space 128                        # 메모리에 블록을 할당하며,
+                                            # 자동으로 지워지지 않습니다.
+                                            # 이러한 메모리 블록은 서로
+                                            # 인접하게 정렬됩니다.
 
 .text
-  la $s0, list                              # Load address of list
-  li $t0, 0                                 # Counter
-  li $t1, 5                                 # Length of the list
+  la $s0, list                              # list의 주소 로드
+  li $t0, 0                                 # 카운터
+  li $t1, 5                                 # 리스트의 길이
 
   loop:
     bge $t0, $t1, end_loop
 
     lw $a0, ($s0)
     li $v0, 1
-    syscall                                 # Print the number
+    syscall                                 # 숫자 출력
 
-    addi $s0, $s0, 4                        # Size of a word is 4 bytes
-    addi $t0, $t0, 1                        # Increment
+    addi $s0, $s0, 4                        # 워드의 크기는 4바이트
+    addi $t0, $t0, 1                        # 증가
     j loop
   end_loop:
 
-## INCLUDE ##
-# You do this to import external files into your program (behind the scenes,
-# it really just takes whatever code that is in that file and places it where
-# the include statement is)
+## 포함 ##
+# 외부 파일을 프로그램으로 가져오려면 이 작업을 수행합니다(실제로는
+# 해당 파일에 있는 코드를 가져와 include 문이 있는 위치에
+# 배치합니다).
 .include "somefile.asm"
 ```

--- a/ko/moonscript.md
+++ b/ko/moonscript.md
@@ -1,5 +1,3 @@
-# moonscript.md (번역)
-
 ---
 name: MoonScript
 contributors:
@@ -8,26 +6,24 @@ contributors:
 filename: moonscript.moon
 ---
 
-MoonScript is a dynamic scripting language that compiles into Lua. It gives
-you the power of one of the fastest scripting languages combined with a
-rich set of features.
+MoonScript는 Lua로 컴파일되는 동적 스크립팅 언어입니다. 가장 빠른 스크립팅 언어 중 하나의 강력한 기능과 풍부한 기능 세트를 제공합니다.
 
-See [the MoonScript website](https://moonscript.org/) to see official guides on installation for all platforms.
+모든 플랫폼에 대한 공식 설치 가이드는 [MoonScript 웹사이트](https://moonscript.org/)를 참조하십시오.
 
 ```moon
--- Two dashes start a comment. Comments can go until the end of the line.
--- MoonScript transpiled to Lua does not keep comments.
+-- 두 개의 대시는 주석을 시작합니다. 주석은 줄 끝까지 이어질 수 있습니다.
+-- Lua로 트랜스파일된 MoonScript는 주석을 유지하지 않습니다.
 
--- As a note, MoonScript does not use 'do', 'then', or 'end' like Lua would and
--- instead uses an indented syntax, much like Python.
+-- 참고로, MoonScript는 Lua처럼 'do', 'then' 또는 'end'를 사용하지 않고
+-- 대신 Python과 매우 유사한 들여쓰기 구문을 사용합니다.
 
 --------------------------------------------------
--- 1. Assignment
+-- 1. 할당
 --------------------------------------------------
 
 hello = "world"
 a, b, c = 1, 2, 3
-hello = 123 -- Overwrites `hello` from above.
+hello = 123 -- 위의 `hello`를 덮어씁니다.
 
 x = 0
 x += 10 -- x = x + 10
@@ -39,115 +35,116 @@ b = false
 b and= true or false -- b = b and (true or false)
 
 --------------------------------------------------
--- 2. Literals and Operators
+-- 2. 리터럴 및 연산자
 --------------------------------------------------
 
--- Literals work almost exactly as they would in Lua. Strings can be broken in
--- the middle of a line without requiring a \.
+-- 리터럴은 Lua에서와 거의 똑같이 작동합니다. 문자열은
+-- \ 없이 줄 중간에서 끊을 수 있습니다.
 
 some_string = "exa
 mple" -- local some_string = "exa\nmple"
 
--- Strings can also have interpolated values, or values that are evaluated and
--- then placed inside of a string.
+-- 문자열에는 보간된 값, 즉 평가된 다음
+-- 문자열 내에 배치되는 값을 포함할 수도 있습니다.
 
-some_string = "This is an #{some_string}" -- Becomes 'This is an exa\nmple'
+some_string = "This is an #{some_string}" -- 'This is an exa\nmple'이 됩니다
 
 --------------------------------------------------
--- 2.1. Function Literals
+-- 2.1. 함수 리터럴
 --------------------------------------------------
 
--- Functions are written using arrows:
+-- 함수는 화살표를 사용하여 작성됩니다:
 
-my_function = -> -- compiles to `function() end`
-my_function() -- calls an empty function
+my_function = -> -- `function() end`로 컴파일됨
+my_function() -- 빈 함수 호출
 
--- Functions can be called without using parenthesis. Parentheses may still be
--- used to have priority over other functions.
+-- 함수는 괄호를 사용하지 않고 호출할 수 있습니다. 괄호는 여전히
+-- 다른 함수보다 우선순위를 갖기 위해 사용할 수 있습니다.
 
 func_a = -> print "Hello World!"
 func_b = ->
 	value = 100
 	print "The value: #{value}"
 
--- If a function needs no parameters, it can be called with either `()` or `!`.
+-- 함수에 매개변수가 필요 없는 경우 `()` 또는 `!`로 호출할 수 있습니다.
 
 func_a!
 func_b()
 
--- Functions can use arguments by preceding the arrow with a list of argument
--- names bound by parentheses.
+-- 함수는 화살표 앞에 괄호로 묶인 인수 이름 목록을
+-- 사용하여 인수를 사용할 수 있습니다.
 
-sum = (x, y)-> x + y -- The last expression is returned from the function.
+sum = (x, y)-> x + y -- 마지막 표현식이 함수에서 반환됩니다.
 print sum(5, 10)
 
--- Lua has an idiom of sending the first argument to a function as the object,
--- like a 'self' object. Using a fat arrow (=>) instead of a skinny arrow (->)
--- automatically creates a `self` variable. `@x` is a shorthand for `self.x`.
+-- Lua에는 첫 번째 인수를 'self' 객체처럼 객체로 함수에
+-- 보내는 관용구가 있습니다. 얇은 화살표(->) 대신 굵은 화살표(=>)를
+-- 사용하면 자동으로 `self` 변수가 생성됩니다. `@x`는 `self.x`의
+-- 약어입니다.
 
 func = (num)=> @value + num
 
--- Default arguments can also be used with function literals:
+-- 기본 인수는 함수 리터럴과 함께 사용할 수도 있습니다:
 
 a_function = (name = "something", height=100)->
 	print "Hello, I am #{name}.\nMy height is #{height}."
 
--- Because default arguments are calculated in the body of the function when
--- transpiled to Lua, you can reference previous arguments.
+-- 기본 인수는 Lua로 트랜스파일될 때 함수 본문에서
+-- 계산되므로 이전 인수를 참조할 수 있습니다.
 
 some_args = (x = 100, y = x + 1000)-> print(x + y)
 
 --------------------------------------------------
--- Considerations
+-- 고려 사항
 --------------------------------------------------
 
--- The minus sign plays two roles, a unary negation operator and a binary
--- subtraction operator. It is recommended to always use spaces between binary
--- operators to avoid the possible collision.
+-- 마이너스 기호는 단항 부정 연산자와 이항
+-- 뺄셈 연산자라는 두 가지 역할을 합니다. 가능한 충돌을 피하기 위해
+-- 이항 연산자 사이에는 항상 공백을 사용하는 것이 좋습니다.
 
 a = x - 10 --  a = x - 10
 b = x-10 -- b = x - 10
 c = x -y -- c = x(-y)
 d = x- z -- d = x - z
 
--- When there is no space between a variable and string literal, the function
--- call takes priority over following expressions:
+-- 변수와 문자열 리터럴 사이에 공백이 없으면 함수
+-- 호출이 다음 표현식보다 우선합니다:
 
 x = func"hello" + 100 -- func("hello") + 100
 y = func "hello" + 100 -- func("hello" + 100)
 
--- Arguments to a function can span across multiple lines as long as the
--- arguments are indented. The indentation can be nested as well.
+-- 함수에 대한 인수는 들여쓰기된 한 여러 줄에 걸쳐 있을 수 있습니다.
+-- 들여쓰기는 중첩될 수도 있습니다.
 
-my_func 5, -- called as my_func(5, 8, another_func(6, 7, 9, 1, 2), 5, 4)
-	8, another_func 6, 7, -- called as
-		9, 1, 2,		  -- another_func(6, 7, 9, 1, 2)
+my_func 5, -- my_func(5, 8, another_func(6, 7, 9, 1, 2), 5, 4)로 호출됨
+	8, another_func 6, 7, --
+		9, 1, 2,		  -- another_func(6, 7, 9, 1, 2)로 호출됨
 	5, 4
 
--- If a function is used at the start of a block, the indentation can be
--- different than the level of indentation used in a block:
+-- 함수가 블록 시작 부분에서 사용되면 들여쓰기는
+-- 블록에서 사용되는 들여쓰기 수준과 다를 수 있습니다:
 
-if func 1, 2, 3, -- called as func(1, 2, 3, "hello", "world")
+if func 1, 2, 3, -- func(1, 2, 3, "hello", "world")로 호출됨
 		"hello",
 		"world"
 	print "hello"
 
 --------------------------------------------------
--- 3. Tables
+-- 3. 테이블
 --------------------------------------------------
 
--- Tables are defined by curly braces, like Lua:
+-- 테이블은 Lua처럼 중괄호로 정의됩니다:
 
 some_values = {1, 2, 3, 4}
 
--- Tables can use newlines instead of commas.
+-- 테이블은 쉼표 대신 줄 바꿈을 사용할 수 있습니다.
 
 some_other_values = {
 	5, 6
 	7, 8
 }
 
--- Assignment is done with `:` instead of `=`:
+-- 할당은 `=` 대신 `:`으로 수행됩니다:
 
 profile = {
 	name: "Bill"
@@ -155,89 +152,90 @@ profile = {
 	"favorite food": "rice"
 }
 
--- Curly braces can be left off for `key: value` tables.
+-- `key: value` 테이블의 경우 중괄호를 생략할 수 있습니다.
 
 y = type: "dog", legs: 4, tails: 1
 
 profile =
 	height: "4 feet",
 	shoe_size: 13,
-	favorite_foods: -- nested table
+	favorite_foods: -- 중첩 테이블
 		foo: "ice cream",
 		bar: "donuts"
 
 my_function dance: "Tango", partner: "none" -- :( forever alone
 
--- Tables constructed from variables can use the same name as the variables
--- by using `:` as a prefix operator.
+-- 변수로 구성된 테이블은 변수와 동일한 이름을
+-- 접두사 연산자로 `:`를 사용하여 사용할 수 있습니다.
 
 hair = "golden"
 height = 200
 person = {:hair, :height}
 
--- Like in Lua, keys can be non-string or non-numeric values by using `[]`.
+-- Lua에서와 같이 키는 `[]`를 사용하여 문자열이 아니거나
+-- 숫자가 아닌 값일 수 있습니다.
 
 t =
 	[1 + 2]: "hello"
-	"hello world": true -- Can use string literals without `[]`.
+	"hello world": true -- `[]` 없이 문자열 리터럴을 사용할 수 있습니다.
 
 --------------------------------------------------
--- 3.1. Table Comprehensions
+-- 3.1. 테이블 컴프리헨션
 --------------------------------------------------
 
--- List Comprehensions
+-- 리스트 컴프리헨션
 
--- Creates a copy of a list but with all items doubled. Using a star before a
--- variable name or table can be used to iterate through the table's values.
+-- 모든 항목이 두 배인 리스트의 복사본을 만듭니다. 별표를 사용하여
+-- 변수 이름이나 테이블 앞에 붙이면 테이블의 값을 반복할 수 있습니다.
 
 items = {1, 2, 3, 4}
 doubled = [item * 2 for item in *items]
--- Uses `when` to determine if a value should be included.
+-- `when`을 사용하여 값을 포함할지 여부를 결정합니다.
 
 slice = [item for item in *items when item > 1 and item < 3]
 
--- `for` clauses inside of list comprehensions can be chained.
+-- 리스트 컴프리헨션 내부의 `for` 절은 연결될 수 있습니다.
 
 x_coords = {4, 5, 6, 7}
 y_coords = {9, 2, 3}
 
 points = [{x,y} for x in *x_coords for y in *y_coords]
 
--- Numeric for loops can also be used in comprehensions:
+-- 숫자 for 루프는 컴프리헨션에서도 사용할 수 있습니다:
 
 evens = [i for i=1, 100 when i % 2 == 0]
 
--- Table Comprehensions are very similar but use `{` and `}` and take two
--- values for each iteration.
+-- 테이블 컴프리헨션은 매우 유사하지만 `{`와 `}`를 사용하고
+-- 각 반복에 대해 두 개의 값을 사용합니다.
 
 thing = color: "red", name: "thing", width: 123
 thing_copy = {k, v for k, v in pairs thing}
 
--- Tables can be "flattened" from key-value pairs in an array by using `unpack`
--- to return both values, using the first as the key and the second as the
--- value.
+-- 테이블은 `unpack`을 사용하여 배열의 키-값 쌍에서 "평탄화"될 수 있습니다.
+-- 두 값을 모두 반환하여 첫 번째는 키로, 두 번째는
+-- 값으로 사용합니다.
 
 tuples = {{"hello", "world"}, {"foo", "bar"}}
 table = {unpack tuple for tuple in *tuples}
 
--- Slicing can be done to iterate over only a certain section of an array. It
--- uses the `*` notation for iterating but appends `[start, end, step]`.
+-- 슬라이싱은 배열의 특정 섹션만 반복하는 데 사용할 수 있습니다.
+-- 반복을 위해 `*` 표기법을 사용하지만 `[start, end, step]`을 추가합니다.
 
--- The next example also shows that this syntax can be used in a `for` loop as
--- well as any comprehensions.
+-- 다음 예는 이 구문이 `for` 루프뿐만 아니라
+-- 모든 컴프리헨션에서도 사용할 수 있음을 보여줍니다.
 
 for item in *points[1, 10, 2]
 	print unpack item
 
--- Any undesired values can be left off. The second comma is not required if
--- the step is not included.
+-- 원하지 않는 값은 생략할 수 있습니다.
+-- 단계가 포함되지 않은 경우 두 번째 쉼표는 필요하지 않습니다.
 
 words = {"these", "are", "some", "words"}
 for word in *words[,3]
 	print word
 
 --------------------------------------------------
--- 4. Control Structures
+-- 4. 제어 구조
 --------------------------------------------------
 
 have_coins = false
@@ -246,63 +244,63 @@ if have_coins
 else
 	print "No coins"
 
--- Use `then` for single-line `if`
+-- 한 줄 `if`에 `then` 사용
 if have_coins then "Got coins" else "No coins"
 
--- `unless` is the opposite of `if`
+-- `unless`는 `if`의 반대입니다.
 unless os.date("%A") == "Monday"
 	print "It is not Monday!"
 
--- `if` and `unless` can be used as expressions
+-- `if`와 `unless`는 표현식으로 사용할 수 있습니다.
 is_tall = (name)-> if name == "Rob" then true else false
 message = "I am #{if is_tall "Rob" then "very tall" else "not so tall"}"
 print message -- "I am very tall"
 
--- `if`, `elseif`, and `unless` can evaluate assignment as well as expressions.
-if x = possibly_nil! -- sets `x` to `possibly_nil()` and evaluates `x`
+-- `if`, `elseif`, `unless`는 할당과 표현식을 평가할 수 있습니다.
+if x = possibly_nil! -- `x`를 `possibly_nil()`로 설정하고 `x`를 평가
 	print x
 
--- Conditionals can be used after a statement as well as before. This is
--- called a "line decorator".
+-- 조건문은 문장 앞뿐만 아니라 뒤에도 사용할 수 있습니다. 이것은
+-- "라인 데코레이터"라고 합니다.
 
 is_monday = os.date("%A") == "Monday"
 print("It IS Monday!") if isMonday
 print("It is not Monday..") unless isMonday
---print("It IS Monday!" if isMonday) -- Not a statement, does not work
+--print("It IS Monday!" if isMonday) -- 문장이 아니므로 작동하지 않음
 
 --------------------------------------------------
--- 4.1 Loops
+-- 4.1 루프
 --------------------------------------------------
 
 for i = 1, 10
 	print i
 
-for i = 10, 1, -1 do print i -- Use `do` for single-line loops.
+for i = 10, 1, -1 do print i -- 한 줄 루프에 `do` 사용.
 
 i = 0
 while i < 10
-	continue if i % 2 == 0 -- Continue statement; skip the rest of the loop.
+	continue if i % 2 == 0 -- continue 문; 루프의 나머지 부분을 건너뜁니다.
 	print i
 
--- Loops can be used as a line decorator, just like conditionals
+-- 루프는 조건문처럼 라인 데코레이터로 사용할 수 있습니다.
 print "item: #{item}" for item in *items
 
--- Using loops as an expression generates an array table. The last statement
--- in the block is coerced into an expression and added to the table.
+-- 루프를 표현식으로 사용하면 배열 테이블이 생성됩니다. 블록의
+-- 마지막 문은 표현식으로 강제 변환되어 테이블에 추가됩니다.
 my_numbers = for i = 1, 6 do i -- {1, 2, 3, 4, 5, 6}
 
--- use `continue` to filter out values
+-- 값을 필터링하려면 `continue` 사용
 odds = for i in *my_numbers
-	continue if i % 2 == 0 -- acts opposite to `when` in comprehensions!
-	i -- Only added to return table if odd
+	continue if i % 2 == 0 -- 컴프리헨션의 `when`과 반대로 작동!
+	i -- 홀수일 때만 반환 테이블에 추가됨
 
--- A `for` loop returns `nil` when it is the last statement of a function
--- Use an explicit `return` to generate a table.
-print_squared = (t) -> for x in *t do x*x -- returns `nil`
-squared = (t) -> return for x in *t do x*x -- returns new table of squares
+-- `for` 루프는 함수 마지막 문일 때 `nil`을 반환합니다.
+-- 테이블을 생성하려면 명시적 `return`을 사용하십시오.
+print_squared = (t) -> for x in *t do x*x -- `nil` 반환
+squared = (t) -> return for x in *t do x*x -- 새 제곱 테이블 반환
 
--- The following does the same as `(t) -> [i for i in *t when i % 2 == 0]`
--- But list comprehension generates better code and is more readable!
+-- 다음은 `(t) -> [i for i in *t when i % 2 == 0]`와 동일하게 작동합니다.
+-- 하지만 리스트 컴프리헨션은 더 나은 코드를 생성하고 더 읽기 쉽습니다!
 
 filter_odds = (t) ->
 	return for x in *t
@@ -310,11 +308,11 @@ filter_odds = (t) ->
 evens = filter_odds(my_numbers) -- {2, 4, 6}
 
 --------------------------------------------------
--- 4.2 Switch Statements
+-- 4.2 Switch 문
 --------------------------------------------------
 
--- Switch statements are a shorthand way of writing multiple `if` statements
--- checking against the same value. The value is only evaluated once.
+-- Switch 문은 동일한 값에 대해 여러 `if` 문을 작성하는
+-- 약식 방법입니다. 값은 한 번만 평가됩니다.
 
 name = "Dan"
 
@@ -326,9 +324,9 @@ switch name
 	else
 		print "You are neither Dave nor Dan."
 
--- Switches can also be used as expressions, as well as compare multiple
--- values. The values can be on the same line as the `when` clause if they
--- are only one expression.
+-- Switch는 표현식으로 사용할 수 있을 뿐만 아니라 여러 값을
+-- 비교할 수도 있습니다. 값이 단일 표현식인 경우 `when` 절과
+-- 같은 줄에 있을 수 있습니다.
 
 b = 4
 next_even = switch b
@@ -338,32 +336,32 @@ next_even = switch b
 	else error "I can't count that high! D:"
 
 --------------------------------------------------
--- 5. Object Oriented Programming
+-- 5. 객체 지향 프로그래밍
 --------------------------------------------------
 
--- Classes are created using the `class` keyword followed by an identifier,
--- typically written using CamelCase. Values specific to a class can use @ as
--- the identifier instead of `self.value`.
+-- 클래스는 식별자 뒤에 `class` 키워드를 사용하여 생성되며,
+-- 일반적으로 CamelCase를 사용하여 작성됩니다. 클래스에 특정한 값은
+-- `self.value` 대신 식별자로 @를 사용할 수 있습니다.
 
 class Inventory
 	new: => @items = {}
-	add_item: (name)=> -- note the use of fat arrow for classes!
+	add_item: (name)=> -- 클래스에 굵은 화살표 사용에 유의!
 		@items[name] = 0 unless @items[name]
 		@items[name] += 1
 
--- The `new` function inside of a class is special because it is called when
--- an instance of the class is created.
+-- 클래스 내부의 `new` 함수는 클래스의 인스턴스가
+-- 생성될 때 호출되므로 특별합니다.
 
--- Creating an instance of the class is as simple as calling the class as a
--- function. Calling functions inside of the class uses \ to separate the
--- instance from the function it is calling.
+-- 클래스의 인스턴스를 만드는 것은 클래스를 함수로 호출하는 것만큼
+-- 간단합니다. 클래스 내부의 함수를 호출하려면 \를 사용하여
+-- 인스턴스와 호출하는 함수를 구분합니다.
 
 inv = Inventory!
 inv\add_item "t-shirt"
 inv\add_item "pants"
 
--- Values defined in the class - not the new() function - will be shared across
--- all instances of the class.
+-- new() 함수가 아닌 클래스에 정의된 값은 모든
+-- 인스턴스에서 공유됩니다.
 
 class Person
 	clothes: {}
@@ -376,17 +374,17 @@ b = Person!
 a\give_item "pants"
 b\give_item "shirt"
 
--- prints out both "pants" and "shirt"
+-- "pants"와 "shirt" 모두 출력
 
 print item for item in *a.clothes
 
--- Class instances have a value `.__class` that are equal to the class object
--- that created the instance.
+-- 클래스 인스턴스는 인스턴스를 생성한 클래스 객체와
+-- 동일한 값 `.__class`를 가집니다.
 
 assert(b.__class == Person)
 
--- Variables declared in class body the using the `=` operator are locals,
--- so these "private" variables are only accessible within the current scope.
+-- `=` 연산자를 사용하여 클래스 본문에 선언된 변수는 지역 변수이므로
+-- 이러한 "비공개" 변수는 현재 범위 내에서만 액세스할 수 있습니다.
 
 class SomeClass
 	x = 0
@@ -401,33 +399,33 @@ a.reveal! -- 1
 b.reveal! -- 2
 
 --------------------------------------------------
--- 5.1 Inheritance
+-- 5.1 상속
 --------------------------------------------------
 
--- The `extends` keyword can be used to inherit properties and methods from
--- another class.
+-- `extends` 키워드를 사용하여 다른 클래스에서 속성과 메서드를
+-- 상속받을 수 있습니다.
 
 class Backpack extends Inventory
 	size: 10
 	add_item: (name)=>
 		error "backpack is full" if #@items > @size
-		super name -- calls Inventory.add_item with `name`.
+		super name -- `name`으로 Inventory.add_item 호출.
 
--- Because a `new` method was not added, the `new` method from `Inventory` will
--- be used instead. If we did want to use a constructor while still using the
--- constructor from `Inventory`, we could use the magical `super` function
--- during `new()`.
+-- `new` 메서드가 추가되지 않았으므로 `Inventory`의 `new` 메서드가
+-- 대신 사용됩니다. `Inventory`의 생성자를 계속 사용하면서
+-- 생성자를 사용하려면 `new()` 중에 마법의 `super` 함수를
+-- 사용할 수 있습니다.
 
--- When a class extends another, it calls the method `__inherited` on the
--- parent class (if it exists). It is always called with the parent and the
--- child object.
+-- 클래스가 다른 클래스를 확장하면 부모 클래스(있는 경우)의
+-- `__inherited` 메서드를 호출합니다. 항상 부모와
+-- 자식 객체로 호출됩니다.
 
 class ParentClass
 	@__inherited: (child)=>
 		print "#{@__name} was inherited by #{child.__name}"
 	a_method: (a, b) => print a .. ' ' .. b
 
--- Will print 'ParentClass was inherited by MyClass'
+-- 'ParentClass was inherited by MyClass' 출력
 
 class MyClass extends ParentClass
 	a_method: =>
@@ -435,28 +433,28 @@ class MyClass extends ParentClass
 		assert super == ParentClass
 
 --------------------------------------------------
--- 6. Scope
+-- 6. 범위
 --------------------------------------------------
 
--- All values are local by default. The `export` keyword can be used to
--- declare the variable as a global value.
+-- 모든 값은 기본적으로 지역 변수입니다. `export` 키워드를 사용하여
+-- 변수를 전역 값으로 선언할 수 있습니다.
 
 export var_1, var_2
-var_1, var_3 = "hello", "world" -- var_3 is local, var_1 is not.
+var_1, var_3 = "hello", "world" -- var_3는 지역 변수, var_1은 아님.
 
 export this_is_global_assignment = "Hi!"
 
--- Classes can also be prefixed with `export` to make them global classes.
--- Alternatively, all CamelCase variables can be exported automatically using
--- `export ^`, and all values can be exported using `export *`.
+-- 클래스 앞에 `export`를 붙여 전역 클래스로 만들 수도 있습니다.
+-- 또는 `export ^`를 사용하여 모든 CamelCase 변수를 자동으로 내보내거나
+-- `export *`를 사용하여 모든 값을 내보낼 수 있습니다.
 
--- `do` lets you manually create a scope, for when you need local variables.
+-- `do`를 사용하면 지역 변수가 필요할 때 수동으로 범위를 만들 수 있습니다.
 
 do
 	x = 5
 print x -- nil
 
--- Here we use `do` as an expression to create a closure.
+-- 여기서는 `do`를 표현식으로 사용하여 클로저를 만듭니다.
 
 counter = do
 	i = 0
@@ -467,15 +465,15 @@ counter = do
 print counter!  -- 1
 print counter!  -- 2
 
--- The `local` keyword can be used to define variables
--- before they are assigned.
+-- `local` 키워드를 사용하여 할당되기 전에
+-- 변수를 정의할 수 있습니다.
 
 local var_4
 if something
 	var_4 = 1
-print var_4 -- works because `var_4` was set in this scope, not the `if` scope.
+print var_4 -- `var_4`가 `if` 범위가 아닌 이 범위에서 설정되었으므로 작동합니다.
 
--- The `local` keyword can also be used to shadow an existing variable.
+-- `local` 키워드를 사용하여 기존 변수를 가릴 수도 있습니다.
 
 x = 10
 if false
@@ -483,8 +481,8 @@ if false
 	x = 12
 print x -- 10
 
--- Use `local *` to forward-declare all variables.
--- Alternatively, use `local ^` to forward-declare all CamelCase values.
+-- `local *`를 사용하여 모든 변수를 미리 선언합니다.
+-- 또는 `local ^`를 사용하여 모든 CamelCase 값을 미리 선언합니다.
 
 local *
 
@@ -497,19 +495,19 @@ second = ->
 data = {}
 
 --------------------------------------------------
--- 6.1 Import
+-- 6.1 가져오기
 --------------------------------------------------
 
--- Values from a table can be brought to the current scope using the `import`
--- and `from` keyword. Names in the `import` list can be preceded by `\` if
--- they are a module function.
+-- 테이블의 값은 `import` 및 `from` 키워드를 사용하여
+-- 현재 범위로 가져올 수 있습니다. `import` 목록의 이름은
+-- 모듈 함수인 경우 `\`를 앞에 붙일 수 있습니다.
 
 import insert from table -- local insert = table.insert
 import \add from state: 100, add: (value)=> @state + value
 print add 22
 
--- Like tables, commas can be excluded from `import` lists to allow for longer
--- lists of imported items.
+-- 테이블과 마찬가지로 `import` 목록에서 쉼표를 제외하여
+-- 더 긴 가져오기 항목 목록을 허용할 수 있습니다.
 
 import
 	asdf, gh, jkl
@@ -520,10 +518,10 @@ import
 -- 6.2 With
 --------------------------------------------------
 
--- The `with` statement can be used to quickly call and assign values in an
--- instance of a class or object.
+-- `with` 문을 사용하여 클래스 또는 객체의 인스턴스에서
+-- 값을 빠르게 호출하고 할당할 수 있습니다.
 
-file = with File "lmsi15m.moon" -- `file` is the value of `set_encoding()`.
+file = with File "lmsi15m.moon" -- `file`은 `set_encoding()`의 값입니다.
 	\set_encoding "utf8"
 
 create_person = (name, relatives)->
@@ -532,16 +530,16 @@ create_person = (name, relatives)->
 		\add_relative relative for relative in *relatives
 me = create_person "Ryan", {"sister", "sister", "brother", "dad", "mother"}
 
-with str = "Hello" -- assignment as expression! :D
+with str = "Hello" -- 표현식으로 할당! :D
 	print "original: #{str}"
 	print "upper: #{\upper!}"
 
 --------------------------------------------------
--- 6.3 Destructuring
+-- 6.3 구조 분해
 --------------------------------------------------
 
--- Destructuring can take arrays, tables, and nested tables and convert them
--- into local variables.
+-- 구조 분해는 배열, 테이블 및 중첩된 테이블을 가져와
+-- 지역 변수로 변환할 수 있습니다.
 
 obj2 =
 	numbers: {1, 2, 3, 4}
@@ -553,20 +551,21 @@ obj2 =
 
 print first, second, color -- 1 2 green
 
--- `first` and `second` return [1] and [2] because they are as an array, but
--- `:color` is like `color: color` so it sets itself to the `color` value.
+-- `first`와 `second`는 배열이므로 [1]과 [2]를 반환하지만,
+-- `:color`는 `color: color`와 같으므로 `color` 값으로
+-- 설정됩니다.
 
--- Destructuring can be used in place of `import`.
+-- 구조 분해는 `import` 대신 사용할 수 있습니다.
 
-{:max, :min, random: rand} = math -- rename math.random to rand
+{:max, :min, random: rand} = math -- math.random을 rand로 이름 변경
 
--- Destructuring can be done anywhere assignment can be done.
+-- 구조 분해는 할당이 가능한 모든 곳에서 수행할 수 있습니다.
 
 for {left, right} in *{{"hello", "world"}, {"egg", "head"}}
 	print left, right
 ```
 
-## Additional Resources
+## 추가 자료
 
-- [Language Guide](https://moonscript.org/reference/)
-- [Online Compiler](https://moonscript.org/compiler/)
+- [언어 가이드](https://moonscript.org/reference/)
+- [온라인 컴파일러](https://moonscript.org/compiler/)

--- a/ko/nmap.md
+++ b/ko/nmap.md
@@ -1,5 +1,3 @@
-# nmap.md (번역)
-
 ---
 name: Nmap
 category: tool
@@ -7,198 +5,199 @@ contributors:
     - ["Sebastian Oberdorfer", "https://github.com/SOberdorfer"]
 ---
 
-### Learn Nmap in Y Minutes
+### Y분 안에 Nmap 배우기
 
-So, you’re connected to a network and want to know what else is connected to it.
-Maybe you’re trying to find that mystery device eating up bandwidth or check
-if there are services running you didn’t know about, or you just want to verify
-what ports are exposed on your machine?
+그래서, 당신은 네트워크에 연결되어 있고 다른 무엇이 연결되어 있는지 알고 싶습니다.
+대역폭을 잡아먹는 미스터리 장치를 찾으려고 하거나
+당신이 모르는 서비스가 실행 중인지 확인하거나, 아니면 단지
+당신의 머신에 어떤 포트가 노출되어 있는지 확인하고 싶을 수도 있습니다.
 
-Meet your swiss-army network knife named **Nmap**!
+**Nmap**이라는 이름의 스위스 군용 네트워크 칼을 만나보세요!
 
 ---
 
-### Introduction
+### 소개
 
 **Nmap 101**
-Nmap is an open-source network scanning tool built by Gordon Lyon. Designed to
-help you find devices, open ports and services across your network.
-It’s a swiss-army knife for network admins, security folks, dev's and anyone
-curious about what’s living on their network.
+Nmap은 Gordon Lyon이 만든 오픈소스 네트워크 스캐닝 도구입니다.
+네트워크 전체에서 장치, 열린 포트 및 서비스를 찾는 데 도움이 되도록 설계되었습니다.
+네트워크 관리자, 보안 담당자, 개발자 및 네트워크에 무엇이 있는지 궁금한 모든 사람을 위한
+스위스 군용 칼입니다.
 
-**When to Use It**
+**언제 사용해야 할까요?**
 
-- **Finding Devices**: What’s connected, and what’s running?
-- **Network Troubleshooting**: Resolve DNS or connection issues.
-- **Vulnerability Detection**: Spotting potentially risky services.
-- **Network Security**: Evaluate exposed ports.
+- **장치 찾기**: 무엇이 연결되어 있고, 무엇이 실행 중인가요?
+- **네트워크 문제 해결**: DNS 또는 연결 문제를 해결합니다.
+- **취약점 탐지**: 잠재적으로 위험한 서비스를 발견합니다.
+- **네트워크 보안**: 노출된 포트를 평가합니다.
 
-**When *Not* to Use It**
+**언제 사용하면 *안 될까요*?**
 
-- **Public Networks**: Scanning Starbucks WiFi might land you in hot tea.
-- **Corporate Networks**: Scanning your corporate network without permission, is
-  potentially not allowed.
-- **Global Web**: In some cases scanning across the web can be illegal.
+- **공용 네트워크**: 스타벅스 WiFi를 스캔하면 곤란한 상황에 처할 수 있습니다.
+- **기업 네트워크**: 허가 없이 회사 네트워크를 스캔하는 것은
+  허용되지 않을 수 있습니다.
+- **글로벌 웹**: 경우에 따라 웹 전체를 스캔하는 것은 불법일 수 있습니다.
 
-Certain scans are intrusive and can trigger security alarms, so stick to **only
+특정 스캔은 침입적이며 보안 경보를 유발할 수 있으므로, **
 **
-scanning networks or systems where you have permission. Unauthorized scanning
-can be considered illegal under cybersecurity laws in many regions, and
-companies
-might view it as a hacking attempt.
+허가된 네트워크나 시스템만 스캔하십시오. 무단 스캔은
+많은 지역의 사이버 보안 법에 따라 불법으로 간주될 수 있으며,
+회사는
+이를 해킹 시도로 간주할 수 있습니다.
 
-Use Nmap extensively and wisely.
-
----
-
-### Installation
-
-Installation is straightforward, thoroughly explained on [nmap.org - install](https://nmap.org/book/install.html)
+Nmap을 광범위하고 현명하게 사용하십시오.
 
 ---
 
-### The Basics
+### 설치
 
-These are low-key scans that safe to use since they don’t do deep probing.
+설치는 간단하며 [nmap.org - 설치](https://nmap.org/book/install.html)에 자세히 설명되어 있습니다.
 
-- **Ping Scan**:
-  A low-impact scan just to check if devices are online. Typically fine on
-  trusted networks.
-    - Scan a single device
+---
+
+### 기본
+
+이것들은 심층적인 조사를 하지 않으므로 안전하게 사용할 수 있는 낮은 수준의 스캔입니다.
+
+- **핑 스캔**:
+  장치가 온라인 상태인지 확인하기 위한 낮은 영향의 스캔입니다. 일반적으로 신뢰할 수 있는
+  네트워크에서는 괜찮습니다.
+    - 단일 장치 스캔
       ```bash
        nmap -sn 192.168.1.1
       ```
-    - Scan a range of devices
+    - 장치 범위 스캔
       ```bash
       nmap -sn 192.168.1.1-100
       ```
-    - Scan a CIDR range of devices
+    - 장치의 CIDR 범위 스캔
       ```bash
-      nmap -sn 192.168.1.0/24   # Range 192.168.1.0 to 192.168.1.255
-      nmap -sn 192.168.0.0/16   # Range 192.168.0.0 to 192.168.255.255
-      nmap -sn 192.0.0.0/8      # Range 192.0.0.0 to 192.255.255.255
+      nmap -sn 192.168.1.0/24   # 범위 192.168.1.0 ~ 192.168.1.255
+      nmap -sn 192.168.0.0/16   # 범위 192.168.0.0 ~ 192.168.255.255
+      nmap -sn 192.0.0.0/8      # 범위 192.0.0.0 ~ 192.255.255.255
       ```
 
-- **Fast Scan**:
-  Quickly checks the 100 most common ports. Great for a quick peek without
-  probing all 65,535 ports.
+- **빠른 스캔**:
+  가장 일반적인 100개 포트를 빠르게 확인합니다.
+  65,535개의 모든 포트를 조사하지 않고 빠른 확인에 좋습니다.
   ```bash
   nmap -F 192.168.1.1
   ```
 
-- **Operating System Detection**:
-  OS detection requires some extra probing, which might be detectable by
-  Intrusion Detection Systems (IDS).
+- **운영 체제 탐지**:
+  OS 탐지에는 추가 조사가 필요하며, 이는
+  침입 탐지 시스템(IDS)에 의해 탐지될 수 있습니다.
   ```bash
   nmap -O 192.168.1.1
   ```
 
-- **Output to File**
-  Specific scanning and saving the output to a file, enables you to scan more
-  thorough without overloading your network.
-    - Plain text
+- **파일로 출력**
+  특정 스캔을 수행하고 출력을 파일에 저장하면
+  네트워크에 과부하를 주지 않고 더 철저하게 스캔할 수 있습니다.
+    - 일반 텍스트
       ```bash
       nmap -oN output.txt 192.168.1.1
       ```
-    - XML, handy for using elsewhere
+    - XML, 다른 곳에서 사용하기 편리함
       ```bash
       nmap -oX output.xml 192.168.1.1
       ```
 
 ---
 
-### Moving Up: More Insightful Scans
+### 한 단계 더 나아가기: 더 통찰력 있는 스캔
 
-These scans dig a bit deeper, so they may trigger alarms on security systems.
-Use these only on networks where you have explicit permission to scan.
+이러한 스캔은 조금 더 깊이 파고들므로 보안 시스템에서 경보를 울릴 수 있습니다.
+스캔할 명시적인 권한이 있는 네트워크에서만 사용하십시오.
 
-- **Service Version Detection**:
-  Tries to identify versions of services on open ports. Useful but more
-  invasive.
+- **서비스 버전 탐지**:
+  열린 포트에서 서비스 버전을 식별하려고 시도합니다. 유용하지만 더
+  침입적입니다.
   ```bash
   nmap -sV 192.168.1.1
   ```
 
-- **Aggressive Scan**:
-  The aggressive scan mode (`-A`) combines multiple checks, like OS detection,
-  version detection and traceroute. This is likely to be flagged on
-  any network and can be considered illegal on networks you don’t own.
+- **공격적인 스캔**:
+  공격적인 스캔 모드(`-A`)는 OS 탐지,
+  버전 탐지 및 트레이스라우트와 같은 여러 검사를 결합합니다. 이것은
+  모든 네트워크에서 플래그가 지정될 가능성이 높으며 소유하지 않은 네트워크에서는
+  불법으로 간주될 수 있습니다.
   ```bash
   nmap -A 192.168.1.1
   ```
 
-- **Scanning Specific Ports**:
-  Narrowing scans to specific ports is generally fine.
-    - Scan a specific port
+- **특정 포트 스캔**:
+  스캔을 특정 포트로 좁히는 것은 일반적으로 괜찮습니다.
+    - 특정 포트 스캔
       ```bash
       nmap -p 80 192.168.1.1
       ```
-    - Scan a range of ports
+    - 포트 범위 스캔
       ```bash
       nmap -p 1-100 192.168.1.1
       ```
 
 ---
 
-### Advanced Scans: When You’re the Power User
+### 고급 스캔: 파워 유저일 때
 
-So, you’re getting into the advanced stuff—maybe testing your own firewall or
-finding rogue services.
-The following scans are loud and intrusive that definitely trigger security
-defenses.
+그래서, 당신은 고급 기능을 사용하고 있습니다. 아마도 자신의 방화벽을 테스트하거나
+불량 서비스를 찾고 있을 것입니다.
+다음 스캔은 시끄럽고 침입적이어서 보안
+방어를 확실히 트리거합니다.
 
-- **Scripted Scans (NSE)**
-  Nmap’s script engine is like a toolbox of plugins. Need to check for a
-  specific vulnerability? There’s likely an NSE script for it.
+- **스크립트 스캔 (NSE)**
+  Nmap의 스크립트 엔진은 플러그인 도구 상자와 같습니다.
+  특정 취약점을 확인해야 합니까? 아마도 NSE 스크립트가 있을 것입니다.
   ```bash
   nmap --script=http-vuln-cve2021-12345 192.168.1.1
   ```
 
-- **Aggressive and fastest Scans**:
-  `-T5` turns up to knob to 11. `-A` scans all ports.
-  Use it sparse and only if you really need full visibility.
+- **공격적이고 가장 빠른 스캔**:
+  `-T5`는 노브를 11까지 올립니다. `-A`는 모든 포트를 스캔합니다.
+  드물게 사용하고 전체 가시성이 정말로 필요한 경우에만 사용하십시오.
   ```bash
   nmap -T5 -A 192.168.1.1
   ```
 
-- **TCP and UDP Combined Scans**:
-  Combining TCP and UDP scans (`-sS` for SYN scans and `-sU` for UDP) gives
-  complete coverage but increases the scan’s footprint, making it detectable.
+- **TCP 및 UDP 결합 스캔**:
+  TCP 및 UDP 스캔(`-sS`는 SYN 스캔, `-sU`는 UDP)을 결합하면
+  완전한 범위를 제공하지만 스캔의 공간을 늘려 탐지 가능하게 만듭니다.
   ```bash
   nmap -sS -sU 192.168.1.1
   ```
 
-- **Spoofing and Decoy Scans**:
-  Using decoys (`-D`) or spoofed IP addresses to hide your real IP can be seen
-  as deceptive. These scans are easily flagged by IDS and could lead to legal
-  repercussions if you’re not authorized.
+- **스푸핑 및 디코이 스캔**:
+  디코이(`-D`) 또는 스푸핑된 IP 주소를 사용하여 실제 IP를 숨기는 것은
+  기만적인 것으로 간주될 수 있습니다. 이러한 스캔은 IDS에 의해 쉽게 플래그가 지정되며
+  권한이 없는 경우 법적 처벌을 받을 수 있습니다.
   ```bash
-  # 10 random IP decoys
+  # 10개의 임의 IP 디코이
   nmap -D RND:10 192.168.1.1
   ```
 
 ---
 
-### Practical Tips and Tricks
+### 실용적인 팁과 요령
 
-**Timing Templates**
-Nmap has timing options from `-T0` (paranoid) to `-T5` (insane). Stick with
-`-T2` or `-T3` for a good balance between speed and not making too much noise.
-More
-on [nmap - timing-templates](https://nmap.org/book/performance-timing-templates.html)
+**타이밍 템플릿**
+Nmap에는 `-T0`(편집증)에서 `-T5`(미친)까지의 타이밍 옵션이 있습니다.
+속도와 너무 많은 소음을 내지 않는 것 사이의 좋은 균형을 위해 `-T2` 또는 `-T3`을
+사용하십시오.
+자세한 내용은 [nmap - 타이밍 템플릿](https://nmap.org/book/performance-timing-templates.html)에서 확인하십시오.
 
-**Check Out Nmap’s Scripts**
-NSE scripts make Nmap super versatile. From DNS enumeration to vulnerability
-checks, there’s probably a script for whatever you need.
-More on [nmap - Nmap Scripting Engine](https://nmap.org/book/man-nse.html)
+**Nmap의 스크립트 확인**
+NSE 스크립트는 Nmap을 매우 다재다능하게 만듭니다. DNS 열거에서 취약점
+확인에 이르기까지 필요한 모든 것에 대한 스크립트가 있을 것입니다.
+자세한 내용은 [nmap - Nmap 스크립팅 엔진](https://nmap.org/book/man-nse.html)에서 확인하십시오.
 
-**Use aggressive scans and decoys only on networks you own** or with formal
-authorization, such as during a penetration test with client permission. If
-you’re running scans at work, talk to the network admins first.
+**소유하거나 공식적인** 허가(예: 클라이언트 허가가 있는 침투 테스트 중)가 있는
+네트워크에서만 공격적인 스캔과 디코이를 사용하십시오. 직장에서
+스캔을 실행하는 경우 먼저 네트워크 관리자와 상의하십시오.
 
-**Know When to Stop**
-Once you’ve got the info you need, wrap it up. It’s easy to get scan-happy.
+**언제 멈춰야 하는지 알기**
+필요한 정보를 얻었으면 마무리하십시오. 스캔에 중독되기 쉽습니다.
 
 ---
 
-Happy scanning!
+즐거운 스캔 되세요!

--- a/ko/ocaml.md
+++ b/ko/ocaml.md
@@ -1,5 +1,3 @@
-# ocaml.md (번역)
-
 ---
 name: OCaml
 filename: learnocaml.ml
@@ -8,28 +6,23 @@ contributors:
     - ["Stanislav Modrak", "https://stanislav.gq/"]
     - ["Luke Tong", "https://lukert.me/"]
 ---
-OCaml is a strictly evaluated functional language with some imperative
-features.
+OCaml은 일부 명령형 기능이 있는 엄격하게 평가되는 함수형 언어입니다.
 
-Along with Standard ML and its dialects it belongs to ML language family.
-F# is also heavily influenced by OCaml.
+Standard ML 및 그 방언과 함께 ML 언어 계열에 속합니다.
+F#도 OCaml의 영향을 많이 받았습니다.
 
-Just like Standard ML, OCaml features both an interpreter, that can be
-used interactively, and a compiler.
-The interpreter binary is normally called `ocaml` and the compiler is `ocamlopt`.
-There is also a bytecode compiler, `ocamlc`, but there are few reasons to use it.
+Standard ML과 마찬가지로 OCaml은 대화형으로 사용할 수 있는 인터프리터와 컴파일러를 모두 갖추고 있습니다.
+인터프리터 바이너리는 일반적으로 `ocaml`이라고 하고 컴파일러는 `ocamlopt`입니다.
+바이트코드 컴파일러인 `ocamlc`도 있지만 사용할 이유는 거의 없습니다.
 
-It also includes a package manager, `opam`, and a build system, `dune`.
+또한 패키지 관리자인 `opam`과 빌드 시스템인 `dune`도 포함합니다.
 
-It is strongly and statically typed, but instead of using manually written
-type annotations, it infers types of expressions using the
+강력하고 정적으로 유형이 지정되지만 수동으로 작성된 유형 주석을 사용하는 대신
 [Hindley-Milner](https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system)
-algorithm.
-It makes type annotations unnecessary in most cases, but can be a major
-source of confusion for beginners.
+알고리즘을 사용하여 표현식의 유형을 유추합니다.
+대부분의 경우 유형 주석이 필요하지 않지만 초보자에게는 큰 혼란의 원인이 될 수 있습니다.
 
-When you are in the top level loop, OCaml will print the inferred type
-after you enter an expression
+최상위 루프에 있을 때 OCaml은 표현식을 입력한 후 유추된 유형을 인쇄합니다.
 
 ```
 # let inc x = x	+ 1 ;;
@@ -38,8 +31,7 @@ val inc : int -> int = <fun>
 val a : int = 99
 ```
 
-For a source file you can use the `ocamlc -i /path/to/file.ml` command
-to print all names and type signatures
+소스 파일의 경우 `ocamlc -i /path/to/file.ml` 명령을 사용하여 모든 이름과 유형 서명을 인쇄할 수 있습니다.
 
 ```
 $ cat sigtest.ml
@@ -54,106 +46,104 @@ val add : int -> int -> int
 val a : int
 ```
 
-Note that type signatures of functions of multiple arguments are
-written in [curried](https://en.wikipedia.org/wiki/Currying) form.
-A function that takes multiple arguments can be
-represented as a composition of functions that take only one argument.
-The `f(x,y) = x + y` function from the example above applied to
-arguments 2 and 3 is equivalent to the `f0(y) = 2 + y` function applied to 3.
-Hence the `int -> int -> int` signature.
+여러 인수를 갖는 함수의 유형 서명은
+[커링된](https://en.wikipedia.org/wiki/Currying) 형식으로 작성됩니다.
+여러 인수를 받는 함수는 단일 인수를 받는 함수의
+구성으로 나타낼 수 있습니다.
+위 예제의 `f(x,y) = x + y` 함수를
+인수 2와 3에 적용하면 `f0(y) = 2 + y` 함수를 3에 적용한 것과 같습니다.
+따라서 `int -> int -> int` 서명이 됩니다.
 
 ```ocaml
-(*** Comments ***)
+(*** 주석 ***)
 
-(* Comments are enclosed in (* and *). It's fine to nest comments. *)
+(* 주석은 (*와 *)로 묶습니다. 주석을 중첩해도 괜찮습니다. *)
 
-(* There are no single-line comments. *)
+(* 한 줄 주석은 없습니다. *)
 
 
-(*** Variables and functions ***)
+(*** 변수와 함수 ***)
 
-(* Expressions can be separated by a double semicolon ";;".
-   In many cases it's redundant, but in this tutorial we use it after
-   every expression for easy pasting into the interpreter shell.
-   Unnecessary use of expression separators in source code files
-   is often considered to be a bad style. *)
+(* 표현식은 이중 세미콜론 ";;"으로 구분할 수 있습니다.
+   많은 경우 중복되지만, 이 튜토리얼에서는 인터프리터 셸에
+   쉽게 붙여넣을 수 있도록 모든 표현식 뒤에 사용합니다.
+   소스 코드 파일에서 표현식 구분자를 불필요하게 사용하는 것은
+   종종 나쁜 스타일로 간주됩니다. *)
 
-(* Variable and function declarations use the "let" keyword. *)
-(* Variables are immutable by default in OCaml *)
+(* 변수 및 함수 선언은 "let" 키워드를 사용합니다. *)
+(* OCaml에서 변수는 기본적으로 불변입니다. *)
 let x = 10 ;;
 
-(* OCaml allows single quote characters in identifiers.
-   Single quote doesn't have a special meaning in this case, it's often used
-   in cases when in other languages one would use names like "foo_tmp". *)
+(* OCaml은 식별자에 작은따옴표 문자를 허용합니다.
+   이 경우 작은따옴표는 특별한 의미가 없으며, 다른 언어에서
+   "foo_tmp"와 같은 이름을 사용하는 경우에 종종 사용됩니다. *)
 let foo = 1 ;;
 let foo' = foo * 2 ;;
 
-(* Since OCaml compiler infers types automatically, you normally don't need to
-   specify argument types explicitly. However, you can do it if
-   you want or need to. *)
+(* OCaml 컴파일러는 유형을 자동으로 유추하므로 일반적으로
+   인수 유형을 명시적으로 지정할 필요가 없습니다. 하지만
+   원하거나 필요한 경우 그렇게 할 수 있습니다. *)
 let inc_int (x: int) : int = x + 1 ;;
 
-(* One of the cases when explicit type annotations may be needed is
-   resolving ambiguity between two record types that have fields with
-   the same name. The alternative is to encapsulate those types in
-   modules, but both topics are a bit out of scope of this
-   tutorial. *)
+(* 명시적 유형 주석이 필요할 수 있는 경우 중 하나는
+   이름이 같은 필드를 가진 두 레코드 유형 간의 모호성을
+   해결하는 것입니다. 대안은 해당 유형을 모듈로 캡슐화하는 것이지만,
+   두 주제 모두 이 튜토리얼의 범위를 약간 벗어납니다. *)
 
-(* You need to mark recursive function definitions as such with "rec" keyword. *)
+(* "rec" 키워드로 재귀 함수 정의를 표시해야 합니다. *)
 let rec factorial n =
     if n = 0 then 1
     else n * factorial (n-1)
 ;;
 
-(* Function application usually doesn't need parentheses around arguments *)
+(* 함수 적용은 일반적으로 인수 주위에 괄호가 필요하지 않습니다. *)
 let fact_5 = factorial 5 ;;
 
-(* ...unless the argument is an expression. *)
+(* ...인수가 표현식인 경우는 예외입니다. *)
 let fact_4 = factorial (5-1) ;;
 let sqr2 = sqr (-2) ;;
 
-(* Every function must have at least one argument.
-   Since some functions naturally don't take any arguments, there's
-   "unit" type for it that has the only one value written as "()" *)
+(* 모든 함수는 최소한 하나의 인수를 가져야 합니다.
+   일부 함수는 자연스럽게 인수를 받지 않으므로,
+   "()"로 작성된 유일한 값을 갖는 "unit" 유형이 있습니다. *)
 let print_hello () = print_endline "hello world" ;;
 
-(* Note that you must specify "()" as the argument when calling it. *)
+(* 호출할 때 인수로 "()"를 지정해야 한다는 점에 유의하십시오. *)
 print_hello () ;;
 
-(* Calling a function with an insufficient number of arguments
-   does not cause an error, it produces a new function. *)
-let make_inc x y = x + y ;; (* make_inc is int -> int -> int *)
-let inc_2 = make_inc 2 ;;   (* inc_2 is int -> int *)
-inc_2 3 ;; (* Evaluates to 5 *)
+(* 불충분한 수의 인수로 함수를 호출해도
+   오류가 발생하지 않으며, 새 함수가 생성됩니다. *)
+let make_inc x y = x + y ;; (* make_inc는 int -> int -> int *)
+let inc_2 = make_inc 2 ;;   (* inc_2는 int -> int *)
+inc_2 3 ;; (* 5로 평가됨 *)
 
-(* You can use multiple expressions in the function body.
-   The last expression becomes the return value. All other
-   expressions must be of the "unit" type.
-   This is useful when writing in imperative style, the simplest
-   form of which is inserting a debug print. *)
+(* 함수 본문에 여러 표현식을 사용할 수 있습니다.
+   마지막 표현식이 반환 값이 됩니다. 다른 모든
+   표현식은 "unit" 유형이어야 합니다.
+   이것은 명령형 스타일로 작성할 때 유용하며, 가장 간단한
+   형태는 디버그 인쇄를 삽입하는 것입니다. *)
 let print_and_return x =
     print_endline (string_of_int x);
     x
 ;;
 
-(* Since OCaml is a functional language, it lacks "procedures".
-   Every function must return something. So functions that do not
-   really return anything and are called solely for their side
-   effects, like print_endline, return a value of "unit" type. *)
+(* OCaml은 함수형 언어이므로 "프로시저"가 없습니다.
+   모든 함수는 무언가를 반환해야 합니다. 따라서
+   print_endline처럼 실제로는 아무것도 반환하지 않고 부수 효과를
+   위해서만 호출되는 함수는 "unit" 유형의 값을 반환합니다. *)
 
 
-(* Definitions can be chained with the "let ... in" construct.
-   This is roughly the same as assigning values to multiple
-   variables before using them in expressions in imperative
-   languages. *)
+(* 정의는 "let ... in" 구문으로 연결할 수 있습니다.
+   이것은 명령형 언어에서 표현식에서 사용하기 전에 여러
+   변수에 값을 할당하는 것과 거의 같습니다. *)
 let x = 10 in
 let y = 20 in
 x + y ;;
 
-(* Alternatively you can use the "let ... and ... in" construct.
-   This is especially useful for mutually recursive functions,
-   with ordinary "let ... in" the compiler will complain about
-   unbound values. *)
+(* 또는 "let ... and ... in" 구문을 사용할 수 있습니다.
+   이것은 상호 재귀 함수에 특히 유용하며,
+   일반적인 "let ... in"을 사용하면 컴파일러가
+   바인딩되지 않은 값에 대해 불평합니다. *)
 let rec
   is_even = function
   | 0 -> true
@@ -164,156 +154,155 @@ and
   | n -> is_even (n-1)
 ;;
 
-(* Anonymous functions use the following syntax: *)
+(* 익명 함수는 다음 구문을 사용합니다: *)
 let my_lambda = fun x -> x * x ;;
 
-(*** Operators ***)
+(*** 연산자 ***)
 
-(* There is little distinction between operators and functions.
-   Every operator can be called as a function. *)
+(* 연산자와 함수 사이에는 거의 구별이 없습니다.
+   모든 연산자는 함수로 호출할 수 있습니다. *)
 
-(+) 3 4  (* Same as 3 + 4 *)
+(+) 3 4  (* 3 + 4와 동일 *)
 
-(* There's a number of built-in operators. One unusual feature is
-   that OCaml doesn't just refrain from any implicit conversions
-   between integers and floats, it also uses different operators
-   for floats. *)
-12 + 3 ;; (* Integer addition. *)
-12.0 +. 3.0 ;; (* Floating point addition. *)
+(* 여러 내장 연산자가 있습니다. 한 가지 특이한 특징은
+   OCaml이 정수와 부동 소수점 간의 암시적 변환을
+   자제할 뿐만 아니라 부동 소수점에 대해 다른 연산자를
+   사용한다는 것입니다. *)
+12 + 3 ;; (* 정수 덧셈. *)
+12.0 +. 3.0 ;; (* 부동 소수점 덧셈. *)
 
-12 / 3 ;; (* Integer division. *)
-12.0 /. 3.0 ;; (* Floating point division. *)
-5 mod 2 ;; (* Remainder. *)
+12 / 3 ;; (* 정수 나눗셈. *)
+12.0 /. 3.0 ;; (* 부동 소수점 나눗셈. *)
+5 mod 2 ;; (* 나머지. *)
 
-(* Unary minus is a notable exception, it's polymorphic.
-   However, it also has "pure" integer and float forms. *)
-- 3 ;; (* Polymorphic, integer *)
-- 4.5 ;; (* Polymorphic, float *)
-~- 3 (* Integer only *)
-~- 3.4 (* Type error *)
-~-. 3.4 (* Float only *)
+(* 단항 마이너스는 주목할 만한 예외이며, 다형성입니다.
+   그러나 "순수" 정수 및 부동 소수점 형식도 있습니다. *)
+- 3 ;; (* 다형성, 정수 *)
+- 4.5 ;; (* 다형성, 부동 소수점 *)
+~- 3 (* 정수만 *)
+~- 3.4 (* 유형 오류 *)
+~-. 3.4 (* 부동 소수점만 *)
 
-(* You can define your own operators or redefine existing ones.
-   Unlike Standard ML or Haskell, only certain symbols can be
-   used for operator names and the operator's first symbol determines
-   its associativity and precedence rules. *)
-let (+) a b = a - b ;; (* Surprise maintenance programmers. *)
+(* 자신만의 연산자를 정의하거나 기존 연산자를 재정의할 수 있습니다.
+   Standard ML이나 Haskell과 달리 특정 기호만
+   연산자 이름으로 사용할 수 있으며 연산자의 첫 번째 기호가
+   결합성 및 우선 순위 규칙을 결정합니다. *)
+let (+) a b = a - b ;; (* 유지보수 프로그래머를 놀라게 하십시오. *)
 
-(* More useful: a reciprocal operator for floats.
-   Unary operators must start with "~". *)
+(* 더 유용한 예: 부동 소수점의 역수 연산자.
+   단항 연산자는 "~"로 시작해야 합니다. *)
 let (~/) x = 1.0 /. x ;;
 ~/4.0 (* = 0.25 *)
 
 
-(*** Built-in data structures ***)
+(*** 내장 데이터 구조 ***)
 
-(* Lists are enclosed in square brackets, items are separated by
-   semicolons. *)
-let my_list = [1; 2; 3] ;; (* Has type "int list". *)
+(* 리스트는 대괄호로 묶고, 항목은
+   세미콜론으로 구분합니다. *)
+let my_list = [1; 2; 3] ;; (* "int list" 유형을 가짐. *)
 
-(* Tuples are (optionally) enclosed in parentheses, items are separated
-   by commas. *)
-let first_tuple = 3, 4 ;; (* Has type "int * int". *)
+(* 튜플은 (선택적으로) 괄호로 묶고, 항목은
+   쉼표로 구분합니다. *)
+let first_tuple = 3, 4 ;; (* "int * int" 유형을 가짐. *)
 let second_tuple = (4, 5) ;;
 
-(* Corollary: if you try to separate list items by commas, you get a list
-   with a tuple inside, probably not what you want. *)
-let bad_list = [1, 2] ;; (* Becomes [(1, 2)] *)
+(* 결과적으로: 리스트 항목을 쉼표로 구분하려고 하면,
+   튜플이 들어있는 리스트가 생성되는데, 아마 원하는 것이 아닐 것입니다. *)
+let bad_list = [1, 2] ;; (* [(1, 2)]가 됨 *)
 
-(* You can access individual list items with the List.nth function. *)
+(* List.nth 함수로 개별 리스트 항목에 접근할 수 있습니다. *)
 List.nth my_list 1 ;;
 
-(* There are higher-order functions for lists such as map and filter. *)
+(* map 및 filter와 같은 리스트에 대한 고차 함수가 있습니다. *)
 List.map (fun x -> x * 2) [1; 2; 3] ;;
 List.filter (fun x -> x mod 2 = 0) [1; 2; 3; 4] ;;
 
-(* You can add an item to the beginning of a list with the "::" constructor
-   often referred to as "cons". *)
-1 :: [2; 3] ;; (* Gives [1; 2; 3] *)
+(* "::" 생성자(종종 "cons"라고 함)를 사용하여 리스트 시작 부분에
+   항목을 추가할 수 있습니다. *)
+1 :: [2; 3] ;; (* [1; 2; 3]을 반환 *)
 
-(* Remember that the cons :: constructor can only cons a single item to the front
-   of a list. To combine two lists use the append @ operator *)
-[1; 2] @ [3; 4] ;; (* Gives [1; 2; 3; 4] *)
+(* cons :: 생성자는 단일 항목만 리스트의 앞에 추가할 수 있다는 점을
+   기억하십시오. 두 리스트를 결합하려면 append @ 연산자를 사용하십시오. *)
+[1; 2] @ [3; 4] ;; (* [1; 2; 3; 4]를 반환 *)
 
-(* Arrays are enclosed in [| |] *)
+(* 배열은 [| |]로 묶습니다. *)
 let my_array = [| 1; 2; 3 |] ;;
 
-(* You can access array items like this: *)
+(* 다음과 같이 배열 항목에 접근할 수 있습니다: *)
 my_array.(0) ;;
 
 
-(*** Strings and characters ***)
+(*** 문자열과 문자 ***)
 
-(* Use double quotes for string literals. *)
+(* 문자열 리터럴에는 큰따옴표를 사용합니다. *)
 let my_str = "Hello world" ;;
 
-(* Use single quotes for character literals. *)
+(* 문자 리터럴에는 작은따옴표를 사용합니다. *)
 let my_char = 'a' ;;
 
-(* Single and double quotes are not interchangeable. *)
-let bad_str = 'syntax error' ;; (* Syntax error. *)
+(* 작은따옴표와 큰따옴표는 서로 바꿔 쓸 수 없습니다. *)
+let bad_str = 'syntax error' ;; (* 구문 오류. *)
 
-(* This will give you a single character string, not a character. *)
+(* 이것은 문자가 아닌 단일 문자 문자열을 제공합니다. *)
 let single_char_str = "w" ;;
 
-(* Strings can be concatenated with the "^" operator. *)
+(* 문자열은 "^" 연산자로 연결할 수 있습니다. *)
 let some_str = "hello" ^ "world" ;;
 
-(* Strings are not arrays of characters.
-   You can't mix characters and strings in expressions.
-   You can convert a character to a string with "String.make 1 my_char".
-   There are more convenient functions for this purpose in additional
-   libraries such as Core.Std that may not be installed and/or loaded
-   by default. *)
+(* 문자열은 문자 배열이 아닙니다.
+   표현식에서 문자와 문자열을 혼합할 수 없습니다.
+   "String.make 1 my_char"를 사용하여 문자를 문자열로 변환할 수 있습니다.
+   Core.Std와 같은 추가 라이브러리에는 이 목적을 위한 더 편리한
+   함수가 있으며, 기본적으로 설치 및/또는 로드되지 않을 수 있습니다. *)
 let ocaml = (String.make 1 'O') ^ "Caml" ;;
 
-(* There is a printf function. *)
+(* printf 함수가 있습니다. *)
 Printf.printf "%d %s" 99 "bottles of beer" ;;
 
-(* There's also unformatted read and write functions. *)
+(* 서식 없는 읽기 및 쓰기 함수도 있습니다. *)
 print_string "hello world\n" ;;
 print_endline "hello world" ;;
 let line = read_line () ;;
 
 
-(*** User-defined data types ***)
+(*** 사용자 정의 데이터 유형 ***)
 
-(* You can define types with the "type some_type =" construct. Like in this
-   useless type alias: *)
+(* "type some_type =" 구문으로 유형을 정의할 수 있습니다. 이
+   쓸모없는 유형 별칭처럼: *)
 type my_int = int ;;
 
-(* More interesting types include so called type constructors.
-   Constructors must start with a capital letter. *)
+(* 더 흥미로운 유형에는 소위 유형 생성자가 포함됩니다.
+   생성자는 대문자로 시작해야 합니다. *)
 type ml = OCaml | StandardML ;;
-let lang = OCaml ;;  (* Has type "ml". *)
+let lang = OCaml ;;  (* "ml" 유형을 가짐. *)
 
-(* Type constructors don't need to be empty. *)
+(* 유형 생성자는 비어 있을 필요가 없습니다. *)
 type my_number = PlusInfinity | MinusInfinity | Real of float ;;
-let r0 = Real (-3.4) ;; (* Has type "my_number". *)
+let r0 = Real (-3.4) ;; (* "my_number" 유형을 가짐. *)
 
-(* Can be used to implement polymorphic arithmetics. *)
+(* 다형성 산술을 구현하는 데 사용할 수 있습니다. *)
 type number = Int of int | Float of float ;;
 
-(* Point on a plane, essentially a type-constrained tuple *)
+(* 평면 위의 점, 본질적으로 유형이 제한된 튜플 *)
 type point2d = Point of float * float ;;
 let my_point = Point (2.0, 3.0) ;;
 
-(* Types can be parameterized, like in this type for "list of lists
-   of anything". 'a can be substituted with any type. *)
+(* 유형은 매개변수화될 수 있습니다. 이 유형은 "무엇이든
+   리스트의 리스트"에 대한 것입니다. 'a는 모든 유형으로 대체될 수 있습니다. *)
 type 'a list_of_lists = 'a list list ;;
 type int_list_list = int list_of_lists ;;
 
-(* These features allow for useful optional types *)
+(* 이러한 기능은 유용한 선택적 유형을 허용합니다. *)
 type 'a option = Some of 'a | None ;;
 let x = Some x ;;
 let y = None ;;
 
-(* Types can also be recursive. Like in this type analogous to
-   a built-in list of integers. *)
+(* 유형은 재귀적일 수도 있습니다. 이 유형은
+   내장 정수 리스트와 유사합니다. *)
 type my_int_list = EmptyList | IntList of int * my_int_list ;;
 let l = IntList (1, EmptyList) ;;
 
-(* or Trees *)
+(* 또는 트리 *)
 type 'a tree =
    | Empty
    | Node of 'a tree * 'a * 'a tree
@@ -330,9 +319,9 @@ let example_tree: int tree =
  7   9
 *)
 
-(*** Records ***)
+(*** 레코드 ***)
 
-(* A collection of values with named fields *)
+(* 이름 있는 필드가 있는 값 모음 *)
 
 type animal =
    {
@@ -353,30 +342,30 @@ val cow : animal
 cow.name ;;
 - : string = "cow"
 
-(*** Pattern matching ***)
+(*** 패턴 매칭 ***)
 
-(* Pattern matching is somewhat similar to the switch statement in imperative
-   languages, but offers a lot more expressive power.
+(* 패턴 매칭은 명령형 언어의 switch 문과 다소 유사하지만,
+   훨씬 더 많은 표현력을 제공합니다.
 
-   Even though it may look complicated, it really boils down to matching
-   an argument against an exact value, a predicate, or a type constructor.
-   The type system is what makes it so powerful. *)
+   복잡해 보일 수 있지만, 실제로는 인수를 정확한 값,
+   술어 또는 유형 생성자와 일치시키는 것으로 귀결됩니다.
+   유형 시스템이 이를 매우 강력하게 만듭니다. *)
 
-(** Matching exact values.  **)
+(** 정확한 값 일치.  **)
 
 let is_zero x =
     match x with
     | 0 -> true
-    | _ -> false  (* The "_" means "anything else". *)
+    | _ -> false  (* "_"는 "그 밖의 모든 것"을 의미합니다. *)
 ;;
 
-(* Alternatively, you can use the "function" keyword. *)
+(* 또는 "function" 키워드를 사용할 수 있습니다. *)
 let is_one = function
 | 1 -> true
 | _ -> false
 ;;
 
-(* Matching predicates, aka "guarded pattern matching". *)
+(* 술어 일치, 즉 "가드된 패턴 매칭". *)
 let abs x =
     match x with
     | x when x < 0 -> -x
@@ -384,9 +373,9 @@ let abs x =
 ;;
 
 abs 5 ;; (* 5 *)
-abs (-5) (* 5 again *)
+abs (-5) (* 다시 5 *)
 
-(** Matching type constructors **)
+(** 유형 생성자 일치 **)
 
 type animal = Dog of string | Cat of string ;;
 
@@ -398,35 +387,35 @@ let say x =
 
 say (Cat "Fluffy") ;; (* "Fluffy says meow". *)
 
-(* However, pattern matching must be exhaustive *)
+(* 그러나 패턴 매칭은 철저해야 합니다. *)
 type color = Red | Blue | Green ;;
 let what_color x =
    match x with
    | Red -> "color is red"
    | Blue -> "color is blue"
-   (* Won't compile! You have to add a _ case or a Green case
-      to ensure all possibilities are accounted for *)
+   (* 컴파일되지 않음! 모든 가능성을 고려하도록 _ 케이스 또는 Green 케이스를
+      추가해야 합니다. *)
 ;;
-(* Also, the match statement checks each case in order.
-   So, if a _ case appears first, none of the
-   following cases will be reached! *)
+(* 또한 match 문은 각 케이스를 순서대로 확인합니다.
+   따라서 _ 케이스가 먼저 나타나면
+   다음 케이스는 도달하지 않습니다! *)
 
-(** Traversing data structures with pattern matching **)
+(** 패턴 매칭으로 데이터 구조 순회 **)
 
-(* Recursive types can be traversed with pattern matching easily.
-   Let's see how we can traverse a data structure of the built-in list type.
-   Even though the built-in cons ("::") looks like an infix operator,
-   it's actually a type constructor and can be matched like any other. *)
+(* 재귀 유형은 패턴 매칭으로 쉽게 순회할 수 있습니다.
+   내장 리스트 유형의 데이터 구조를 순회하는 방법을 살펴보겠습니다.
+   내장 cons ("::")가 중위 연산자처럼 보이지만,
+   실제로는 유형 생성자이며 다른 것과 같이 일치시킬 수 있습니다. *)
 let rec sum_list l =
     match l with
     | [] -> 0
     | head :: tail -> head + (sum_list tail)
 ;;
 
-sum_list [1; 2; 3] ;; (* Evaluates to 6 *)
+sum_list [1; 2; 3] ;; (* 6으로 평가됨 *)
 
-(* Built-in syntax for cons obscures the structure a bit, so we'll make
-   our own list for demonstration. *)
+(* 내장 cons 구문은 구조를 약간 모호하게 하므로,
+   데모용으로 우리만의 리스트를 만들겠습니다. *)
 
 type int_list = Nil | Cons of int * int_list ;;
 let rec sum_int_list l =
@@ -438,7 +427,7 @@ let rec sum_int_list l =
 let t = Cons (1, Cons (2, Cons (3, Nil))) ;;
 sum_int_list t ;;
 
-(* Heres a function to tell if a list is sorted *)
+(* 리스트가 정렬되었는지 확인하는 함수입니다. *)
 let rec is_sorted l =
    match l with
    | x :: y :: tail -> x <= y && is_sorted (y :: tail)
@@ -446,22 +435,22 @@ let rec is_sorted l =
 ;;
 
 is_sorted [1; 2; 3] ;; (* True *)
-(* OCaml's powerful type inference guesses that l is of type int list
-   since the <= operator is used on elements of l *)
+(* OCaml의 강력한 유형 추론은 l의 요소에 <= 연산자가
+   사용되므로 l이 int list 유형이라고 추측합니다. *)
 
-(* And another to reverse a list *)
+(* 그리고 리스트를 뒤집는 또 다른 함수 *)
 let rec rev (l: 'a list) : 'a list =
   match l with
   | [] -> []
   | x::tl -> (rev tl) @ [x]
 ;;
 
-rev [1; 2; 3] ;; (* Gives [3; 2; 1] *)
-(* This function works on lists of any element type *)
+rev [1; 2; 3] ;; (* [3; 2; 1]을 반환 *)
+(* 이 함수는 모든 요소 유형의 리스트에서 작동합니다. *)
 
-(*** Higher Order Functions ***)
+(*** 고차 함수 ***)
 
-(* Functions are first class in OCaml *)
+(* 함수는 OCaml에서 일급입니다. *)
 
 let rec transform (f: 'a -> 'b) (l: 'a list) : 'b list =
   match l with
@@ -469,9 +458,9 @@ let rec transform (f: 'a -> 'b) (l: 'a list) : 'b list =
   | head :: tail -> (f head) :: transform f tail
 ;;
 
-transform (fun x -> x + 1) [1; 2; 3] ;; (* Gives [2; 3; 4] *)
+transform (fun x -> x + 1) [1; 2; 3] ;; (* [2; 3; 4]를 반환 *)
 
-(** Lets combine everything we learned! **)
+(** 배운 모든 것을 결합해 봅시다! **)
 let rec filter (pred: 'a -> bool) (l: 'a list) : 'a list =
   begin match l with
   | [] -> []
@@ -481,32 +470,32 @@ let rec filter (pred: 'a -> bool) (l: 'a list) : 'a list =
   end
 ;;
 
-filter (fun x -> x < 4) [3; 1; 4; 1; 5] ;; (* Gives [3; 1; 1]) *)
+filter (fun x -> x < 4) [3; 1; 4; 1; 5] ;; (* [3; 1; 1]을 반환) *)
 
-(*** Mutability ***)
+(*** 가변성 ***)
 
-(* Records and variables are immutable: you cannot change where a variable points to *)
+(* 레코드와 변수는 불변입니다: 변수가 가리키는 위치를 변경할 수 없습니다. *)
 
-(* However, you can create mutable polymorphic fields *)
+(* 그러나 변경 가능한 다형성 필드를 만들 수 있습니다. *)
 type counter = { mutable num : int } ;;
 
 let c = { num = 0 } ;;
-c.num ;; (* Gives 0 *)
-c.num <- 1 ;; (* <- operator can set mutable record fields *)
-c.num ;; (* Gives 1 *)
+c.num ;; (* 0을 반환 *)
+c.num <- 1 ;; (* <- 연산자는 변경 가능한 레코드 필드를 설정할 수 있습니다. *)
+c.num ;; (* 1을 반환 *)
 
-(* OCaml's standard library provides a ref type to make single field mutability easier *)
+(* OCaml의 표준 라이브러리는 단일 필드 가변성을 더 쉽게 만들기 위해 ref 유형을 제공합니다. *)
 type 'a ref = { mutable contents : 'a } ;;
 let counter = ref 0 ;;
-!counter ;; (* ! operator returns x.contents *)
-counter := !counter + 1 ;; (* := can be used to set contents *)
+!counter ;; (* ! 연산자는 x.contents를 반환합니다. *)
+counter := !counter + 1 ;; (* :=는 내용을 설정하는 데 사용할 수 있습니다. *)
 ```
 
-## Further reading
+## 더 읽을거리
 
-* Visit the official website to get the compiler and read the docs: [http://ocaml.org/](http://ocaml.org/)
-* Quick tutorial on OCaml: [https://ocaml.org/docs/up-and-running](https://ocaml.org/docs/up-and-running)
-* Complete online OCaml v5 playground: [https://ocaml.org/play](https://ocaml.org/play)
-* An up-to-date (2022) book (with free online version) "Real World OCaml": [https://www.cambridge.org/core/books/real-world-ocaml-functional-programming-for-the-masses/052E4BCCB09D56A0FE875DD81B1ED571](https://www.cambridge.org/core/books/real-world-ocaml-functional-programming-for-the-masses/052E4BCCB09D56A0FE875DD81B1ED571)
-* Online interactive textbook "OCaml Programming: Correct + Efficient + Beautiful" from Cornell University: [https://cs3110.github.io/textbook/cover.html](https://cs3110.github.io/textbook/cover.html)
-* Try interactive tutorials and a web-based interpreter by OCaml Pro: [http://try.ocamlpro.com/](http://try.ocamlpro.com/)
+* 공식 웹사이트를 방문하여 컴파일러를 받고 문서를 읽으십시오: [http://ocaml.org/](http://ocaml.org/)
+* OCaml 빠른 튜토리얼: [https://ocaml.org/docs/up-and-running](https://ocaml.org/docs/up-and-running)
+* 완전한 온라인 OCaml v5 놀이터: [https://ocaml.org/play](https://ocaml.org/play)
+* 최신(2022년) 책(무료 온라인 버전 포함) "Real World OCaml": [https://www.cambridge.org/core/books/real-world-ocaml-functional-programming-for-the-masses/052E4BCCB09D56A0FE875DD81B1ED571](https://www.cambridge.org/core/books/real-world-ocaml-functional-programming-for-the-masses/052E4BCCB09D56A0FE875DD81B1ED571)
+* 코넬 대학의 온라인 대화형 교과서 "OCaml Programming: Correct + Efficient + Beautiful": [https://cs3110.github.io/textbook/cover.html](https://cs3110.github.io/textbook/cover.html)
+* OCaml Pro의 대화형 튜토리얼 및 웹 기반 인터프리터 시도: [http://try.ocamlpro.com/](http://try.ocamlpro.com/)

--- a/ko/opencv.md
+++ b/ko/opencv.md
@@ -1,5 +1,3 @@
-# opencv.md (번역)
-
 ---
 category: framework
 name: OpenCV
@@ -9,105 +7,105 @@ contributors:
 ---
 ### OpenCV
 
-OpenCV (Open Source Computer Vision) is a library of programming functions mainly aimed at real-time computer vision.
-Originally developed by Intel, it was later supported by Willow Garage then Itseez (which was later acquired by Intel).
-OpenCV currently supports wide variety of languages like, C++, Python, Java, etc.
+OpenCV(오픈 소스 컴퓨터 비전)는 주로 실시간 컴퓨터 비전을 목표로 하는 프로그래밍 함수 라이브러리입니다.
+원래 인텔에서 개발했으며, 나중에 Willow Garage와 Itseez(나중에 인텔에 인수됨)의 지원을 받았습니다.
+OpenCV는 현재 C++, Python, Java 등 다양한 언어를 지원합니다.
 
-#### Installation
-Please refer to these articles for installation of OpenCV on your computer.
+#### 설치
+컴퓨터에 OpenCV를 설치하려면 다음 문서를 참조하십시오.
 
-* Windows Installation Instructions: [https://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_setup/py_setup_in_windows/py_setup_in_windows.html#install-opencv-python-in-windows](https://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_setup/py_setup_in_windows/py_setup_in_windows.html#install-opencv-python-in-windows)
-* Mac Installation Instructions (High Sierra): [https://medium.com/@nuwanprabhath/installing-opencv-in-macos-high-sierra-for-python-3-89c79f0a246a](https://medium.com/@nuwanprabhath/installing-opencv-in-macos-high-sierra-for-python-3-89c79f0a246a)
-* Linux Installation Instructions (Ubuntu 18.04): [https://www.pyimagesearch.com/2018/05/28/ubuntu-18-04-how-to-install-opencv](https://www.pyimagesearch.com/2018/05/28/ubuntu-18-04-how-to-install-opencv)
+* Windows 설치 지침: [https://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_setup/py_setup_in_windows/py_setup_in_windows.html#install-opencv-python-in-windows](https://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_setup/py_setup_in_windows/py_setup_in_windows.html#install-opencv-python-in-windows)
+* Mac 설치 지침 (High Sierra): [https://medium.com/@nuwanprabhath/installing-opencv-in-macos-high-sierra-for-python-3-89c79f0a246a](https://medium.com/@nuwanprabhath/installing-opencv-in-macos-high-sierra-for-python-3-89c79f0a246a)
+* Linux 설치 지침 (Ubuntu 18.04): [https://www.pyimagesearch.com/2018/05/28/ubuntu-18-04-how-to-install-opencv](https://www.pyimagesearch.com/2018/05/28/ubuntu-18-04-how-to-install-opencv)
 
-### Here we will be focusing on Python implementation of OpenCV
+### 여기서는 OpenCV의 Python 구현에 중점을 둘 것입니다
 
 ```python
-# Reading image in OpenCV
+# OpenCV에서 이미지 읽기
 import cv2
 img = cv2.imread('cat.jpg')
 
-# Displaying the image
-# imshow() function is used to display the image
+# 이미지 표시
+# imshow() 함수는 이미지를 표시하는 데 사용됩니다.
 cv2.imshow('Image', img)
-# Your first argument is the title of the window and second parameter is image
-# If you are getting an error, Object Type None, your image path may be wrong. Please recheck the path to the image
+# 첫 번째 인수는 창의 제목이고 두 번째 매개변수는 이미지입니다.
+# Object Type None 오류가 발생하는 경우 이미지 경로가 잘못되었을 수 있습니다. 이미지 경로를 다시 확인하십시오.
 cv2.waitKey(0)
-# waitKey() is a keyboard binding function and takes an argument in milliseconds. For GUI events you MUST use waitKey() function.
+# waitKey()는 키보드 바인딩 함수이며 밀리초 단위로 인수를 받습니다. GUI 이벤트의 경우 waitKey() 함수를 사용해야 합니다.
 
-# Writing an image
+# 이미지 쓰기
 cv2.imwrite('catgray.png', img)
-# The first argument is the file name and second is the image
+# 첫 번째 인수는 파일 이름이고 두 번째는 이미지입니다.
 
-# Convert image to grayscale
+# 이미지를 회색조로 변환
 gray_image = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
 
-# Capturing Video from Webcam
+# 웹캠에서 비디오 캡처
 cap = cv2.VideoCapture(0)
-# 0 is your camera, if you have multiple cameras, you need to enter their id
+# 0은 카메라입니다. 여러 대의 카메라가 있는 경우 해당 ID를 입력해야 합니다.
 while True:
-    # Capturing frame-by-frame
+    # 프레임별 캡처
     _, frame = cap.read()
     cv2.imshow('Frame', frame)
-    # When user presses q -> quit
+    # 사용자가 q를 누르면 종료
     if cv2.waitKey(1) & 0xFF == ord('q'):
         break
-# Camera must be released
+# 카메라를 해제해야 합니다.
 cap.release()
 
-# Playing Video from file
+# 파일에서 비디오 재생
 cap = cv2.VideoCapture('movie.mp4')
 while cap.isOpened():
     _, frame = cap.read()
-    # Play the video in grayscale
+    # 비디오를 회색조로 재생
     gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
     cv2.imshow('frame', gray)
     if cv2.waitKey(1) & 0xFF == ord('q'):
         break
 cap.release()
 
-# Drawing The Line in OpenCV
+# OpenCV에서 선 그리기
 # cv2.line(img, (x,y), (x1,y1), (color->r,g,b->0 to 255), thickness)
 cv2.line(img, (0, 0), (511, 511), (255, 0, 0), 5)
 
-# Drawing Rectangle
+# 사각형 그리기
 # cv2.rectangle(img, (x,y), (x1,y1), (color->r,g,b->0 to 255), thickness)
-# thickness = -1 used for filling the rectangle
+# thickness = -1은 사각형을 채우는 데 사용됩니다.
 cv2.rectangle(img, (384, 0), (510, 128), (0, 255, 0), 3)
 
-# Drawing Circle
+# 원 그리기
 # cv2.circle(img, (xCenter,yCenter), radius, (color->r,g,b->0 to 255), thickness)
 cv2.circle(img, (200, 90), 100, (0, 0, 255), -1)
 
-# Drawing Ellipse
+# 타원 그리기
 cv2.ellipse(img, (256, 256), (100, 50), 0, 0, 180, 255, -1)
 
-# Adding Text On Images
+# 이미지에 텍스트 추가
 cv2.putText(img, "Hello World!!!", (x, y), cv2.FONT_HERSHEY_SIMPLEX, 2, 255)
 
-# Blending Images
+# 이미지 블렌딩
 img1 = cv2.imread('cat.png')
 img2 = cv2.imread('openCV.jpg')
 dst = cv2.addWeighted(img1, 0.5, img2, 0.5, 0)
 
-# Thresholding image
-# Binary Thresholding
+# 이미지 임계 처리
+# 이진 임계 처리
 _, thresImg = cv2.threshold(img, 127, 255, cv2.THRESH_BINARY)
-# Adaptive Thresholding
+# 적응형 임계 처리
 adapThres = cv2.adaptiveThreshold(img, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY, 11, 2)
 
-# Blur Image
-# Gaussian Blur
+# 이미지 블러
+# 가우시안 블러
 blur = cv2.GaussianBlur(img, (5, 5), 0)
-# Median Blur
+# 미디언 블러
 medianBlur = cv2.medianBlur(img, 5)
 
-# Canny Edge Detection
+# 캐니 에지 검출
 img = cv2.imread('cat.jpg', 0)
 edges = cv2.Canny(img, 100, 200)
 
-# Face Detection using Haar Cascades
-# Download Haar Cascades from https://github.com/opencv/opencv/blob/master/data/haarcascades/
+# Haar Cascades를 사용한 얼굴 검출
+# https://github.com/opencv/opencv/blob/master/data/haarcascades/에서 Haar Cascades 다운로드
 import cv2
 import numpy as np
 
@@ -119,30 +117,30 @@ gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
 
 faces = face_cascade.detectMultiScale(gray, 1.3, 5)
 for x, y, w, h in faces:
-    # Draw a rectangle around detected face
+    # 검출된 얼굴 주위에 사각형 그리기
     cv2.rectangle(img, (x, y), (x + w, y + h), (255, 0, 0), 2)
     roi_gray = gray[y : y + h, x : x + w]
     roi_color = img[y : y + h, x : x + w]
     eyes = eye_cascade.detectMultiScale(roi_gray)
     for ex, ey, ew, eh in eyes:
-        # Draw a rectangle around detected eyes
+        # 검출된 눈 주위에 사각형 그리기
         cv2.rectangle(roi_color, (ex, ey), (ex + ew, ey + eh), (0, 255, 0), 2)
 
 cv2.imshow('img', img)
 cv2.waitKey(0)
 
 cv2.destroyAllWindows()
-# destroyAllWindows() destroys all windows.
-# If you wish to destroy specific window pass the exact name of window you created.
+# destroyAllWindows()는 모든 창을 닫습니다.
+# 특정 창을 닫으려면 생성한 창의 정확한 이름을 전달하십시오.
 ```
 
-### Further Reading:
+### 더 읽을거리:
 
-* Download Cascade from [https://github.com/opencv/opencv/blob/master/data/haarcascades](https://github.com/opencv/opencv/blob/master/data/haarcascades)
-* OpenCV drawing Functions [https://docs.opencv.org/2.4/modules/core/doc/drawing_functions.html](https://docs.opencv.org/2.4/modules/core/doc/drawing_functions.html)
-* An up-to-date language reference can be found at [https://opencv.org](https://opencv.org)
-* Additional resources may be found at [https://en.wikipedia.org/wiki/OpenCV](https://en.wikipedia.org/wiki/OpenCV)
-* Good OpenCV Tutorials
+* Cascade 다운로드 [https://github.com/opencv/opencv/blob/master/data/haarcascades](https://github.com/opencv/opencv/blob/master/data/haarcascades)
+* OpenCV 그리기 함수 [https://docs.opencv.org/2.4/modules/core/doc/drawing_functions.html](https://docs.opencv.org/2.4/modules/core/doc/drawing_functions.html)
+* 최신 언어 참조는 [https://opencv.org](https://opencv.org)에서 찾을 수 있습니다.
+* 추가 자료는 [https://en.wikipedia.org/wiki/OpenCV](https://en.wikipedia.org/wiki/OpenCV)에서 찾을 수 있습니다.
+* 좋은 OpenCV 튜토리얼
     * [https://realpython.com/python-opencv-color-spaces](https://realpython.com/python-opencv-color-spaces)
     * [https://pyimagesearch.com](https://pyimagesearch.com)
     * [https://www.learnopencv.com](https://www.learnopencv.com)

--- a/ko/pascal.md
+++ b/ko/pascal.md
@@ -1,5 +1,3 @@
-# pascal.md (번역)
-
 ---
 name: Pascal
 filename: learnpascal.pas
@@ -9,134 +7,133 @@ contributors:
 ---
 
 
->Pascal is an imperative and procedural programming language, which Niklaus Wirth designed in 1968–69 and published in 1970, as a small, efficient language intended to encourage good programming practices using structured programming and data structuring. It is named in honor of the French mathematician, philosopher and physicist Blaise Pascal.
-source : [wikipedia](https://en.wikipedia.org/wiki/Pascal_(programming_language))
+>파스칼은 1968-69년에 니클라우스 비르트가 설계하고 1970년에 발표한 명령형 및 절차적 프로그래밍 언어로, 구조적 프로그래밍과 데이터 구조화를 사용하여 좋은 프로그래밍 습관을 장려하기 위한 작고 효율적인 언어입니다. 프랑스의 수학자, 철학자, 물리학자인 블레즈 파스칼을 기리기 위해 명명되었습니다.
+출처 : [위키백과](https://en.wikipedia.org/wiki/Pascal_(programming_language))
 
 
 
-To compile and run a pascal program you could use a free pascal compiler. [Download Here](https://www.freepascal.org/)
+파스칼 프로그램을 컴파일하고 실행하려면 무료 파스칼 컴파일러를 사용할 수 있습니다. [여기서 다운로드](https://www.freepascal.org/)
 
 ```pascal
-//Anatomy of a Pascal Program
-//this is a comment
+//파스칼 프로그램의 구조
+//이것은 주석입니다
 {
-    this is a
-    multiline comment
+    이것은
+    여러 줄 주석입니다
 }
 
-//name of the program
-program learn_pascal; //<-- don't forget a semicolon
+//프로그램 이름
+program learn_pascal; //<-- 세미콜론을 잊지 마세요
 
 const
     {
-        this is where you should declare constant values
+        상수 값을 선언해야 하는 곳입니다
     }
 type
     {
-        this is where you should declare custom
-        data-types
+        사용자 정의 데이터 타입을 선언해야 하는 곳입니다
     }
 var
     {
-        this is where you should declare a variable
+        변수를 선언해야 하는 곳입니다
     }
 
-//main program area
+//주 프로그램 영역
 begin
     {
-        area to declare your instruction
+        명령을 선언하는 영역
     }
-end. // End of a main program area should require a "." symbol
+end. // 주 프로그램 영역의 끝에는 "." 기호가 필요합니다
 ```
 
 ```pascal
-//When declaring variables
-//you can do this
+//변수를 선언할 때
+//이렇게 할 수 있습니다
 var a:integer;
 var b:integer;
-//or this
+//또는 이렇게
 var
     a : integer;
     b : integer;
-//or this
+//또는 이렇게
 var a,b : integer;
 ```
 
 ```pascal
 program Learn_More;
-//Let's learn about data types and their operations
+//데이터 타입과 그 연산에 대해 알아봅시다
 
 const
     PI = 3.141592654;
     GNU = 'GNU''s Not Unix';
-        // constants are conventionally named using CAPS
-        // their values are fixed and cannot be changed during runtime
-        // holds any standard data type (integer, real, boolean, char, string)
+        // 상수는 관례적으로 대문자를 사용하여 명명합니다
+        // 그 값은 고정되어 있으며 런타임 중에 변경할 수 없습니다
+        // 모든 표준 데이터 타입(정수, 실수, 불리언, 문자, 문자열)을 가질 수 있습니다
 
 type
     ch_array : array [0..255] of char;
-        // arrays are new 'types' specifying the length and data type
-        // this defines a new data type that contains 255 characters
-        // (this is functionally equivalent to a string[256] variable)
+        // 배열은 길이와 데이터 타입을 지정하는 새로운 '타입'입니다
+        // 이것은 255개의 문자를 포함하는 새로운 데이터 타입을 정의합니다
+        // (이것은 기능적으로 string[256] 변수와 동일합니다)
     md_array : array of array of integer;
-        // nested arrays are equivalent to multidimensional arrays
-        // can define zero (0) length arrays that are dynamically sized
-        // this is a 2-dimensional array of integers
+        // 중첩 배열은 다차원 배열과 동일합니다
+        // 동적으로 크기가 조정되는 길이가 0인 배열을 정의할 수 있습니다
+        // 이것은 2차원 정수 배열입니다
 
-//Declaring variables
+//변수 선언
 var
     int, c, d  : integer;
-           // three variables that contain integer numbers
-           // integers are 16-bits and limited to the range [-32,768..32,767]
+           // 정수 숫자를 포함하는 세 개의 변수
+           // 정수는 16비트이며 [-32,768..32,767] 범위로 제한됩니다
     r    : real;
-           // a variable that contains a real number data types
-           // reals can range between [3.4E-38..3.4E38]
+           // 실수 데이터 타입을 포함하는 변수
+           // 실수는 [3.4E-38..3.4E38] 범위일 수 있습니다
     bool : boolean;
-           // a variable that contains a Boolean(True/False) value
+           // 불리언(True/False) 값을 포함하는 변수
     ch   : char;
-           // a variable that contains a character value
-           // char variables are stored as 8-bit data types so no UTF
+           // 문자 값을 포함하는 변수
+           // 문자 변수는 8비트 데이터 타입으로 저장되므로 UTF가 없습니다
     str  : string;
-           // a non-standard variable that contains a string value
-           // strings are an extension included in most Pascal compilers
-           // they are stored as an array of char with default length of 255.
+           // 문자열 값을 포함하는 비표준 변수
+           // 문자열은 대부분의 파스칼 컴파일러에 포함된 확장 기능입니다
+           // 기본 길이가 255인 문자 배열로 저장됩니다.
     s    : string[50];
-           // a string with maximum length of 50 chars.
-           // you can specify the length of the string to minimize memory usage
+           // 최대 길이가 50자인 문자열.
+           // 메모리 사용량을 최소화하기 위해 문자열 길이를 지정할 수 있습니다
     my_str: ch_array;
-           // you can declare variables of custom types
+           // 사용자 정의 타입의 변수를 선언할 수 있습니다
     my_2d : md_array;
-           // dynamically sized arrays need to be sized before they can be used.
+           // 동적으로 크기가 조정되는 배열은 사용하기 전에 크기를 지정해야 합니다.
 
-    // additional integer data types
-    b    : byte;     // range [0..255]
-    shi  : shortint; // range [-128..127]
-    smi  : smallint; // range [-32,768..32,767] (standard Integer)
-    w    : word;     // range [0..65,535]
-    li   : longint;  // range [-2,147,483,648..2,147,483,647]
-    lw   : longword; // range [0..4,294,967,295]
+    // 추가 정수 데이터 타입
+    b    : byte;     // 범위 [0..255]
+    shi  : shortint; // 범위 [-128..127]
+    smi  : smallint; // 범위 [-32,768..32,767] (표준 정수)
+    w    : word;     // 범위 [0..65,535]
+    li   : longint;  // 범위 [-2,147,483,648..2,147,483,647]
+    lw   : longword; // 범위 [0..4,294,967,295]
     c    : cardinal; // longword
-    i64  : int64;    // range [-9223372036854775808..9223372036854775807]
-    qw   : qword;    // range [0..18,446,744,073,709,551,615]
+    i64  : int64;    // 범위 [-9223372036854775808..9223372036854775807]
+    qw   : qword;    // 범위 [0..18,446,744,073,709,551,615]
 
-    // additional real types
-    rr   : real;     // range depends on platform (i.e., 8-bit, 16-bit, etc.)
-    rs   : single;   // range [1.5E-45..3.4E38]
-    rd   : double;   // range [5.0E-324 .. 1.7E308]
-    re   : extended; // range [1.9E-4932..1.1E4932]
-    rc   : comp;     // range [-2E64+1 .. 2E63-1]
+    // 추가 실수 타입
+    rr   : real;     // 범위는 플랫폼에 따라 다름 (예: 8비트, 16비트 등)
+    rs   : single;   // 범위 [1.5E-45..3.4E38]
+    rd   : double;   // 범위 [5.0E-324 .. 1.7E308]
+    re   : extended; // 범위 [1.9E-4932..1.1E4932]
+    rc   : comp;     // 범위 [-2E64+1 .. 2E63-1]
 
 Begin
-    int := 1;// how to assign a value to a variable
+    int := 1;// 변수에 값을 할당하는 방법
     r   := 3.14;
     ch  := 'a';
     str := 'apple';
     bool := true;
-    //pascal is not a case-sensitive language
-    //arithmetic operation
-    int := 1 + 1; // int = 2 overwriting the previous assignment
+    //파스칼은 대소문자를 구분하지 않는 언어입니다
+    //산술 연산
+    int := 1 + 1; // int = 2, 이전 할당을 덮어씁니다
     int := int + 1; // int = 2 + 1 = 3;
-    int := 4 div 2; //int = 2 division operation where result will be floored
+    int := 4 div 2; //int = 2, 결과가 버림되는 나눗셈 연산
     int := 3 div 2; //int = 1
     int := 1 div 2; //int = 0
 
@@ -144,19 +141,19 @@ Begin
     bool := false and true; // bool = false
     bool := true xor true; // bool = false
 
-    r := 3 / 2; // a division operator for real
-    r := int; // can assign an integer to a real variable but not the reverse
+    r := 3 / 2; // 실수를 위한 나눗셈 연산자
+    r := int; // 정수를 실수 변수에 할당할 수 있지만 그 반대는 안 됩니다
 
-    c := str[1]; // assign the first letter of str to c
-    str := 'hello' + 'world'; //combining strings
+    c := str[1]; // str의 첫 글자를 c에 할당
+    str := 'hello' + 'world'; //문자열 결합
 
-    my_str[0] := 'a'; // array assignment needs an index
+    my_str[0] := 'a'; // 배열 할당에는 인덱스가 필요합니다
 
-    setlength(my_2d,10,10); // initialize dynamically sized arrays: 10×10 array
-    for c := 0 to 9 do // arrays begin at 0 and end at length-1
-        for d := 0 to 9 do // for loop counters need to be declared variables
+    setlength(my_2d,10,10); // 동적으로 크기가 조정되는 배열 초기화: 10×10 배열
+    for c := 0 to 9 do // 배열은 0에서 시작하여 길이-1에서 끝납니다
+        for d := 0 to 9 do // for 루프 카운터는 선언된 변수여야 합니다
         my_2d[c,d] := c * d;
-          // address multidimensional arrays with a single set of brackets
+          // 단일 대괄호 세트로 다차원 배열 주소 지정
 
 End.
 ```
@@ -168,39 +165,39 @@ Var
     i, dummy : integer;
 
 function factorial_recursion(const a: integer) : integer;
-{ recursively calculates the factorial of integer parameter a }
+{ 정수 매개변수 a의 계승을 재귀적으로 계산합니다 }
 
-// Declare local variables within the function
-// e.g.:
+// 함수 내에서 지역 변수 선언
+// 예:
 // Var
 //    local_a : integer;
 
 Begin
     If a >= 1 Then
-    // return values from functions by assigning a value to the function name
+    // 함수 이름에 값을 할당하여 함수에서 값을 반환합니다
         factorial_recursion := a * factorial_recursion(a-1)
     Else
         factorial_recursion := 1;
-End; // terminate a function using a semicolon after the End statement.
+End; // End 문 뒤에 세미콜론을 사용하여 함수를 종료합니다.
 
 procedure get_integer(var i : integer; dummy : integer);
-{ get user input and store it in the integer parameter i.
-  parameters prefaced with 'var' are variable, meaning their value can change
-  outside of the parameter. Value parameters (without 'var') like 'dummy' are
-  static and changes made within the scope of the function/procedure do not
-  affect the variable passed as a parameter }
+{ 사용자 입력을 받아 정수 매개변수 i에 저장합니다.
+  'var'가 앞에 붙은 매개변수는 가변적이므로 매개변수 외부에서
+  값이 변경될 수 있습니다. 'dummy'와 같은 값 매개변수('var' 없음)는
+  정적이며 함수/프로시저 범위 내에서 변경해도
+  매개변수로 전달된 변수에 영향을 미치지 않습니다 }
 
 Begin
     write('Enter an integer: ');
     readln(i);
-    dummy := 4; // dummy will not change value outside of the procedure
+    dummy := 4; // dummy는 프로시저 외부에서 값이 변경되지 않습니다
 End;
 
-Begin // main program block
+Begin // 주 프로그램 블록
     dummy := 3;
     get_integer(i, dummy);
     writeln(i, '! = ', factorial_recursion(i));
-    // outputs i!
-    writeln('dummy = ', dummy); // always outputs '3' since dummy is unchanged.
+    // i! 출력
+    writeln('dummy = ', dummy); // dummy는 변경되지 않았으므로 항상 '3'을 출력합니다.
 End.
 ```

--- a/ko/pcre.md
+++ b/ko/pcre.md
@@ -1,5 +1,3 @@
-# pcre.md (번역)
-
 ---
 name: PCRE
 filename: pcre.txt
@@ -8,76 +6,76 @@ contributors:
 
 ---
 
-A regular expression (regex or regexp for short) is a special text string for describing a search pattern. e.g. to extract the protocol from a url string we can say `/^[a-z]+:/` and it will match `http:` from `http://github.com/`.
+정규 표현식(줄여서 regex 또는 regexp)은 검색 패턴을 설명하기 위한 특수 텍스트 문자열입니다. 예를 들어, URL 문자열에서 프로토콜을 추출하려면 `/^[a-z]+:/`라고 할 수 있으며, `http://github.com/`에서 `http:`와 일치합니다.
 
-PCRE (Perl Compatible Regular Expressions) is a C library implementing regex. It was written in 1997 when Perl was the de-facto choice for complex text processing tasks. The syntax for patterns used in PCRE closely resembles Perl. PCRE syntax is being used in many big projects including PHP, Apache, R to name a few.
+PCRE(Perl 호환 정규 표현식)는 정규식을 구현하는 C 라이브러리입니다. 1997년 Perl이 복잡한 텍스트 처리 작업의 사실상 표준이었을 때 작성되었습니다. PCRE에서 사용되는 패턴 구문은 Perl과 매우 유사합니다. PCRE 구문은 PHP, Apache, R을 비롯한 많은 대규모 프로젝트에서 사용되고 있습니다.
 
 
-There are two different sets of metacharacters:
+메타 문자에는 두 가지 다른 집합이 있습니다:
 
-* Those that are recognized anywhere in the pattern except within square brackets
-
-```
-  \      general escape character with several uses
-  ^      assert start of string (or line, in multiline mode)
-  $      assert end of string (or line, in multiline mode)
-  .      match any character except newline (by default)
-  [      start character class definition
-  |      start of alternative branch
-  (      start subpattern
-  )      end subpattern
-  ?      extends the meaning of (
-         also 0 or 1 quantifier
-         also quantifier minimizer
-  *      0 or more quantifier
-  +      1 or more quantifier
-         also "possessive quantifier"
-  {      start min/max quantifier
-```
-
-* Those that are recognized within square brackets. Outside square brackets. They are also called as character classes.
+* 대괄호 안을 제외하고 패턴의 모든 곳에서 인식되는 것들
 
 ```
-  \      general escape character
-  ^      negate the class, but only if the first character
-  -      indicates character range
-  [      POSIX character class (only if followed by POSIX syntax)
-  ]      terminates the character class
+  \      여러 용도로 사용되는 일반 이스케이프 문자
+  ^      문자열의 시작을 나타냄 (또는 여러 줄 모드에서는 줄의 시작)
+  $      문자열의 끝을 나타냄 (또는 여러 줄 모드에서는 줄의 끝)
+  .      개행 문자를 제외한 모든 문자와 일치 (기본값)
+  [      문자 클래스 정의 시작
+  |      대체 분기 시작
+  (      하위 패턴 시작
+  )      하위 패턴 끝
+  ?      (의 의미를 확장
+         또한 0 또는 1 수량자
+         또한 수량자 최소화
+  *      0개 이상 수량자
+  +      1개 이상 수량자
+         또한 "소유 수량자"
+  {      최소/최대 수량자 시작
 ```
 
-PCRE provides some generic character types, also called as character classes.
+* 대괄호 안에서 인식되는 것들. 대괄호 밖. 문자 클래스라고도 합니다.
 
 ```
-  \d     any decimal digit
-  \D     any character that is not a decimal digit
-  \h     any horizontal white space character
-  \H     any character that is not a horizontal white space character
-  \s     any white space character
-  \S     any character that is not a white space character
-  \v     any vertical white space character
-  \V     any character that is not a vertical white space character
-  \w     any "word" character
-  \W     any "non-word" character
+  \      일반 이스케이프 문자
+  ^      클래스를 부정하지만 첫 번째 문자인 경우에만 해당
+  -      문자 범위를 나타냄
+  [      POSIX 문자 클래스 (POSIX 구문이 뒤따르는 경우에만 해당)
+  ]      문자 클래스를 종료
 ```
 
-## Examples
+PCRE는 문자 클래스라고도 하는 몇 가지 일반적인 문자 유형을 제공합니다.
 
-We will test our examples on the following string:
+```
+  \d     모든 10진수
+  \D     10진수가 아닌 모든 문자
+  \h     모든 가로 공백 문자
+  \H     가로 공백 문자가 아닌 모든 문자
+  \s     모든 공백 문자
+  \S     공백 문자가 아닌 모든 문자
+  \v     모든 세로 공백 문자
+  \V     세로 공백 문자가 아닌 모든 문자
+  \w     모든 "단어" 문자
+  \W     모든 "비단어" 문자
+```
+
+## 예제
+
+다음 문자열에서 예제를 테스트합니다:
 
 ```
 66.249.64.13 - - [18/Sep/2004:11:07:48 +1000] "GET /robots.txt HTTP/1.0" 200 468 "-" "Googlebot/2.1"
 ```
 
- It is a standard Apache access log.
+ 이것은 표준 Apache 액세스 로그입니다.
 
-| Regex | Result          | Comment |
+| 정규식 | 결과          | 설명 |
 | :---- | :-------------- | :------ |
-| `GET`   | GET | GET matches the characters GET literally (case sensitive) |
-| `\d+.\d+.\d+.\d+` | 66.249.64.13 | `\d+` match a digit [0-9] one or more times defined by `+` quantifier, `\.` matches `.` literally |
-| `(\d+\.){3}\d+` | 66.249.64.13 | `(\d+\.){3}` is trying to match group (`\d+\.`) exactly three times. |
-| `\[.+\]` | [18/Sep/2004:11:07:48 +1000] | `.+` matches any character (except newline), `.` is any character |
-| `^\S+` | 66.249.64.13 | `^` means start of the line, `\S+` matches any number of non-space characters |
-| `\+[0-9]+` | +1000 | `\+` matches the character `+` literally. `[0-9]` character class means single number. Same can be achieved using `\+\d+` |
+| `GET`   | GET | GET은 GET 문자를 문자 그대로 일치시킵니다 (대소문자 구분) |
+| `\d+.\d+.\d+.\d+` | 66.249.64.13 | `\d+`는 숫자 [0-9]를 `+` 수량자로 정의된 한 번 이상 일치시키고, `\.`는 `.`을 문자 그대로 일치시킵니다 |
+| `(\d+\.){3}\d+` | 66.249.64.13 | `(\d+\.){3}`은 그룹 (`\d+\.`)을 정확히 세 번 일치시키려고 합니다. |
+| `\[.+\]` | [18/Sep/2004:11:07:48 +1000] | `.+`는 모든 문자(개행 문자 제외)와 일치하며, `.`은 모든 문자입니다 |
+| `^\S+` | 66.249.64.13 | `^`는 줄의 시작을 의미하고, `\S+`는 공백이 아닌 문자를 여러 개 일치시킵니다 |
+| `\+[0-9]+` | +1000 | `\+`는 `+` 문자를 문자 그대로 일치시킵니다. `[0-9]` 문자 클래스는 단일 숫자를 의미합니다. `\+\d+`를 사용하여 동일한 결과를 얻을 수 있습니다 |
 
-## Further Reading
-[Regex101](https://regex101.com/) - Regular Expression tester and debugger
+## 더 읽을거리
+[Regex101](https://regex101.com/) - 정규 표현식 테스터 및 디버거

--- a/ko/wolfram.md
+++ b/ko/wolfram.md
@@ -1,5 +1,3 @@
-# wolfram.md (번역)
-
 ---
 name: Wolfram
 contributors:
@@ -7,140 +5,134 @@ contributors:
 filename: learnwolfram.nb
 ---
 
-The Wolfram Language is the underlying language originally used in Mathematica,
-but now available for use in multiple contexts.
+Wolfram 언어는 원래 Mathematica에서 사용되던 기본 언어이지만, 지금은 여러 컨텍스트에서 사용할 수 있습니다.
 
-Wolfram Language has several interfaces:
+Wolfram 언어에는 여러 인터페이스가 있습니다:
 
-* The command line kernel interface on Raspberry Pi (just called _The Wolfram Language_)
-    which runs interactively and can't produce graphical input.
-* _Mathematica_ which is a rich text/maths editor with interactive Wolfram built in:
-    Pressing <kbd>shift</kbd> + <kbd>Return</kbd> on a "code cell"
-    creates an output cell with the result, which is not dynamic.
-* _Wolfram Workbench_ which is Eclipse interfaced to the Wolfram Language backend.
+* 라즈베리 파이의 명령줄 커널 인터페이스(_The Wolfram Language_라고도 함)는 대화형으로 실행되며 그래픽 입력을 생성할 수 없습니다.
+* _Mathematica_는 대화형 Wolfram이 내장된 풍부한 텍스트/수학 편집기입니다: "코드 셀"에서 <kbd>shift</kbd> + <kbd>Return</kbd>을 누르면 결과가 포함된 출력 셀이 생성되며, 이는 동적이 아닙니다.
+* _Wolfram Workbench_는 Wolfram 언어 백엔드에 연결된 Eclipse입니다.
 
-The code in this example can be typed in to any interface and edited with Wolfram Workbench.
-Loading directly into Mathematica may be awkward because the file contains no cell formatting information
-(which would make the file a huge mess to read as text) - it can be viewed/edited but may require some setting up.
+이 예제의 코드는 모든 인터페이스에 입력하고 Wolfram Workbench로 편집할 수 있습니다. 파일에 셀 서식 정보가 포함되어 있지 않아(텍스트로 읽기에 매우 지저분하게 만듦) Mathematica로 직접 로드하는 것이 어색할 수 있습니다. 보거나 편집할 수는 있지만 일부 설정이 필요할 수 있습니다.
 
 ```mathematica
-(* This is a comment *)
+(* 이것은 주석입니다 *)
 
-(* In Mathematica instead of using these comments you can create a text cell
-   and annotate your code with nicely typeset text and images *)
+(* Mathematica에서는 이러한 주석 대신 텍스트 셀을 만들어
+   코드를 멋지게 조판된 텍스트와 이미지로 주석 처리할 수 있습니다 *)
 
-(* Typing an expression returns the result *)
+(* 표현식을 입력하면 결과가 반환됩니다 *)
 2*2              (* 4 *)
 5+8              (* 13 *)
 
-(* Function Call *)
-(* Note, function names (and everything else) are case sensitive *)
+(* 함수 호출 *)
+(* 참고, 함수 이름(및 다른 모든 것)은 대소문자를 구분합니다 *)
 Sin[Pi/2]        (* 1 *)
 
-(* Alternate Syntaxes for Function Call with one parameter *)
+(* 매개변수 하나를 사용하는 함수 호출의 대체 구문 *)
 Sin@(Pi/2)       (* 1 *)
 (Pi/2) // Sin    (* 1 *)
 
-(* Every syntax in WL has some equivalent as a function call *)
+(* WL의 모든 구문은 함수 호출과 동등한 형태를 가집니다 *)
 Times[2, 2]      (* 4 *)
 Plus[5, 8]       (* 13 *)
 
-(* Using a variable for the first time defines it and makes it global *)
+(* 변수를 처음 사용하면 정의되고 전역 변수가 됩니다 *)
 x = 5            (* 5 *)
-x == 5           (* True, C-style assignment and equality testing *)
+x == 5           (* True, C 스타일 할당 및 동등성 테스트 *)
 x                (* 5 *)
 x = x + 5        (* 10 *)
 x                (* 10 *)
-Set[x, 20]       (* I wasn't kidding when I said EVERYTHING has a function equivalent *)
+Set[x, 20]       (* 모든 것이 함수와 동등하다고 말했을 때 농담이 아니었습니다 *)
 x                (* 20 *)
 
-(* Because WL is based on a computer algebra system, *)
-(* using undefined variables is fine, they just obstruct evaluation *)
-cow + 5          (* 5 + cow, cow is undefined so can't evaluate further *)
-cow + 5 + 10     (* 15 + cow, it'll evaluate what it can *)
-%                (* 15 + cow, % fetches the last return *)
-% - cow          (* 15, undefined variable cow cancelled out *)
-moo = cow + 5    (* Beware, moo now holds an expression, not a number! *)
+(* WL은 컴퓨터 대수 시스템을 기반으로 하므로, *)
+(* 정의되지 않은 변수를 사용해도 괜찮습니다. 평가를 방해할 뿐입니다. *)
+cow + 5          (* 5 + cow, cow는 정의되지 않았으므로 더 이상 평가할 수 없습니다 *)
+cow + 5 + 10     (* 15 + cow, 가능한 것은 평가합니다 *)
+%                (* 15 + cow, %는 마지막 반환값을 가져옵니다 *)
+% - cow          (* 15, 정의되지 않은 변수 cow가 상쇄됨 *)
+moo = cow + 5    (* 주의, moo는 이제 숫자가 아닌 표현식을 담고 있습니다! *)
 
-(* Defining a function *)
-Double[x_] := x * 2    (* Note := to prevent immediate evaluation of the RHS
-                          And _ after x to indicate no pattern matching constraints *)
+(* 함수 정의 *)
+Double[x_] := x * 2    (* 참고: RHS의 즉시 평가를 막기 위한 :=
+                          그리고 x 뒤의 _는 패턴 매칭 제약 조건이 없음을 나타냅니다 *)
 Double[10]             (* 20 *)
 Double[Sin[Pi/2]]      (* 2 *)
-Double @ Sin @ (Pi/2)  (* 2, @-syntax avoids queues of close brackets *)
-(Pi/2) // Sin // Double(* 2, //-syntax lists functions in execution order *)
+Double @ Sin @ (Pi/2)  (* 2, @-구문은 닫는 괄호의 연속을 피합니다 *)
+(Pi/2) // Sin // Double(* 2, //-구문은 함수를 실행 순서대로 나열합니다 *)
 
-(* For imperative-style programming use ; to separate statements *)
-(* Discards any output from LHS and runs RHS *)
-MyFirst[] := (Print@"Hello"; Print@"World")  (* Note outer parens are critical
-                                                ;'s precedence is lower than := *)
+(* 명령형 스타일 프로그래밍을 위해 ;를 사용하여 문장을 구분합니다 *)
+(* LHS의 모든 출력을 버리고 RHS를 실행합니다 *)
+MyFirst[] := (Print@"Hello"; Print@"World")  (* 참고: 바깥쪽 괄호가 중요합니다
+                                                ;의 우선순위는 :=보다 낮습니다 *)
 MyFirst[]                                    (* Hello World *)
 
-(* C-Style For Loop *)
-PrintTo[x_] := For[y=0, y<x, y++, (Print[y])]  (* Start, test, incr, body *)
+(* C-스타일 For 루프 *)
+PrintTo[x_] := For[y=0, y<x, y++, (Print[y])]  (* 시작, 테스트, 증가, 본문 *)
 PrintTo[5]                                     (* 0 1 2 3 4 *)
 
-(* While Loop *)
-x = 0; While[x < 2, (Print@x; x++)]     (* While loop with test and body *)
+(* While 루프 *)
+x = 0; While[x < 2, (Print@x; x++)]     (* 테스트와 본문이 있는 While 루프 *)
 
-(* If and conditionals *)
-x = 8; If[x==8, Print@"Yes", Print@"No"]   (* Condition, true case, else case *)
-Switch[x, 2, Print@"Two", 8, Print@"Yes"]  (* Value match style switch *)
-Which[x==2, Print@"No", x==8, Print@"Yes"] (* Elif style switch *)
+(* If와 조건문 *)
+x = 8; If[x==8, Print@"Yes", Print@"No"]   (* 조건, 참인 경우, 거짓인 경우 *)
+Switch[x, 2, Print@"Two", 8, Print@"Yes"]  (* 값 일치 스타일 스위치 *)
+Which[x==2, Print@"No", x==8, Print@"Yes"] (* Elif 스타일 스위치 *)
 
-(* Variables other than parameters are global by default, even inside functions *)
-y = 10             (* 10, global variable y *)
+(* 매개변수 이외의 변수는 함수 내부에서도 기본적으로 전역입니다 *)
+y = 10             (* 10, 전역 변수 y *)
 PrintTo[5]         (* 0 1 2 3 4 *)
-y                  (* 5, global y clobbered by loop counter inside PrintTo *)
-x = 20             (* 20, global variable x *)
+y                  (* 5, PrintTo 내부의 루프 카운터에 의해 전역 y가 덮어쓰여짐 *)
+x = 20             (* 20, 전역 변수 x *)
 PrintTo[5]         (* 0 1 2 3 4 *)
-x                  (* 20, x in PrintTo is a parameter and automatically local *)
+x                  (* 20, PrintTo의 x는 매개변수이며 자동으로 지역 변수입니다 *)
 
-(* Local variables are declared using the Module metafunction *)
-(* Version with local variable *)
+(* 지역 변수는 Module 메타함수를 사용하여 선언됩니다 *)
+(* 지역 변수 버전 *)
 BetterPrintTo[x_] := Module[{y}, (For[y=0, y<x, y++, (Print@y)])]
-y = 20             (* Global variable y *)
+y = 20             (* 전역 변수 y *)
 BetterPrintTo[5]   (* 0 1 2 3 4 *)
-y                  (* 20, that's better *)
+y                  (* 20, 이제 괜찮습니다 *)
 
-(* Module actually lets us declare any scope we like *)
-Module[{count}, count=0;        (* Declare scope of this variable count *)
-  (IncCount[] := ++count);      (* These functions are inside that scope *)
+(* Module은 실제로 원하는 모든 범위를 선언할 수 있습니다 *)
+Module[{count}, count=0;        (* 이 변수 count의 범위 선언 *)
+  (IncCount[] := ++count);      (* 이 함수들은 해당 범위 내에 있습니다 *)
   (DecCount[] := --count)]
-count              (* count - global variable count is not defined *)
-IncCount[]         (* 1, using the count variable inside the scope *)
-IncCount[]         (* 2, incCount updates it *)
-DecCount[]         (* 1, so does decCount *)
-count              (* count - still no global variable by that name *)
+count              (* count - 전역 변수 count는 정의되지 않았습니다 *)
+IncCount[]         (* 1, 범위 내의 count 변수 사용 *)
+IncCount[]         (* 2, incCount가 업데이트함 *)
+DecCount[]         (* 1, decCount도 마찬가지 *)
+count              (* count - 여전히 해당 이름의 전역 변수 없음 *)
 
-(* Lists *)
+(* 리스트 *)
 myList = {1, 2, 3, 4}     (* {1, 2, 3, 4} *)
-myList[[1]]               (* 1 - note list indexes start at 1, not 0 *)
-Map[Double, myList]       (* {2, 4, 6, 8} - functional style list map function *)
-Double /@ myList          (* {2, 4, 6, 8} - Abbreviated syntax for above *)
-Scan[Print, myList]       (* 1 2 3 4 - imperative style loop over list *)
+myList[[1]]               (* 1 - 참고: 리스트 인덱스는 0이 아닌 1부터 시작합니다 *)
+Map[Double, myList]       (* {2, 4, 6, 8} - 함수형 스타일 리스트 맵 함수 *)
+Double /@ myList          (* {2, 4, 6, 8} - 위 구문의 축약형 *)
+Scan[Print, myList]       (* 1 2 3 4 - 명령형 스타일 리스트 순회 *)
 Fold[Plus, 0, myList]     (* 10 (0+1+2+3+4) *)
-FoldList[Plus, 0, myList] (* {0, 1, 3, 6, 10} - fold storing intermediate results *)
-Append[myList, 5]         (* {1, 2, 3, 4, 5} - note myList is not updated *)
-Prepend[myList, 5]        (* {5, 1, 2, 3, 4} - add "myList = " if you want it to be *)
+FoldList[Plus, 0, myList] (* {0, 1, 3, 6, 10} - 중간 결과를 저장하는 fold *)
+Append[myList, 5]         (* {1, 2, 3, 4, 5} - 참고: myList는 업데이트되지 않습니다 *)
+Prepend[myList, 5]        (* {5, 1, 2, 3, 4} - 업데이트하려면 "myList = "를 추가하십시오 *)
 Join[myList, {3, 4}]      (* {1, 2, 3, 4, 3, 4} *)
-myList[[2]] = 5          (* {1, 5, 3, 4} - this does update myList *)
+myList[[2]] = 5          (* {1, 5, 3, 4} - 이것은 myList를 업데이트합니다 *)
 
-(* Associations, aka Dictionaries/Hashes *)
-myHash = <|"Green" -> 2, "Red" -> 1|>   (* Create an association *)
-myHash[["Green"]]                       (* 2, use it *)
-myHash[["Green"]] := 5                  (* 5, update it *)
-myHash[["Puce"]] := 3.5                 (* 3.5, extend it *)
-KeyDropFrom[myHash, "Green"]            (* Wipes out key Green *)
+(* 연관 배열, 즉 딕셔너리/해시 *)
+myHash = <|"Green" -> 2, "Red" -> 1|>   (* 연관 배열 생성 *)
+myHash[["Green"]]                       (* 2, 사용 *)
+myHash[["Green"]] := 5                  (* 5, 업데이트 *)
+myHash[["Puce"]] := 3.5                 (* 3.5, 확장 *)
+KeyDropFrom[myHash, "Green"]            (* Green 키 제거 *)
 Keys[myHash]                            (* {Red, Puce} *)
 Values[myHash]                          (* {1, 3.5} *)
 
-(* And you can't do any demo of Wolfram without showing this off *)
-Manipulate[y^2, {y, 0, 20}] (* Return a reactive user interface that displays y^2
-                               and allows y to be adjusted between 0-20 with a slider.
-                               Only works on graphical frontends *)
+(* 그리고 Wolfram 데모에서 이것을 보여주지 않을 수 없습니다 *)
+Manipulate[y^2, {y, 0, 20}] (* y^2를 표시하고 슬라이더로 y를 0-20 사이에서
+                               조정할 수 있는 반응형 사용자 인터페이스를 반환합니다.
+                               그래픽 프론트엔드에서만 작동합니다 *)
 ```
 
-## Further reading
+## 더 읽을거리
 
-* [Wolfram Language Documentation Center](http://reference.wolfram.com/language/)
+* [Wolfram 언어 문서 센터](http://reference.wolfram.com/language/)


### PR DESCRIPTION
This change translates all remaining markdown files in the `ko/` directory that were marked with `(번역)` on the first line.

The translation was performed on the markdown content, leaving YAML frontmatter and code blocks untouched. The `(번역)` marker was removed from the translated files.

- [ ] I solemnly swear that this is all original content of which I am the original author
- [ ] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [ ] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
